### PR TITLE
Don't set container name in ksvc podspecs

### DIFF
--- a/pkg/reconciler/decorator/resources/decorator.go
+++ b/pkg/reconciler/decorator/resources/decorator.go
@@ -19,12 +19,13 @@ package resources
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/kmeta"
 	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
 	servingv1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
-	"strconv"
 
 	"github.com/google/knative-gcp/pkg/apis/messaging/v1alpha1"
 )
@@ -85,7 +86,6 @@ func makeDecoratorPodSpec(args *DecoratorArgs) corev1.PodSpec {
 
 	podSpec := corev1.PodSpec{
 		Containers: []corev1.Container{{
-			Name:  "publisher",
 			Image: args.Image,
 			Env: []corev1.EnvVar{{
 				Name:  "K_CE_EXTENSIONS",

--- a/pkg/reconciler/decorator/resources/decorator_test.go
+++ b/pkg/reconciler/decorator/resources/decorator_test.go
@@ -82,7 +82,7 @@ func TestMakePublisherV1alpha1(t *testing.T) {
       "spec": {
         "containers": [
           {
-            "name": "publisher",
+            "name": "",
             "image": "test-image",
             "env": [
               {

--- a/pkg/reconciler/topic/resources/publisher.go
+++ b/pkg/reconciler/topic/resources/publisher.go
@@ -62,7 +62,6 @@ func makePublisherPodSpec(args *PublisherArgs) corev1.PodSpec {
 
 	podSpec := corev1.PodSpec{
 		Containers: []corev1.Container{{
-			Name:  "publisher",
 			Image: args.Image,
 			Env: []corev1.EnvVar{{
 				Name:  "GOOGLE_APPLICATION_CREDENTIALS",

--- a/pkg/reconciler/topic/resources/publisher_test.go
+++ b/pkg/reconciler/topic/resources/publisher_test.go
@@ -94,7 +94,7 @@ func TestMakePublisherV1beta1(t *testing.T) {
         ],
         "containers": [
           {
-            "name": "publisher",
+            "name": "",
             "image": "test-image",
             "env": [
               {
@@ -197,7 +197,7 @@ func TestMakePublisherV1alpha1(t *testing.T) {
         ],
         "containers": [
           {
-            "name": "publisher",
+            "name": "",
             "image": "test-image",
             "env": [
               {


### PR DESCRIPTION
Recent versions of Knative Serving allow setting container name, but new versions take a while to propagate everywhere. Looks like we don't actually need the name, so let's remove it.