### PR TITLE
Controller unit tests

### DIFF
--- a/pkg/apis/events/v1alpha1/storage_lifecycle.go
+++ b/pkg/apis/events/v1alpha1/storage_lifecycle.go
@@ -46,14 +46,14 @@ func (s *StorageStatus) MarkPullSubscriptionReady() {
 	gcsSourceCondSet.Manage(s).MarkTrue(PullSubscriptionReady)
 }
 
-// MarkPubSubTopicNotReady sets the condition that the PubSub topic was not created and why
-func (s *StorageStatus) MarkPubSubTopicNotReady(reason, messageFormat string, messageA ...interface{}) {
-	gcsSourceCondSet.Manage(s).MarkFalse(PubSubTopicReady, reason, messageFormat, messageA...)
+// MarkTopicNotReady sets the condition that the PubSub topic was not created and why
+func (s *StorageStatus) MarkTopicNotReady(reason, messageFormat string, messageA ...interface{}) {
+	gcsSourceCondSet.Manage(s).MarkFalse(TopicReady, reason, messageFormat, messageA...)
 }
 
-// MarkPubSubTopicReady sets the condition that the underlying PubSub topic was created successfully
-func (s *StorageStatus) MarkPubSubTopicReady() {
-	gcsSourceCondSet.Manage(s).MarkTrue(PubSubTopicReady)
+// MarkTopicReady sets the condition that the underlying PubSub topic was created successfully
+func (s *StorageStatus) MarkTopicReady() {
+	gcsSourceCondSet.Manage(s).MarkTrue(TopicReady)
 }
 
 // MarkStorageNotReady sets the condition that the GCS has been configured to send Notifications

--- a/pkg/apis/events/v1alpha1/storage_types.go
+++ b/pkg/apis/events/v1alpha1/storage_types.go
@@ -104,8 +104,8 @@ const (
 	// PullSubscriptionReady has status True when the underlying PullSubscription is ready
 	PullSubscriptionReady apis.ConditionType = "PullSubscriptionReady"
 
-	// PubSubTopicReady has status True when the underlying GCP PubSub topic is ready
-	PubSubTopicReady apis.ConditionType = "PubSubTopicReady"
+	// TopicReady has status True when the underlying GCP PubSub topic is ready
+	TopicReady apis.ConditionType = "TopicReady"
 
 	// GCSReady has status True when GCS has been configured properly to send Notification events
 	GCSReady apis.ConditionType = "GCSReady"
@@ -113,7 +113,7 @@ const (
 
 var gcsSourceCondSet = apis.NewLivingConditionSet(
 	PullSubscriptionReady,
-	PubSubTopicReady,
+	TopicReady,
 	GCSReady)
 
 // StorageStatus is the status for a GCS resource

--- a/pkg/operations/storage/notification.go
+++ b/pkg/operations/storage/notification.go
@@ -103,9 +103,6 @@ func NewNotificationOps(arg NotificationArgs) *batchv1.Job {
 	}, {
 		Name:  "BUCKET",
 		Value: arg.Bucket,
-	}, {
-		Name:  "PUBSUB_TOPIC_ID",
-		Value: arg.TopicID,
 	}}
 
 	switch arg.Action {

--- a/pkg/reconciler/storage/resources/pullsubscription.go
+++ b/pkg/reconciler/storage/resources/pullsubscription.go
@@ -26,7 +26,7 @@ import (
 
 // MakePullSubscription creates the spec for, but does not create, a GCP PullSubscrkiption
 // for a given GCS.
-func MakePullSubscription(source *v1alpha1.Storage) *pubsubv1alpha1.PullSubscription {
+func MakePullSubscription(source *v1alpha1.Storage, topic string) *pubsubv1alpha1.PullSubscription {
 	labels := map[string]string{
 		"receive-adapter": "storage.events.cloud.run",
 	}
@@ -48,7 +48,7 @@ func MakePullSubscription(source *v1alpha1.Storage) *pubsubv1alpha1.PullSubscrip
 		Spec: pubsubv1alpha1.PullSubscriptionSpec{
 			Secret:  &pubsubSecret,
 			Project: source.Spec.Project,
-			Topic:   source.Status.TopicID,
+			Topic:   topic,
 			Sink:    source.Spec.Sink,
 		},
 	}

--- a/pkg/reconciler/storage/resources/pullsubscription_test.go
+++ b/pkg/reconciler/storage/resources/pullsubscription_test.go
@@ -60,13 +60,9 @@ func TestMakePullSubscription(t *testing.T) {
 				},
 			},
 		},
-		Status: v1alpha1.StorageStatus{
-			ProjectID: "project-123",
-			TopicID:   "topic-abc",
-		},
 	}
 
-	got := MakePullSubscription(source)
+	got := MakePullSubscription(source, "topic-abc")
 
 	yes := true
 	want := &pubsubv1alpha1.PullSubscription{

--- a/pkg/reconciler/storage/resources/topic.go
+++ b/pkg/reconciler/storage/resources/topic.go
@@ -26,7 +26,7 @@ import (
 
 // MakeTopic creates the spec for, but does not create, a GCP Topic
 // for a given GCS.
-func MakeTopic(source *v1alpha1.Storage) *pubsubv1alpha1.Topic {
+func MakeTopic(source *v1alpha1.Storage, topic string) *pubsubv1alpha1.Topic {
 	labels := map[string]string{
 		"receive-adapter": "storage.events.cloud.run",
 	}
@@ -48,7 +48,7 @@ func MakeTopic(source *v1alpha1.Storage) *pubsubv1alpha1.Topic {
 		Spec: pubsubv1alpha1.TopicSpec{
 			Secret:            &pubsubSecret,
 			Project:           source.Spec.Project,
-			Topic:             source.Status.TopicID,
+			Topic:             topic,
 			PropagationPolicy: pubsubv1alpha1.TopicPolicyCreateDelete,
 		},
 	}

--- a/pkg/reconciler/storage/resources/topic_test.go
+++ b/pkg/reconciler/storage/resources/topic_test.go
@@ -55,13 +55,9 @@ func TestMakeTopic(t *testing.T) {
 				},
 			},
 		},
-		Status: v1alpha1.StorageStatus{
-			ProjectID: "project-123",
-			TopicID:   "topic-abc",
-		},
 	}
 
-	got := MakeTopic(source)
+	got := MakeTopic(source, "topic-abc")
 
 	yes := true
 	want := &pubsubv1alpha1.Topic{

--- a/pkg/reconciler/storage/storage_test.go
+++ b/pkg/reconciler/storage/storage_test.go
@@ -1,0 +1,301 @@
+/*
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Veroute.on 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	//	"knative.dev/pkg/apis/duck/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	//	"k8s.io/apimachinery/pkg/util/intstr"
+	//	"knative.dev/pkg/apis"
+	//	"knative.dev/pkg/apis/duck/v1beta1"
+	//	"knative.dev/pkg/kmeta"
+
+	//	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	//	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes/scheme"
+	clientgotesting "k8s.io/client-go/testing"
+
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	logtesting "knative.dev/pkg/logging/testing"
+
+	storagev1alpha1 "github.com/google/knative-gcp/pkg/apis/events/v1alpha1"
+	pubsubv1alpha1 "github.com/google/knative-gcp/pkg/apis/pubsub/v1alpha1"
+	pubsubClient "github.com/google/knative-gcp/pkg/client/injection/client"
+	//	ops "github.com/google/knative-gcp/pkg/operations"
+	//	operations "github.com/google/knative-gcp/pkg/operations/pubsub"
+	"github.com/google/knative-gcp/pkg/reconciler"
+	//	"github.com/google/knative-gcp/pkg/reconciler/pubsub"
+	//	"github.com/google/knative-gcp/pkg/reconciler/storage/resources"
+
+	. "knative.dev/pkg/reconciler/testing"
+
+	. "github.com/google/knative-gcp/pkg/reconciler/testing"
+)
+
+const (
+	storageName = "my-test-storage"
+	bucket      = "my-test-bucket"
+	sinkName    = "sink"
+
+	testNS       = "testnamespace"
+	testImage    = "notification-ops-image"
+	topicUID     = storageName + "-abc-123"
+	topicName    = "storage-test-storage-uid"
+	testProject  = "test-project-id"
+	testTopicID  = "cloud-run-topic-" + testNS + "-" + storageName + "-" + topicUID
+	testTopicURI = "http://" + storageName + "-topic." + testNS + ".svc.cluster.local"
+)
+
+var (
+	trueVal = true
+
+	sinkDNS = sinkName + ".mynamespace.svc.cluster.local"
+	sinkURI = "http://" + sinkDNS + "/"
+
+	sinkGVK = metav1.GroupVersionKind{
+		Group:   "testing.cloud.run",
+		Version: "v1alpha1",
+		Kind:    "Sink",
+	}
+
+	secret = corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{
+			Name: "testing-secret",
+		},
+		Key: "testing-key",
+	}
+
+	// Message for when the topic and pullsubscription with the above variables is not ready.
+	topicNotReadyMsg            = "Topic testnamespace/my-test-storage not ready"
+	pullSubscriptionNotReadyMsg = "PullSubscription testnamespace/my-test-storage not ready"
+)
+
+func init() {
+	// Add types to scheme
+	_ = storagev1alpha1.AddToScheme(scheme.Scheme)
+}
+
+// Returns an ownerref for the test Storage object
+func ownerRef() metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion:         "events.cloud.run/v1alpha1",
+		Kind:               "Storage",
+		Name:               "my-test-storage",
+		UID:                "test-storage-uid",
+		Controller:         &trueVal,
+		BlockOwnerDeletion: &trueVal,
+	}
+}
+
+func patchFinalizers(namespace, name string, add bool) clientgotesting.PatchActionImpl {
+	action := clientgotesting.PatchActionImpl{}
+	action.Name = name
+	action.Namespace = namespace
+	var fname string
+	if add {
+		fname = fmt.Sprintf("%q", finalizerName)
+	}
+	patch := `{"metadata":{"finalizers":[` + fname + `],"resourceVersion":""}}`
+	action.Patch = []byte(patch)
+	return action
+}
+
+func newSink() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "testing.cloud.run/v1alpha1",
+			"kind":       "Sink",
+			"metadata": map[string]interface{}{
+				"namespace": testNS,
+				"name":      sinkName,
+			},
+			"status": map[string]interface{}{
+				"address": map[string]interface{}{
+					"hostname": sinkDNS,
+				},
+			},
+		},
+	}
+}
+
+func TestAllCases(t *testing.T) {
+	table := TableTest{{
+		Name: "bad workqueue key",
+		// Make sure Reconcile handles bad keys.
+		Key: "too/many/parts",
+	}, {
+		Name: "key not found",
+		// Make sure Reconcile handles good keys that don't exist.
+		Key: "foo/not-found",
+	}, {
+		Name: "topic created, not ready",
+		Objects: []runtime.Object{
+			NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+			),
+			newSink(),
+		},
+		Key:     testNS + "/" + storageName,
+		WantErr: true,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithInitStorageConditions,
+				WithStorageTopicNotReady("TopicNotReady", topicNotReadyMsg),
+			),
+		}},
+		WantCreates: []runtime.Object{
+			NewTopic(storageName, testNS,
+				WithTopicSpec(pubsubv1alpha1.TopicSpec{
+					Topic:             topicName,
+					PropagationPolicy: "CreateDelete",
+				}),
+				WithTopicLabels(map[string]string{
+					"receive-adapter": "storage.events.cloud.run",
+				}),
+				WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
+			),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(testNS, storageName, true),
+		},
+	}, {
+		Name: "topic exists, topic not ready",
+		Objects: []runtime.Object{
+			NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+			),
+			NewTopic(storageName, testNS,
+				WithTopicTopicID(topicName),
+			),
+			newSink(),
+		},
+		Key:     testNS + "/" + storageName,
+		WantErr: true,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+				WithInitStorageConditions,
+				WithStorageTopicNotReady("TopicNotReady", topicNotReadyMsg),
+			),
+		}},
+	}, {
+		Objects: []runtime.Object{
+			NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+			),
+			NewTopic(storageName, testNS,
+				WithTopicReady(topicName),
+				WithTopicAddress("http://test-example.com"),
+			),
+			newSink(),
+		},
+		Key: testNS + "/" + storageName,
+		//		WantErr: true,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithInitStorageConditions,
+				WithStorageTopicReady(),
+				WithStoragePullSubscriptionNotReady("PullSubscriptionNotReady", pullSubscriptionNotReadyMsg),
+			),
+		}},
+		WantCreates: []runtime.Object{
+			NewPullSubscriptionWithNoDefaults(storageName, testNS,
+				WithPullSubscriptionSpecWithNoDefaults(pubsubv1alpha1.PullSubscriptionSpec{
+					Topic: topicName,
+				}),
+				WithPullSubscriptionLabels(map[string]string{
+					"receive-adapter": "storage.events.cloud.run",
+				}),
+				WithPullSubscriptionOwnerReferences([]metav1.OwnerReference{ownerRef()}),
+			),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(testNS, storageName, true),
+		},
+		/*
+			}, {
+				Name: "create topic",
+				Objects: []runtime.Object{
+					NewTopic(topicName, testNS,
+						WithTopicUID(topicUID),
+						WithTopicSpec(pubsubv1alpha1.TopicSpec{
+							Project: testProject,
+							Topic:   testTopicID,
+							Secret:  &secret,
+						}),
+					),
+					newSink(),
+				},
+				Key: testNS + "/" + topicName,
+				WantEvents: []string{
+					Eventf(corev1.EventTypeNormal, "Updated", "Updated Topic %q finalizers", topicName),
+					Eventf(corev1.EventTypeNormal, "Updated", "Updated Topic %q", topicName),
+				},
+				WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+					Object: NewTopic(topicName, testNS,
+						WithTopicUID(topicUID),
+						WithTopicSpec(pubsubv1alpha1.TopicSpec{
+							Project: testProject,
+							Topic:   testTopicID,
+							Secret:  &secret,
+						}),
+						// Updates
+						WithInitTopicConditions,
+						WithTopicMarkTopicCreating(testTopicID),
+					),
+				}},
+				WantCreates: []runtime.Object{
+					newTopicJob(NewTopic(topicName, testNS, WithTopicUID(topicUID)), ops.ActionCreate),
+				},
+				WantPatches: []clientgotesting.PatchActionImpl{
+					patchFinalizers(testNS, topicName, true),
+				},
+			}, {
+		*/
+	}}
+
+	defer logtesting.ClearAll()
+	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
+		return &Reconciler{
+			NotificationOpsImage: testImage,
+			Base:                 reconciler.NewBase(ctx, controllerAgentName, cmw),
+			storageLister:        listers.GetStorageLister(),
+			pubsubClient:         pubsubClient.Get(ctx),
+			jobLister:            listers.GetJobLister(),
+		}
+	}))
+
+}

