### PR TITLE
Use shorter human friendly topic names for topic backed channels.

### DIFF
--- a/pkg/reconciler/channel/channel_test.go
+++ b/pkg/reconciler/channel/channel_test.go
@@ -295,25 +295,6 @@ func TestAllCases(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "CreatedSubscriber", "Created Subscriber %q", "cre-sub-testsubscription-abc-123"),
 			//Eventf(corev1.EventTypeNormal, "Updated", "Updated Channel %q", channelName),
 		},
-		//WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-		//	Object: NewChannel(channelName, testNS,
-		//		WithChannelUID(channelUID),
-		//		WithChannelSpec(v1alpha1.ChannelSpec{
-		//			Project: testProject,
-		//		}),
-		//		WithInitChannelConditions,
-		//		WithChannelDefaults,
-		//		WithChannelTopic(testTopicID),
-		//		WithChannelAddress(topicURI),
-		//		WithChannelSubscribers([]eventingduck.SubscriberSpec{
-		//			{UID: subscriptionUID, Generation: 1, SubscriberURI: subscriberURI, ReplyURI: replyURI},
-		//		}),
-		//		WithChannelSubscribersStatus([]eventingduck.SubscriberStatus{
-		//			{UID: subscriptionUID, ObservedGeneration: 1},
-		//		}),
-		//	),
-		//}
-		//},
 		WantCreates: []runtime.Object{
 			newPullSubscription(eventingduck.SubscriberSpec{UID: subscriptionUID, SubscriberURI: subscriberURI, ReplyURI: replyURI}),
 		},
@@ -390,11 +371,11 @@ func newTopic() *pubsubv1alpha1.Topic {
 
 	return resources.MakeTopic(&resources.TopicArgs{
 		Owner:   channel,
-		Name:    resources.GenerateTopicName(channel.UID),
+		Name:    resources.GeneratePublisherName(channel),
 		Project: channel.Spec.Project,
 		Topic:   channel.Status.TopicID,
 		Secret:  channel.Spec.Secret,
-		Labels:  resources.GetLabels(controllerAgentName, channel.Name),
+		Labels:  resources.GetLabels(controllerAgentName, channel.Name, string(channel.UID)),
 	})
 }
 
@@ -423,7 +404,7 @@ func newPullSubscription(subscriber eventingduck.SubscriberSpec) *pubsubv1alpha1
 		Project:    channel.Spec.Project,
 		Topic:      channel.Status.TopicID,
 		Secret:     channel.Spec.Secret,
-		Labels:     resources.GetPullSubscriptionLabels(controllerAgentName, channel.Name, resources.GenerateSubscriptionName(subscriber.UID)),
+		Labels:     resources.GetPullSubscriptionLabels(controllerAgentName, channel.Name, resources.GenerateSubscriptionName(subscriber.UID), string(channel.UID)),
 		Subscriber: subscriber,
 	})
 }

