### PR TITLE
Update release labels in release.sh

### DIFF
--- a/config/201-addressable-resolvers-clusterrole.yaml
+++ b/config/201-addressable-resolvers-clusterrole.yaml
@@ -18,6 +18,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: addressable-resolver
+  labels:
+    events.cloud.run/release: devel
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -31,7 +33,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: service-addressable-resolver
   labels:
-      duck.knative.dev/addressable: "true"
+    events.cloud.run/release: devel
+    duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
 - apiGroups:
@@ -50,6 +53,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kservice-addressable-resolver
   labels:
+    events.cloud.run/release: devel
     duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
@@ -70,6 +74,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pubsub-topic-addressable-resolver
   labels:
+    events.cloud.run/release: devel
     duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
@@ -89,6 +94,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: events-channel-addressable-resolver
   labels:
+    events.cloud.run/release: devel
     duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:

--- a/config/201-channelable-manipulator-clusterrole.yaml
+++ b/config/201-channelable-manipulator-clusterrole.yaml
@@ -19,6 +19,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: events-channel-addressable-resolver
   labels:
+    events.cloud.run/release: devel
     duck.knative.dev/channelable: "true"
 # Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:

--- a/config/transformers/pubsub-push.yaml
+++ b/config/transformers/pubsub-push.yaml
@@ -2,6 +2,8 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: pubsub-push
+  labels:
+    events.cloud.run/release: devel
 spec:
   template:
     spec:

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -30,12 +30,21 @@ RELEASES=(
 readonly RELEASES
 
 function build_release() {
+  # Update release labels if this is a tagged release
+  if [[ -n "${TAG}" ]]; then
+    echo "Tagged release, updating release labels to events.cloud.run/release: \"${TAG}\""
+    LABEL_YAML_CMD=(sed -e "s|events.cloud.run/release: devel|events.cloud.run/release: \"${TAG}\"|")
+  else
+    echo "Untagged release, will NOT update release labels"
+    LABEL_YAML_CMD=(cat)
+  fi
+
   # Build the components
   local all_yamls=()
   for yaml in "${!COMPONENTS[@]}"; do
     local config="${COMPONENTS[${yaml}]}"
     echo "Building Cloud Run Events Components - ${config}"
-    ko resolve ${KO_FLAGS} -f ${config}/ > ${yaml}
+    ko resolve ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
     all_yamls+=(${yaml})
   done
   # Assemble the release


### PR DESCRIPTION
Sets release labels on objects when a tagged release is being created. Also adds release labels to objects that didn't have them.