--- a/pkg/reconciler/storage/storage_test.go
+++ b/pkg/reconciler/storage/storage_test.go
@@ -18,22 +18,18 @@ package storage
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
-	//	"knative.dev/pkg/apis/duck/v1alpha1"
-
 	"k8s.io/apimachinery/pkg/runtime"
-	//	"k8s.io/apimachinery/pkg/util/intstr"
-	//	"knative.dev/pkg/apis"
-	//	"knative.dev/pkg/apis/duck/v1beta1"
-	//	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/kmeta"
 
-	//	batchv1 "k8s.io/api/batch/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	//	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
 	clientgotesting "k8s.io/client-go/testing"
 
@@ -44,28 +40,26 @@ import (
 	storagev1alpha1 "github.com/google/knative-gcp/pkg/apis/events/v1alpha1"
 	pubsubv1alpha1 "github.com/google/knative-gcp/pkg/apis/pubsub/v1alpha1"
 	pubsubClient "github.com/google/knative-gcp/pkg/client/injection/client"
-	//	ops "github.com/google/knative-gcp/pkg/operations"
-	//	operations "github.com/google/knative-gcp/pkg/operations/pubsub"
+	ops "github.com/google/knative-gcp/pkg/operations"
+	operations "github.com/google/knative-gcp/pkg/operations/storage"
 	"github.com/google/knative-gcp/pkg/reconciler"
-	//	"github.com/google/knative-gcp/pkg/reconciler/pubsub"
-	//	"github.com/google/knative-gcp/pkg/reconciler/storage/resources"
-
-	. "knative.dev/pkg/reconciler/testing"
 
 	. "github.com/google/knative-gcp/pkg/reconciler/testing"
+	. "knative.dev/pkg/reconciler/testing"
 )
 
 const (
-	storageName = "my-test-storage"
-	bucket      = "my-test-bucket"
-	sinkName    = "sink"
+	storageName    = "my-test-storage"
+	storageUID     = "test-storage-uid"
+	bucket         = "my-test-bucket"
+	sinkName       = "sink"
+	notificationId = "135"
 
 	testNS       = "testnamespace"
 	testImage    = "notification-ops-image"
 	topicUID     = storageName + "-abc-123"
-	topicName    = "storage-test-storage-uid"
 	testProject  = "test-project-id"
-	testTopicID  = "cloud-run-topic-" + testNS + "-" + storageName + "-" + topicUID
+	testTopicID  = "storage-" + storageUID
 	testTopicURI = "http://" + storageName + "-topic." + testNS + ".svc.cluster.local"
 )
 