--- a/pkg/reconciler/channel/resources/labels.go
+++ b/pkg/reconciler/channel/resources/labels.go
@@ -20,23 +20,24 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func GetLabelSelector(controller, channel string) labels.Selector {
-	return labels.SelectorFromSet(GetLabels(controller, channel))
+func GetLabelSelector(controller, channel, uid string) labels.Selector {
+	return labels.SelectorFromSet(GetLabels(controller, channel, uid))
 }
 
-func GetLabels(controller, channel string) map[string]string {
+func GetLabels(controller, channel, uid string) map[string]string {
 	return map[string]string{
-		"cloud-run-events-channel":      controller,
-		"cloud-run-events-channel-name": channel,
+		"cloud-run-events-channel":        controller,
+		"cloud-run-events-channel-name":   channel,
+		"cloud-run-events-controller-uid": uid,
 	}
 }
 
-func GetPullSubscriptionLabelSelector(controller, source, subscriber string) labels.Selector {
-	return labels.SelectorFromSet(GetPullSubscriptionLabels(controller, source, subscriber))
+func GetPullSubscriptionLabelSelector(controller, source, subscriber, uid string) labels.Selector {
+	return labels.SelectorFromSet(GetPullSubscriptionLabels(controller, source, subscriber, uid))
 }
 
-func GetPullSubscriptionLabels(controller, channel, subscriber string) map[string]string {
-	l := GetLabels(controller, channel)
+func GetPullSubscriptionLabels(controller, channel, subscriber, uid string) map[string]string {
+	l := GetLabels(controller, channel, uid)
 	l["cloud-run-events-channel-subscriber"] = subscriber
 	return l
 }

--- a/pkg/reconciler/channel/resources/labels_test.go
+++ b/pkg/reconciler/channel/resources/labels_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 func TestGetLabelSelector(t *testing.T) {
-	want := "cloud-run-events-channel=controller,cloud-run-events-channel-name=source"
-	got := GetLabelSelector("controller", "source").String()
+	want := "cloud-run-events-channel=controller,cloud-run-events-channel-name=source,cloud-run-events-controller-uid=UID"
+	got := GetLabelSelector("controller", "source", "UID").String()
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unexpected (-want, +got) = %v", diff)
@@ -33,10 +33,11 @@ func TestGetLabelSelector(t *testing.T) {
 
 func TestGetLabels(t *testing.T) {
 	want := map[string]string{
-		"cloud-run-events-channel":      "controller",
-		"cloud-run-events-channel-name": "channel",
+		"cloud-run-events-channel":        "controller",
+		"cloud-run-events-channel-name":   "channel",
+		"cloud-run-events-controller-uid": "UID",
 	}
-	got := GetLabels("controller", "channel")
+	got := GetLabels("controller", "channel", "UID")
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unexpected (-want, +got) = %v", diff)
@@ -44,8 +45,8 @@ func TestGetLabels(t *testing.T) {
 }
 
 func TestGetPullSubscriptionLabelSelector(t *testing.T) {
-	want := "cloud-run-events-channel=controller,cloud-run-events-channel-name=source,cloud-run-events-channel-subscriber=subscriber"
-	got := GetPullSubscriptionLabelSelector("controller", "source", "subscriber").String()
+	want := "cloud-run-events-channel=controller,cloud-run-events-channel-name=source,cloud-run-events-channel-subscriber=subscriber,cloud-run-events-controller-uid=UID"
+	got := GetPullSubscriptionLabelSelector("controller", "source", "subscriber", "UID").String()
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unexpected (-want, +got) = %v", diff)
@@ -57,8 +58,9 @@ func TestGetPullSubscriptionLabels(t *testing.T) {
 		"cloud-run-events-channel":            "controller",
 		"cloud-run-events-channel-name":       "channel",
 		"cloud-run-events-channel-subscriber": "subscriber",
+		"cloud-run-events-controller-uid":     "UID",
 	}
-	got := GetPullSubscriptionLabels("controller", "channel", "subscriber")
+	got := GetPullSubscriptionLabels("controller", "channel", "subscriber", "UID")
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unexpected (-want, +got) = %v", diff)

--- a/pkg/reconciler/channel/resources/names.go
+++ b/pkg/reconciler/channel/resources/names.go
@@ -18,12 +18,23 @@ package resources
 
 import (
 	"fmt"
+	"knative.dev/pkg/kmeta"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/google/knative-gcp/pkg/apis/messaging/v1alpha1"
 )
 
-func GenerateTopicName(UID types.UID) string {
+func GenerateTopicID(UID types.UID) string {
 	return fmt.Sprintf("cre-chan-%s", string(UID))
+}
+
+func GeneratePublisherName(channel *v1alpha1.Channel) string {
+	if strings.HasPrefix(channel.Name, "cre-") {
+		return kmeta.ChildName(channel.Name, "-chan")
+	}
+	return kmeta.ChildName(fmt.Sprintf("cre-%s", channel.Name), "-chan")
 }
 
 func GenerateSubscriptionName(UID types.UID) string {

--- a/pkg/reconciler/channel/resources/names_test.go
+++ b/pkg/reconciler/channel/resources/names_test.go
@@ -17,14 +17,43 @@ limitations under the License.
 package resources
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/google/knative-gcp/pkg/apis/messaging/v1alpha1"
 )
 
-func TestGenerateTopicName(t *testing.T) {
+func TestGenerateTopicID(t *testing.T) {
 	want := "cre-chan-a-uid"
-	got := GenerateTopicName("a-uid")
+	got := GenerateTopicID("a-uid")
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected (-want, +got) = %v", diff)
+	}
+}
+
+func TestGeneratePublisherName(t *testing.T) {
+	want := "cre-foo-chan"
+	got := GeneratePublisherName(&v1alpha1.Channel{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "foo",
+		},
+	})
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected (-want, +got) = %v", diff)
+	}
+}
+
+func TestGeneratePublisherNameFromChannel(t *testing.T) {
+	want := "cre-foo-chan"
+	got := GeneratePublisherName(&v1alpha1.Channel{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "cre-foo",
+		},
+	})
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unexpected (-want, +got) = %v", diff)

--- a/pkg/reconciler/channel/resources/topic_test.go
+++ b/pkg/reconciler/channel/resources/topic_test.go
@@ -50,7 +50,7 @@ func TestMakeTopic(t *testing.T) {
 
 	got := MakeTopic(&TopicArgs{
 		Owner:   channel,
-		Name:    GenerateTopicName("channel-uid"),
+		Name:    GeneratePublisherName(channel),
 		Project: channel.Status.ProjectID,
 		Topic:   channel.Status.TopicID,
 		Secret:  channel.Spec.Secret,
@@ -64,7 +64,7 @@ func TestMakeTopic(t *testing.T) {
 	want := &pubsubv1alpha1.Topic{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "channel-namespace",
-			Name:      "cre-chan-channel-uid",
+			Name:      "cre-channel-name-chan",
 			Labels: map[string]string{
 				"test-key1": "test-value1",
 				"test-key2": "test-value2",

--- a/pkg/reconciler/topic/resources/names.go
+++ b/pkg/reconciler/topic/resources/names.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+	. "strings"
 
 	"knative.dev/pkg/kmeta"
 
@@ -25,5 +26,8 @@ import (
 )
 
 func GeneratePublisherName(topic *v1alpha1.Topic) string {
+	if HasPrefix(topic.Name, "cre-") {
+		return kmeta.ChildName(topic.Name, "-publish")
+	}
 	return kmeta.ChildName(fmt.Sprintf("cre-%s", topic.Name), "-publish")
 }


### PR DESCRIPTION
Channel names now look like this:

```

NAME                                    READY   REASON   ADDRESS                                                       AGE
channel.messaging.cloud.run/blue        True             http://cre-blue-chan-publish.default.svc.cluster.local        2m
channel.messaging.cloud.run/green       True             http://cre-green-chan-publish.default.svc.cluster.local       2m
channel.messaging.cloud.run/input       True             http://cre-input-chan-publish.default.svc.cluster.local       1m
channel.messaging.cloud.run/paintings   True             http://cre-paintings-chan-publish.default.svc.cluster.local   1m
channel.messaging.cloud.run/red         True             http://cre-red-chan-publish.default.svc.cluster.local         2m
```