### PR TITLE
Project in topic status

### DIFF
--- a/pkg/operations/pod.go
+++ b/pkg/operations/pod.go
@@ -74,9 +74,11 @@ func MakePodTemplate(image string, UID, action string, secret corev1.SecretKeySe
 }
 
 func GetFirstTerminationMessage(pod *corev1.Pod) string {
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.State.Terminated != nil && cs.State.Terminated.Message != "" {
-			return cs.State.Terminated.Message
+	if pod != nil {
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.State.Terminated != nil && cs.State.Terminated.Message != "" {
+				return cs.State.Terminated.Message
+			}
 		}
 	}
 	return ""

--- a/pkg/operations/storage/notification.go
+++ b/pkg/operations/storage/notification.go
@@ -57,6 +57,9 @@ type NotificationActionResult struct {
 	// NotificationId holds the notification ID for GCS
 	// and is filled in during create operation.
 	NotificationId string `json:"notificationId,omitempty"`
+	// Project is the project id that we used (this might have
+	// been defaulted, to we'll expose it).
+	ProjectId string `json:"projectId,omitempty"`
 }
 
 // NotificationArgs are the configuration required to make a NewNotificationOps.
@@ -300,6 +303,8 @@ func (n *NotificationOps) toStorageEventTypes(eventTypes []string) []string {
 }
 
 func (n *NotificationOps) writeTerminationMessage(result *NotificationActionResult) error {
+	// Always add the project regardless of what we did.
+	result.ProjectId = n.Project
 	m, err := json.Marshal(result)
 	if err != nil {
 		return err

--- a/pkg/reconciler/storage/storage.go
+++ b/pkg/reconciler/storage/storage.go
@@ -305,6 +305,7 @@ func (c *Reconciler) reconcileNotification(ctx context.Context, storage *v1alpha
 	if nar.Result == false {
 		return "", errors.New(nar.Error)
 	}
+	storage.Status.ProjectID = nar.ProjectId
 	return nar.NotificationId, nil
 }
 

--- a/pkg/reconciler/storage/storage.go
+++ b/pkg/reconciler/storage/storage.go
@@ -222,7 +222,13 @@ func (c *Reconciler) reconcile(ctx context.Context, csr *v1alpha1.Storage) error
 		csr.Status.MarkPullSubscriptionReady()
 	}
 
-	notification, err := c.reconcileNotification(ctx, csr)
+	projectId := csr.Spec.Project
+	if t.Status.ProjectID != "" {
+		projectId = t.Status.ProjectID
+		c.Logger.Infof("Project topic resolved was: %q using it in the notification", projectId)
+	}
+
+	notification, err := c.reconcileNotification(ctx, csr, projectId)
 	if err != nil {
 		// TODO: Update status with this...
 		c.Logger.Infof("Failed to reconcile Storage Notification: %s", err)
@@ -280,8 +286,8 @@ func (c *Reconciler) EnsureNotification(ctx context.Context, UID string, owner k
 	})
 }
 
-func (c *Reconciler) reconcileNotification(ctx context.Context, storage *v1alpha1.Storage) (string, error) {
-	state, err := c.EnsureNotification(ctx, string(storage.UID), storage, storage.Spec.GCSSecret, storage.Spec.Project, storage.Spec.Bucket, storage.Status.TopicID)
+func (c *Reconciler) reconcileNotification(ctx context.Context, storage *v1alpha1.Storage, projectId string) (string, error) {
+	state, err := c.EnsureNotification(ctx, string(storage.UID), storage, storage.Spec.GCSSecret, projectId, storage.Spec.Bucket, storage.Status.TopicID)
 
 	if state != ops.OpsJobCompleteSuccessful {
 		return "", fmt.Errorf("Job %q has not completed yet", storage.Name)


### PR DESCRIPTION
 * use Name instead of GenerateName for Topic jobs
 * Populate Status.ProjectId in Topic, PullSubscription,and Storage objects.
 * Use Topic.Status.ProjectId as the Storage.Spec.Project so that when we create Notifications on GCS we're using the Project of the Topic.  