@@ -91,6 +85,9 @@ var (
 	// Message for when the topic and pullsubscription with the above variables is not ready.
 	topicNotReadyMsg            = "Topic testnamespace/my-test-storage not ready"
 	pullSubscriptionNotReadyMsg = "PullSubscription testnamespace/my-test-storage not ready"
+	jobNotCompletedMsg          = `Failed to create Storage notification: Job "my-test-storage" has not completed yet`
+	jobFailedMsg                = `Failed to create Storage notification: Job "my-test-storage" failed to create or job failed`
+	jobPodNotFoundMsg           = "Failed to create Storage notification: Pod not found"
 )
 
 func init() {
@@ -104,7 +101,7 @@ func ownerRef() metav1.OwnerReference {
 		APIVersion:         "events.cloud.run/v1alpha1",
 		Kind:               "Storage",
 		Name:               "my-test-storage",
-		UID:                "test-storage-uid",
+		UID:                storageUID,
 		Controller:         &trueVal,
 		BlockOwnerDeletion: &trueVal,
 	}
@@ -141,7 +138,52 @@ func newSink() *unstructured.Unstructured {
 	}
 }
 
+// turn string into URL or terminate with t.Fatalf
+func sinkURL(t *testing.T, url string) *apis.URL {
+	u, err := apis.ParseURL(url)
+	if err != nil {
+		t.Fatalf("Failed to parse url %q", url)
+	}
+	return u
+}
+
 func TestAllCases(t *testing.T) {
+	storageSinkURL := sinkURL(t, sinkURI)
+
+	narSuccess := operations.NotificationActionResult{
+		Result:         true,
+		NotificationId: notificationId,
+		ProjectId:      testProject,
+	}
+	narFailure := operations.NotificationActionResult{
+		Result:    false,
+		Error:     "test induced failure",
+		ProjectId: testProject,
+	}
+
+	successMsg, err := json.Marshal(narSuccess)
+	if err != nil {
+		t.Fatalf("Failed to marshal success NotificationActionResult: %s", err)
+	}
+
+	failureMsg, err := json.Marshal(narFailure)
+	if err != nil {
+		t.Fatalf("Failed to marshal failure NotificationActionResult: %s", err)
+	}
+
+	type NotificationActionResult struct {
+		// Result is the result the operation attempted.
+		Result bool `json:"result,omitempty"`
+		// Error is the error string if failure occurred
+		Error string `json:"error,omitempty"`
+		// NotificationId holds the notification ID for GCS
+		// and is filled in during create operation.
+		NotificationId string `json:"notificationId,omitempty"`
+		// Project is the project id that we used (this might have
+		// been defaulted, to we'll expose it).
+		ProjectId string `json:"projectId,omitempty"`
+	}
+
 	table := TableTest{{
 		Name: "bad workqueue key",
 		// Make sure Reconcile handles bad keys.
@@ -172,7 +214,7 @@ func TestAllCases(t *testing.T) {
 		WantCreates: []runtime.Object{
 			NewTopic(storageName, testNS,
 				WithTopicSpec(pubsubv1alpha1.TopicSpec{
-					Topic:             topicName,
+					Topic:             testTopicID,
 					PropagationPolicy: "CreateDelete",
 				}),
 				WithTopicLabels(map[string]string{
@@ -193,7 +235,7 @@ func TestAllCases(t *testing.T) {
 				WithStorageFinalizers(finalizerName),
 			),
 			NewTopic(storageName, testNS,
-				WithTopicTopicID(topicName),
+				WithTopicTopicID(testTopicID),
 			),
 			newSink(),
 		},
@@ -209,14 +251,16 @@ func TestAllCases(t *testing.T) {
 			),
 		}},
 	}, {
+		Name: "topic exists and is ready, no projectid",
 		Objects: []runtime.Object{
 			NewStorage(storageName, testNS,
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
 			),
 			NewTopic(storageName, testNS,
-				WithTopicReady(topicName),
-				WithTopicAddress("http://test-example.com"),
+				WithTopicReady(testTopicID),
+				WithTopicAddress(testTopicURI),
 			),
 			newSink(),
 		},
@@ -227,14 +271,94 @@ func TestAllCases(t *testing.T) {
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithInitStorageConditions,
-				WithStorageTopicReady(),
+				WithStorageTopicNotReady("TopicNotReady", "Topic testnamespace/my-test-storage did not expose projectid"),
+				WithStorageFinalizers(finalizerName),
+			),
+		}},
+	}, {
+		Name: "topic exists and is ready, no topicid",
+		Objects: []runtime.Object{
+			NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+			),
+			NewTopic(storageName, testNS,
+				WithTopicReady(""),
+				WithTopicProjectID(testProject),
+				WithTopicAddress(testTopicURI),
+			),
+			newSink(),
+		},
+		Key:     testNS + "/" + storageName,
+		WantErr: true,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithInitStorageConditions,
+				WithStorageTopicNotReady("TopicNotReady", "Topic testnamespace/my-test-storage did not expose topicid"),
+				WithStorageFinalizers(finalizerName),
+			),
+		}},
+	}, {
+		Name: "topic exists and is ready, unexpected topicid",
+		Objects: []runtime.Object{
+			NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+			),
+			NewTopic(storageName, testNS,
+				WithTopicReady("garbaaaaage"),
+				WithTopicProjectID(testProject),
+				WithTopicAddress(testTopicURI),
+			),
+			newSink(),
+		},
+		Key:     testNS + "/" + storageName,
+		WantErr: true,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithInitStorageConditions,
+				WithStorageTopicNotReady("TopicNotReady", `Topic testnamespace/my-test-storage topic mismatch expected "storage-test-storage-uid" got "garbaaaaage"`),
+				WithStorageFinalizers(finalizerName),
+			),
+		}},
+	}, {
+		Name: "topic exists and is ready, pullsubscription created",
+		Objects: []runtime.Object{
+			NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+			),
+			NewTopic(storageName, testNS,
+				WithTopicReady(testTopicID),
+				WithTopicAddress(testTopicURI),
+				WithTopicProjectID(testProject),
+			),
+			newSink(),
+		},
+		Key:     testNS + "/" + storageName,
+		WantErr: true,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithInitStorageConditions,
+				WithStorageTopicReady(testTopicID),
+				WithStorageProjectID(testProject),
+				WithStorageFinalizers(finalizerName),
 				WithStoragePullSubscriptionNotReady("PullSubscriptionNotReady", pullSubscriptionNotReadyMsg),
 			),
 		}},
 		WantCreates: []runtime.Object{
 			NewPullSubscriptionWithNoDefaults(storageName, testNS,
 				WithPullSubscriptionSpecWithNoDefaults(pubsubv1alpha1.PullSubscriptionSpec{
-					Topic:  topicName,
+					Topic:  testTopicID,
 					Secret: &secret,
 				}),
 				WithPullSubscriptionSink(sinkGVK, sinkName),
@@ -244,49 +368,314 @@ func TestAllCases(t *testing.T) {
 				WithPullSubscriptionOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			),
 		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchFinalizers(testNS, storageName, true),
+	}, {
+		Name: "topic exists and ready, pullsubscription exists but is not ready",
+		Objects: []runtime.Object{
+			NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+			),
+			NewTopic(storageName, testNS,
+				WithTopicReady(testTopicID),
+				WithTopicAddress(testTopicURI),
+				WithTopicProjectID(testProject),
+			),
+			NewPullSubscriptionWithNoDefaults(storageName, testNS),
+			newSink(),
 		},
-		/*
-			}, {
-				Name: "create topic",
-				Objects: []runtime.Object{
-					NewTopic(topicName, testNS,
-						WithTopicUID(topicUID),
-						WithTopicSpec(pubsubv1alpha1.TopicSpec{
-							Project: testProject,
-							Topic:   testTopicID,
-							Secret:  &secret,
-						}),
-					),
-					newSink(),
-				},
-				Key: testNS + "/" + topicName,
-				WantEvents: []string{
-					Eventf(corev1.EventTypeNormal, "Updated", "Updated Topic %q finalizers", topicName),
-					Eventf(corev1.EventTypeNormal, "Updated", "Updated Topic %q", topicName),
-				},
-				WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-					Object: NewTopic(topicName, testNS,
-						WithTopicUID(topicUID),
-						WithTopicSpec(pubsubv1alpha1.TopicSpec{
-							Project: testProject,
-							Topic:   testTopicID,
-							Secret:  &secret,
-						}),
-						// Updates
-						WithInitTopicConditions,
-						WithTopicMarkTopicCreating(testTopicID),
-					),
-				}},
-				WantCreates: []runtime.Object{
-					newTopicJob(NewTopic(topicName, testNS, WithTopicUID(topicUID)), ops.ActionCreate),
-				},
-				WantPatches: []clientgotesting.PatchActionImpl{
-					patchFinalizers(testNS, topicName, true),
-				},
-			}, {
-		*/
+		Key:     testNS + "/" + storageName,
+		WantErr: true,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+				WithInitStorageConditions,
+				WithStorageTopicReady(testTopicID),
+				WithStorageProjectID(testProject),
+				WithStoragePullSubscriptionNotReady("PullSubscriptionNotReady", pullSubscriptionNotReadyMsg),
+			),
+		}},
+	}, {
+		Name: "topic and pullsubscription exist and ready, notification job created",
+		Objects: []runtime.Object{
+			NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+			),
+			NewTopic(storageName, testNS,
+				WithTopicReady(testTopicID),
+				WithTopicAddress(testTopicURI),
+				WithTopicProjectID(testProject),
+			),
+			NewPullSubscriptionWithNoDefaults(storageName, testNS,
+				WithPullSubscriptionReady(sinkURI),
+			),
+			newSink(),
+		},
+		Key:     testNS + "/" + storageName,
+		WantErr: true,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+				WithInitStorageConditions,
+				WithStorageTopicReady(testTopicID),
+				WithStorageProjectID(testProject),
+				WithStoragePullSubscriptionReady(),
+				WithStorageGCSNotReady("GCSNotReady", jobNotCompletedMsg),
+				WithStorageSinkURI(storageSinkURL),
+			),
+		}},
+		WantCreates: []runtime.Object{
+			newJob(NewStorage(storageName, testNS), ops.ActionCreate),
+		},
+	}, {
+		Name: "topic and pullsubscription exist and ready, notification job not finished",
+		Objects: []runtime.Object{
+			NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+			),
+			NewTopic(storageName, testNS,
+				WithTopicReady(testTopicID),
+				WithTopicAddress(testTopicURI),
+				WithTopicProjectID(testProject),
+			),
+			NewPullSubscriptionWithNoDefaults(storageName, testNS,
+				WithPullSubscriptionReady(sinkURI),
+			),
+			newSink(),
+			newJob(NewStorage(storageName, testNS), ops.ActionCreate),
+		},
+		Key:     testNS + "/" + storageName,
+		WantErr: true,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+				WithInitStorageConditions,
+				WithStorageTopicReady(testTopicID),
+				WithStorageProjectID(testProject),
+				WithStoragePullSubscriptionReady(),
+				WithStorageGCSNotReady("GCSNotReady", jobNotCompletedMsg),
+				WithStorageSinkURI(storageSinkURL),
+			),
+		}},
+	}, {
+		Name: "topic and pullsubscription exist and ready, notification job failed",
+		Objects: []runtime.Object{
+			NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+			),
+			NewTopic(storageName, testNS,
+				WithTopicReady(testTopicID),
+				WithTopicAddress(testTopicURI),
+				WithTopicProjectID(testProject),
+			),
+			NewPullSubscriptionWithNoDefaults(storageName, testNS,
+				WithPullSubscriptionReady(sinkURI),
+			),
+			newSink(),
+			newJobFinished(NewStorage(storageName, testNS), ops.ActionCreate, false),
+		},
+		Key:     testNS + "/" + storageName,
+		WantErr: true,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+				WithInitStorageConditions,
+				WithStorageTopicReady(testTopicID),
+				WithStorageProjectID(testProject),
+				WithStoragePullSubscriptionReady(),
+				WithStorageGCSNotReady("GCSNotReady", jobFailedMsg),
+				WithStorageSinkURI(storageSinkURL),
+			),
+		}},
+	}, {
+		Name: "topic and pullsubscription exist and ready, notification job finished, no pods found",
+		Objects: []runtime.Object{
+			NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+			),
+			NewTopic(storageName, testNS,
+				WithTopicReady(testTopicID),
+				WithTopicAddress(testTopicURI),
+				WithTopicProjectID(testProject),
+			),
+			NewPullSubscriptionWithNoDefaults(storageName, testNS,
+				WithPullSubscriptionReady(sinkURI),
+			),
+			newSink(),
+			newJobFinished(NewStorage(storageName, testNS), ops.ActionCreate, true),
+		},
+		Key:     testNS + "/" + storageName,
+		WantErr: true,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+				WithInitStorageConditions,
+				WithStorageTopicReady(testTopicID),
+				WithStorageProjectID(testProject),
+				WithStoragePullSubscriptionReady(),
+				WithStorageGCSNotReady("GCSNotReady", jobPodNotFoundMsg),
+				WithStorageSinkURI(storageSinkURL),
+			),
+		}},
+	}, {
+		Name: "topic and pullsubscription exist and ready, notification job finished, no termination msg on pod",
+		Objects: []runtime.Object{
+			NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+			),
+			NewTopic(storageName, testNS,
+				WithTopicReady(testTopicID),
+				WithTopicAddress(testTopicURI),
+				WithTopicProjectID(testProject),
+			),
+			NewPullSubscriptionWithNoDefaults(storageName, testNS,
+				WithPullSubscriptionReady(sinkURI),
+			),
+			newSink(),
+			newJobFinished(NewStorage(storageName, testNS), ops.ActionCreate, true),
+			newPod(""),
+		},
+		Key:     testNS + "/" + storageName,
+		WantErr: true,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+				WithInitStorageConditions,
+				WithStorageTopicReady(testTopicID),
+				WithStorageProjectID(testProject),
+				WithStoragePullSubscriptionReady(),
+				WithStorageGCSNotReady("GCSNotReady", `Failed to create Storage notification: did not find termination message for pod "test-pod"`),
+				WithStorageSinkURI(storageSinkURL),
+			),
+		}},
+	}, {
+		Name: "topic and pullsubscription exist and ready, notification job finished, invalid termination msg on pod",
+		Objects: []runtime.Object{
+			NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+			),
+			NewTopic(storageName, testNS,
+				WithTopicReady(testTopicID),
+				WithTopicAddress(testTopicURI),
+				WithTopicProjectID(testProject),
+			),
+			NewPullSubscriptionWithNoDefaults(storageName, testNS,
+				WithPullSubscriptionReady(sinkURI),
+			),
+			newSink(),
+			newJobFinished(NewStorage(storageName, testNS), ops.ActionCreate, true),
+			newPod("invalid msg"),
+		},
+		Key:     testNS + "/" + storageName,
+		WantErr: true,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+				WithInitStorageConditions,
+				WithStorageTopicReady(testTopicID),
+				WithStorageProjectID(testProject),
+				WithStoragePullSubscriptionReady(),
+				WithStorageGCSNotReady("GCSNotReady", `Failed to create Storage notification: failed to unmarshal terminationmessage: "invalid character 'i' looking for beginning of value"`),
+				WithStorageSinkURI(storageSinkURL),
+			),
+		}},
+	}, {
+		Name: "topic and pullsubscription exist and ready, notification job finished, notification creation failed",
+		Objects: []runtime.Object{
+			NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+			),
+			NewTopic(storageName, testNS,
+				WithTopicReady(testTopicID),
+				WithTopicAddress(testTopicURI),
+				WithTopicProjectID(testProject),
+			),
+			NewPullSubscriptionWithNoDefaults(storageName, testNS,
+				WithPullSubscriptionReady(sinkURI),
+			),
+			newSink(),
+			newJobFinished(NewStorage(storageName, testNS), ops.ActionCreate, true),
+			newPod(string(failureMsg)),
+		},
+		Key:     testNS + "/" + storageName,
+		WantErr: true,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+				WithInitStorageConditions,
+				WithStorageTopicReady(testTopicID),
+				WithStorageProjectID(testProject),
+				WithStoragePullSubscriptionReady(),
+				WithStorageGCSNotReady("GCSNotReady", "Failed to create Storage notification: test induced failure"),
+				WithStorageSinkURI(storageSinkURL),
+			),
+		}},
+	}, {
+		Name: "topic and pullsubscription exist and ready, notification job finished, notification created successfully",
+		Objects: []runtime.Object{
+			NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+			),
+			NewTopic(storageName, testNS,
+				WithTopicReady(testTopicID),
+				WithTopicAddress(testTopicURI),
+				WithTopicProjectID(testProject),
+			),
+			NewPullSubscriptionWithNoDefaults(storageName, testNS,
+				WithPullSubscriptionReady(sinkURI),
+			),
+			newSink(),
+			newJobFinished(NewStorage(storageName, testNS), ops.ActionCreate, true),
+			newPod(string(successMsg)),
+		},
+		Key:     testNS + "/" + storageName,
+		WantErr: false,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: NewStorage(storageName, testNS,
+				WithStorageBucket(bucket),
+				WithStorageSink(sinkGVK, sinkName),
+				WithStorageFinalizers(finalizerName),
+				WithInitStorageConditions,
+				WithStorageTopicReady(testTopicID),
+				WithStoragePullSubscriptionReady(),
+				WithStorageGCSReady(),
+				WithStorageSinkURI(storageSinkURL),
+				WithStorageNotificationID(notificationId),
+				WithStorageProjectID(testProject),
+			),
+		}},
 	}}
 
 	defer logtesting.ClearAll()
@@ -300,4 +689,106 @@ func TestAllCases(t *testing.T) {
 		}
 	}))
 
+}
+
+func newJob(owner kmeta.OwnerRefable, action string) runtime.Object {
+	if action == "create" {
+		return operations.NewNotificationOps(operations.NotificationArgs{
+			UID:       storageUID,
+			Image:     testImage,
+			Action:    ops.ActionCreate,
+			ProjectID: testProject,
+			Bucket:    bucket,
+			TopicID:   testTopicID,
+			Secret:    secret,
+			Owner:     owner,
+		})
+	}
+	return operations.NewNotificationOps(operations.NotificationArgs{
+		UID:            storageUID,
+		Image:          testImage,
+		Action:         ops.ActionDelete,
+		ProjectID:      testProject,
+		Bucket:         bucket,
+		NotificationId: notificationId,
+		Secret:         secret,
+		Owner:          owner,
+	})
+}
+
+func newJobFinished(owner kmeta.OwnerRefable, action string, success bool) runtime.Object {
+	var job *batchv1.Job
+	if action == "create" {
+		job = operations.NewNotificationOps(operations.NotificationArgs{
+			UID:       storageUID,
+			Image:     testImage,
+			Action:    ops.ActionCreate,
+			ProjectID: testProject,
+			Bucket:    bucket,
+			TopicID:   testTopicID,
+			Secret:    secret,
+			Owner:     owner,
+		})
+	} else {
+		job = operations.NewNotificationOps(operations.NotificationArgs{
+			UID:            storageUID,
+			Image:          testImage,
+			Action:         ops.ActionDelete,
+			ProjectID:      testProject,
+			Bucket:         bucket,
+			NotificationId: notificationId,
+			Secret:         secret,
+			Owner:          owner,
+		})
+	}
+
+	if success {
+		job.Status.Active = 0
+		job.Status.Succeeded = 1
+		job.Status.Conditions = []batchv1.JobCondition{{
+			Type:   batchv1.JobComplete,
+			Status: corev1.ConditionTrue,
+		}, {
+			Type:   batchv1.JobFailed,
+			Status: corev1.ConditionFalse,
+		}}
+	} else {
+		job.Status.Active = 0
+		job.Status.Succeeded = 0
+		job.Status.Conditions = []batchv1.JobCondition{{
+			Type:   batchv1.JobComplete,
+			Status: corev1.ConditionTrue,
+		}, {
+			Type:   batchv1.JobFailed,
+			Status: corev1.ConditionTrue,
+		}}
+	}
+
+	return job
+}
+
+func newPod(msg string) runtime.Object {
+	labels := map[string]string{
+		"resource-uid": storageUID,
+		"action":       "create",
+	}
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: testNS,
+			Labels:    labels,
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Message: msg,
+						},
+					},
+				},
+			},
+		},
+	}
 }

--- a/pkg/reconciler/storage/storage_test.go
+++ b/pkg/reconciler/storage/storage_test.go
@@ -83,9 +83,9 @@ var (
 
 	secret = corev1.SecretKeySelector{
 		LocalObjectReference: corev1.LocalObjectReference{
-			Name: "testing-secret",
+			Name: "google-cloud-key",
 		},
-		Key: "testing-key",
+		Key: "key.json",
 	}
 
 	// Message for when the topic and pullsubscription with the above variables is not ready.
@@ -220,8 +220,8 @@ func TestAllCases(t *testing.T) {
 			),
 			newSink(),
 		},
-		Key: testNS + "/" + storageName,
-		//		WantErr: true,
+		Key:     testNS + "/" + storageName,
+		WantErr: true,
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewStorage(storageName, testNS,
 				WithStorageBucket(bucket),
@@ -234,8 +234,10 @@ func TestAllCases(t *testing.T) {
 		WantCreates: []runtime.Object{
 			NewPullSubscriptionWithNoDefaults(storageName, testNS,
 				WithPullSubscriptionSpecWithNoDefaults(pubsubv1alpha1.PullSubscriptionSpec{
-					Topic: topicName,
+					Topic:  topicName,
+					Secret: &secret,
 				}),
+				WithPullSubscriptionSink(sinkGVK, sinkName),
 				WithPullSubscriptionLabels(map[string]string{
 					"receive-adapter": "storage.events.cloud.run",
 				}),

--- a/pkg/reconciler/testing/listers.go
+++ b/pkg/reconciler/testing/listers.go
@@ -18,12 +18,14 @@ package testing
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
+	batchv1listers "k8s.io/client-go/listers/batch/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	rbacv1listers "k8s.io/client-go/listers/rbac/v1"
 	"k8s.io/client-go/tools/cache"
@@ -38,9 +40,11 @@ import (
 	fakesharedclientset "knative.dev/pkg/client/clientset/versioned/fake"
 	fakeservingclientset "knative.dev/serving/pkg/client/clientset/versioned/fake"
 
+	EventsV1alpha1 "github.com/google/knative-gcp/pkg/apis/events/v1alpha1"
 	MessagingV1alpha1 "github.com/google/knative-gcp/pkg/apis/messaging/v1alpha1"
 	pubsubv1alpha1 "github.com/google/knative-gcp/pkg/apis/pubsub/v1alpha1"
 	fakeeventsclientset "github.com/google/knative-gcp/pkg/client/clientset/versioned/fake"
+	storagelisters "github.com/google/knative-gcp/pkg/client/listers/events/v1alpha1"
 	eventslisters "github.com/google/knative-gcp/pkg/client/listers/messaging/v1alpha1"
 	pubsublisters "github.com/google/knative-gcp/pkg/client/listers/pubsub/v1alpha1"
 )
@@ -120,6 +124,14 @@ func (l *Listers) GetTopicLister() pubsublisters.TopicLister {
 
 func (l *Listers) GetChannelLister() eventslisters.ChannelLister {
 	return eventslisters.NewChannelLister(l.indexerFor(&MessagingV1alpha1.Channel{}))
+}
+
+func (l *Listers) GetJobLister() batchv1listers.JobLister {
+	return batchv1listers.NewJobLister(l.indexerFor(&batchv1.Job{}))
+}
+
+func (l *Listers) GetStorageLister() storagelisters.StorageLister {
+	return storagelisters.NewStorageLister(l.indexerFor(&EventsV1alpha1.Storage{}))
 }
 
 func (l *Listers) GetDeploymentLister() appsv1listers.DeploymentLister {

--- a/pkg/reconciler/testing/pullsubscription.go
+++ b/pkg/reconciler/testing/pullsubscription.go
@@ -47,6 +47,21 @@ func NewPullSubscription(name, namespace string, so ...PullSubscriptionOption) *
 	return s
 }
 
+// NewPullSubscriptionWithNoDefaults creates a PullSubscription with
+// PullSubscriptionOptions but does not set defaults.
+func NewPullSubscriptionWithNoDefaults(name, namespace string, so ...PullSubscriptionOption) *v1alpha1.PullSubscription {
+	s := &v1alpha1.PullSubscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	for _, opt := range so {
+		opt(s)
+	}
+	return s
+}
+
 // NewPullSubscriptionWithoutNamespace creates a PullSubscription with PullSubscriptionOptions but without a specific namespace
 func NewPullSubscriptionWithoutNamespace(name string, so ...PullSubscriptionOption) *v1alpha1.PullSubscription {
 	s := &v1alpha1.PullSubscription{
@@ -127,6 +142,13 @@ func WithPullSubscriptionSpec(spec v1alpha1.PullSubscriptionSpec) PullSubscripti
 	return func(s *v1alpha1.PullSubscription) {
 		s.Spec = spec
 		s.Spec.SetDefaults(context.Background())
+	}
+}
+
+// Same as withPullSubscriptionSpec but does not set defaults
+func WithPullSubscriptionSpecWithNoDefaults(spec v1alpha1.PullSubscriptionSpec) PullSubscriptionOption {
+	return func(s *v1alpha1.PullSubscription) {
+		s.Spec = spec
 	}
 }
 

--- a/pkg/reconciler/testing/storage.go
+++ b/pkg/reconciler/testing/storage.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	//	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	//	"k8s.io/apimachinery/pkg/types"
+
+	apisv1alpha1 "knative.dev/pkg/apis/v1alpha1"
+
+	"github.com/google/knative-gcp/pkg/apis/events/v1alpha1"
+)
+
+// StorageOption enables further configuration of a Storage.
+type StorageOption func(*v1alpha1.Storage)
+
+// NewStorage creates a Storage with StorageOptions
+func NewStorage(name, namespace string, so ...StorageOption) *v1alpha1.Storage {
+	s := &v1alpha1.Storage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       "test-storage-uid",
+		},
+	}
+	for _, opt := range so {
+		opt(s)
+	}
+	s.SetDefaults(context.Background())
+	return s
+}
+
+func WithStorageBucket(bucket string) StorageOption {
+	return func(s *v1alpha1.Storage) {
+		s.Spec.Bucket = bucket
+	}
+}
+
+func WithStorageSink(gvk metav1.GroupVersionKind, name string) StorageOption {
+	return func(s *v1alpha1.Storage) {
+		s.Spec.Sink = apisv1alpha1.Destination{
+			ObjectReference: &corev1.ObjectReference{
+				APIVersion: apiVersion(gvk),
+				Kind:       gvk.Kind,
+				Name:       name,
+			},
+		}
+	}
+}
+
+// WithInitStorageConditions initializes the Storages's conditions.
+func WithInitStorageConditions(s *v1alpha1.Storage) {
+	s.Status.InitializeConditions()
+}
+
+// WithStorageTopicNotReady marks the condition that the
+// topic is not ready
+func WithStorageTopicNotReady(reason, message string) StorageOption {
+	return func(s *v1alpha1.Storage) {
+		s.Status.MarkTopicNotReady(reason, message)
+	}
+}
+
+// WithStorageTopicNotReady marks the condition that the
+// topic is not ready
+func WithStorageTopicReady() StorageOption {
+	return func(s *v1alpha1.Storage) {
+		s.Status.MarkTopicReady()
+	}
+}
+
+// WithStoragePullSubscriptionNotReady marks the condition that the
+// topic is not ready
+func WithStoragePullSubscriptionNotReady(reason, message string) StorageOption {
+	return func(s *v1alpha1.Storage) {
+		s.Status.MarkPullSubscriptionNotReady(reason, message)
+	}
+}
+
+// WithStoragePullSubscriptionNotReady marks the condition that the
+// topic is not ready
+func WithStoragePullSubscriptionReady() StorageOption {
+	return func(s *v1alpha1.Storage) {
+		s.Status.MarkPullSubscriptionReady()
+	}
+}
+
+func WithStorageFinalizers(finalizers ...string) StorageOption {
+	return func(s *v1alpha1.Storage) {
+		s.Finalizers = finalizers
+	}
+}

--- a/pkg/reconciler/testing/storage.go
+++ b/pkg/reconciler/testing/storage.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	//	"k8s.io/apimachinery/pkg/types"
 
+	"knative.dev/pkg/apis"
 	apisv1alpha1 "knative.dev/pkg/apis/v1alpha1"
 
 	"github.com/google/knative-gcp/pkg/apis/events/v1alpha1"
@@ -81,9 +82,10 @@ func WithStorageTopicNotReady(reason, message string) StorageOption {
 
 // WithStorageTopicNotReady marks the condition that the
 // topic is not ready
-func WithStorageTopicReady() StorageOption {
+func WithStorageTopicReady(topicID string) StorageOption {
 	return func(s *v1alpha1.Storage) {
 		s.Status.MarkTopicReady()
+		s.Status.TopicID = topicID
 	}
 }
 
@@ -100,6 +102,43 @@ func WithStoragePullSubscriptionNotReady(reason, message string) StorageOption {
 func WithStoragePullSubscriptionReady() StorageOption {
 	return func(s *v1alpha1.Storage) {
 		s.Status.MarkPullSubscriptionReady()
+	}
+}
+
+// WithStorageGCSNotReady marks the condition that the
+// topic is not ready
+func WithStorageGCSNotReady(reason, message string) StorageOption {
+	return func(s *v1alpha1.Storage) {
+		s.Status.MarkGCSNotReady(reason, message)
+	}
+}
+
+// WithStorageGCSNotReady marks the condition that the
+// topic is not ready
+func WithStorageGCSReady() StorageOption {
+	return func(s *v1alpha1.Storage) {
+		s.Status.MarkGCSReady()
+	}
+}
+
+// WithStorageSinkURI sets the status for sink URI
+func WithStorageSinkURI(url *apis.URL) StorageOption {
+	return func(s *v1alpha1.Storage) {
+		s.Status.SinkURI = url
+	}
+}
+
+// WithStorageNotificationId sets the status for Notification ID
+func WithStorageNotificationID(notificationID string) StorageOption {
+	return func(s *v1alpha1.Storage) {
+		s.Status.NotificationID = notificationID
+	}
+}
+
+// WithStorageProjectId sets the status for Project ID
+func WithStorageProjectID(notificationID string) StorageOption {
+	return func(s *v1alpha1.Storage) {
+		s.Status.ProjectID = notificationID
 	}
 }
 

--- a/pkg/reconciler/testing/storage.go
+++ b/pkg/reconciler/testing/storage.go
@@ -18,11 +18,9 @@ package testing
 
 import (
 	"context"
-	//	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	//	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/pkg/apis"
 	apisv1alpha1 "knative.dev/pkg/apis/v1alpha1"

--- a/pkg/reconciler/testing/topic.go
+++ b/pkg/reconciler/testing/topic.go
@@ -119,6 +119,12 @@ func WithTopicDeployed(s *v1alpha1.Topic) {
 	s.Status.MarkDeployed()
 }
 
+func WithTopicProjectID(projectID string) TopicOption {
+	return func(s *v1alpha1.Topic) {
+		s.Status.ProjectID = projectID
+	}
+}
+
 func WithTopicReady(topicID string) TopicOption {
 	return func(s *v1alpha1.Topic) {
 		s.Status.InitializeConditions()


### PR DESCRIPTION
Adding unit tests for the controller.
Drop inconsistent use of PubSubTopic vs. PullSubscription, so don't use PubSub, just Topic and PullSubscription, since those are the resources we care about.
use and validate topic / project from the Topic.Status.
