### PR TITLE
Storage field rename

### DIFF
--- a/config/300-storage.yaml
+++ b/config/300-storage.yaml
@@ -91,12 +91,12 @@ spec:
                       pattern: "https://raw.githubusercontent.com/google/knative-gcp/master/schemas/storage/schema.json"
         spec:
           properties:
-            gcsSecret:
+            secret:
               type: object
-              description: "Credential to use for creating a GCS notification. Must be a service account key in JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys). If omitted, defaults to 'google-cloud-key'"
-            pullSubscriptionSecret:
+              description: "Credential to use for managing GCS notifications. Must be a service account key in JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys). If omitted, defaults to 'google-cloud-key'"
+            pubSubSecret:
               type: object
-              description: "Optional credential to use for creating a Topic and subscribing to the Topic. If omitted, uses gcsSecret. Must be a service account key in JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys)."
+              description: "Optional credential to use for creating a Topic and subscribing to the Topic. If omitted, uses secret. Must be a service account key in JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys)."
             serviceAccountName:
               type: string
               description: "Service Account to run Receive Adapter as. If omitted, uses 'default'."
@@ -125,7 +125,6 @@ spec:
                   - metadataUpdate
                 type: string
           required:
-          - gcsSecret
           - bucket
           - sink
         status:

--- a/pkg/apis/events/v1alpha1/storage_defaults.go
+++ b/pkg/apis/events/v1alpha1/storage_defaults.go
@@ -24,14 +24,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 )
 
-func (g *Storage) SetDefaults(ctx context.Context) {
-	g.Spec.SetDefaults(ctx)
+func (s *Storage) SetDefaults(ctx context.Context) {
+	s.Spec.SetDefaults(ctx)
 }
 
-func (gs *StorageSpec) SetDefaults(ctx context.Context) {
-	// TODO? What defaults?
-
-	if equality.Semantic.DeepEqual(gs.GCSSecret, corev1.SecretKeySelector{}) {
-		gs.GCSSecret = *v1alpha1.DefaultGoogleCloudSecretSelector()
+func (ss *StorageSpec) SetDefaults(ctx context.Context) {
+	if ss.Secret == nil || equality.Semantic.DeepEqual(ss.Secret, &corev1.SecretKeySelector{}) {
+		ss.Secret = v1alpha1.DefaultGoogleCloudSecretSelector()
 	}
 }

--- a/pkg/apis/events/v1alpha1/storage_defaults_test.go
+++ b/pkg/apis/events/v1alpha1/storage_defaults_test.go
@@ -29,14 +29,81 @@ func TestStorage_SetDefaults(t *testing.T) {
 		orig     *StorageSpec
 		expected *StorageSpec
 	}{
-		"gcsSecret": {
+		"missing defaults": {
 			orig: &StorageSpec{},
 			expected: &StorageSpec{
-				GCSSecret: corev1.SecretKeySelector{
+				Secret: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "google-cloud-key",
 					},
 					Key: "key.json",
+				},
+			},
+		},
+		"empty defaults": {
+			orig: &StorageSpec{
+				Secret: &corev1.SecretKeySelector{},
+			},
+			expected: &StorageSpec{
+				Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "google-cloud-key",
+					},
+					Key: "key.json",
+				},
+			},
+		},
+		"secret exists same key": {
+			orig: &StorageSpec{
+				Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "different-name",
+					},
+					Key: "key.json",
+				},
+			},
+			expected: &StorageSpec{
+				Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "different-name",
+					},
+					Key: "key.json",
+				},
+			},
+		},
+		"secret exists same name": {
+			orig: &StorageSpec{
+				Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "google-cloud-key",
+					},
+					Key: "different-key.json",
+				},
+			},
+			expected: &StorageSpec{
+				Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "google-cloud-key",
+					},
+					Key: "different-key.json",
+				},
+			},
+		},
+		"secret exists all different": {
+			orig: &StorageSpec{
+				Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "different-name",
+					},
+					Key: "different-key.json",
+				},
+			},
+			expected: &StorageSpec{
+				Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "different-name",
+					},
+					Key: "different-key.json",
 				},
 			},
 		},

--- a/pkg/apis/events/v1alpha1/storage_lifecycle.go
+++ b/pkg/apis/events/v1alpha1/storage_lifecycle.go
@@ -22,45 +22,46 @@ import (
 
 // GetCondition returns the condition currently associated with the given type, or nil.
 func (s *StorageStatus) GetCondition(t apis.ConditionType) *apis.Condition {
-	return gcsSourceCondSet.Manage(s).GetCondition(t)
+	return storageCondSet.Manage(s).GetCondition(t)
 }
 
 // IsReady returns true if the resource is ready overall.
 func (s *StorageStatus) IsReady() bool {
-	return gcsSourceCondSet.Manage(s).IsHappy()
+	return storageCondSet.Manage(s).IsHappy()
 }
 
 // InitializeConditions sets relevant unset conditions to Unknown state.
 func (s *StorageStatus) InitializeConditions() {
-	gcsSourceCondSet.Manage(s).InitializeConditions()
+	storageCondSet.Manage(s).InitializeConditions()
 }
 
 // MarkPullSubscriptionNotReady sets the condition that the underlying PullSubscription
-// source is not ready and why
+// source is not ready and why.
 func (s *StorageStatus) MarkPullSubscriptionNotReady(reason, messageFormat string, messageA ...interface{}) {
-	gcsSourceCondSet.Manage(s).MarkFalse(PullSubscriptionReady, reason, messageFormat, messageA...)
+	storageCondSet.Manage(s).MarkFalse(PullSubscriptionReady, reason, messageFormat, messageA...)
 }
 
-// MarkPullSubscriptionReady sets the condition that the underlying PubSub source is ready
+// MarkPullSubscriptionReady sets the condition that the underlying PubSub source is ready.
 func (s *StorageStatus) MarkPullSubscriptionReady() {
-	gcsSourceCondSet.Manage(s).MarkTrue(PullSubscriptionReady)
+	storageCondSet.Manage(s).MarkTrue(PullSubscriptionReady)
 }
 
-// MarkTopicNotReady sets the condition that the PubSub topic was not created and why
+// MarkTopicNotReady sets the condition that the PubSub topic was not created and why.
 func (s *StorageStatus) MarkTopicNotReady(reason, messageFormat string, messageA ...interface{}) {
-	gcsSourceCondSet.Manage(s).MarkFalse(TopicReady, reason, messageFormat, messageA...)
+	storageCondSet.Manage(s).MarkFalse(TopicReady, reason, messageFormat, messageA...)
 }
 
-// MarkTopicReady sets the condition that the underlying PubSub topic was created successfully
+// MarkTopicReady sets the condition that the underlying PubSub topic was created successfully.
 func (s *StorageStatus) MarkTopicReady() {
-	gcsSourceCondSet.Manage(s).MarkTrue(TopicReady)
+	storageCondSet.Manage(s).MarkTrue(TopicReady)
 }
 
-// MarkStorageNotReady sets the condition that the GCS has been configured to send Notifications
-func (s *StorageStatus) MarkGCSNotReady(reason, messageFormat string, messageA ...interface{}) {
-	gcsSourceCondSet.Manage(s).MarkFalse(GCSReady, reason, messageFormat, messageA...)
+// MarkNotificationNotReady sets the condition that the GCS has not been configured
+// to send Notifications and why.
+func (s *StorageStatus) MarkNotificationNotReady(reason, messageFormat string, messageA ...interface{}) {
+	storageCondSet.Manage(s).MarkFalse(NotificationReady, reason, messageFormat, messageA...)
 }
 
-func (s *StorageStatus) MarkGCSReady() {
-	gcsSourceCondSet.Manage(s).MarkTrue(GCSReady)
+func (s *StorageStatus) MarkNotificationReady() {
+	storageCondSet.Manage(s).MarkTrue(NotificationReady)
 }

--- a/pkg/apis/events/v1alpha1/storage_types.go
+++ b/pkg/apis/events/v1alpha1/storage_types.go
@@ -53,19 +53,19 @@ type StorageSpec struct {
 	// This brings in CloudEventOverrides and Sink
 	duckv1beta1.SourceSpec
 
-	// GCSSecret is the credential to use to create the Notification on the GCS bucket.
+	// Secret is the credential used to manage Notifications on the GCS bucket.
 	// The value of the secret entry must be a service account key in the JSON format (see
 	// https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
 	// +optional
-	GCSSecret corev1.SecretKeySelector `json:"gcsSecret,omitempty"`
+	Secret *corev1.SecretKeySelector `json:"Secret,omitempty"`
 
-	// PullSubscriptionSecret is the credential to use for the GCP PubSub Subscription.
+	// PubSubSecret is the credential to use for the GCP PubSub Subscription.
 	// It is used for the PullSubscription that is used to deliver events from GCS.
 	// The value of the secret entry must be a service account key in the JSON format (see
 	// https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
-	// If omitted, uses GCSSecret from above.
+	// If omitted, uses Secret from above.
 	// +optional
-	PullSubscriptionSecret *corev1.SecretKeySelector `json:"pullSubscriptionSecret,omitempty"`
+	PubSubSecret *corev1.SecretKeySelector `json:"pullSubscriptionSecret,omitempty"`
 
 	// ServiceAccountName holds the name of the Kubernetes service account
 	// as which the underlying K8s resources should be run. If unspecified
@@ -107,14 +107,15 @@ const (
 	// TopicReady has status True when the underlying GCP PubSub topic is ready
 	TopicReady apis.ConditionType = "TopicReady"
 
-	// GCSReady has status True when GCS has been configured properly to send Notification events
-	GCSReady apis.ConditionType = "GCSReady"
+	// StorageNotificationReady has status True when GCS has been configured properly to
+	// send Notification events
+	NotificationReady apis.ConditionType = "NotificationReady"
 )
 
-var gcsSourceCondSet = apis.NewLivingConditionSet(
+var storageCondSet = apis.NewLivingConditionSet(
 	PullSubscriptionReady,
 	TopicReady,
-	GCSReady)
+	NotificationReady)
 
 // StorageStatus is the status for a GCS resource
 type StorageStatus struct {

--- a/pkg/apis/events/v1alpha1/storage_types.go
+++ b/pkg/apis/events/v1alpha1/storage_types.go
@@ -65,7 +65,7 @@ type StorageSpec struct {
 	// https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
 	// If omitted, uses Secret from above.
 	// +optional
-	PubSubSecret *corev1.SecretKeySelector `json:"pullSubscriptionSecret,omitempty"`
+	PubSubSecret *corev1.SecretKeySelector `json:"pubSubSecret,omitempty"`
 
 	// ServiceAccountName holds the name of the Kubernetes service account
 	// as which the underlying K8s resources should be run. If unspecified

--- a/pkg/apis/events/v1alpha1/storage_validation.go
+++ b/pkg/apis/events/v1alpha1/storage_validation.go
@@ -56,7 +56,7 @@ func (current *StorageSpec) Validate(ctx context.Context) *apis.FieldError {
 	if current.PubSubSecret != nil {
 		err := validateSecret(current.PubSubSecret)
 		if err != nil {
-			errs = errs.Also(err.ViaField("pullSubscriptionSecret"))
+			errs = errs.Also(err.ViaField("pubSubSecret"))
 		}
 	}
 

--- a/pkg/apis/events/v1alpha1/storage_validation.go
+++ b/pkg/apis/events/v1alpha1/storage_validation.go
@@ -44,15 +44,17 @@ func (current *StorageSpec) Validate(ctx context.Context) *apis.FieldError {
 		errs = errs.Also(apis.ErrMissingField("bucket"))
 	}
 
-	if !equality.Semantic.DeepEqual(&current.GCSSecret, &corev1.SecretKeySelector{}) {
-		err := validateSecret(&current.GCSSecret)
-		if err != nil {
-			errs = errs.Also(err.ViaField("gcsSecret"))
+	if current.Secret != nil {
+		if !equality.Semantic.DeepEqual(current.Secret, &corev1.SecretKeySelector{}) {
+			err := validateSecret(current.Secret)
+			if err != nil {
+				errs = errs.Also(err.ViaField("secret"))
+			}
 		}
 	}
 
-	if current.PullSubscriptionSecret != nil {
-		err := validateSecret(current.PullSubscriptionSecret)
+	if current.PubSubSecret != nil {
+		err := validateSecret(current.PubSubSecret)
 		if err != nil {
 			errs = errs.Also(err.ViaField("pullSubscriptionSecret"))
 		}

--- a/pkg/apis/events/v1alpha1/storage_validation_test.go
+++ b/pkg/apis/events/v1alpha1/storage_validation_test.go
@@ -225,7 +225,7 @@ func TestSpecValidationFields(t *testing.T) {
 			},
 		},
 		want: func() *apis.FieldError {
-			fe := apis.ErrMissingField("pullSubscriptionSecret.name")
+			fe := apis.ErrMissingField("pubSubSecret.name")
 			return fe
 		}(),
 	}, {
@@ -247,7 +247,7 @@ func TestSpecValidationFields(t *testing.T) {
 			},
 		},
 		want: func() *apis.FieldError {
-			fe := apis.ErrMissingField("pullSubscriptionSecret.key")
+			fe := apis.ErrMissingField("pubSubSecret.key")
 			return fe
 		}(),
 	}}

--- a/pkg/apis/events/v1alpha1/storage_validation_test.go
+++ b/pkg/apis/events/v1alpha1/storage_validation_test.go
@@ -44,8 +44,8 @@ var (
 		},
 	}
 
-	// Bucket, Sink and GCSSecret
-	withGCSSecret = StorageSpec{
+	// Bucket, Sink and Secret
+	withSecret = StorageSpec{
 		Bucket: "my-test-bucket",
 		SourceSpec: duckv1beta1.SourceSpec{
 			Sink: apisv1alpha1.Destination{
@@ -57,7 +57,7 @@ var (
 				},
 			},
 		},
-		GCSSecret: corev1.SecretKeySelector{
+		Secret: &corev1.SecretKeySelector{
 			LocalObjectReference: corev1.LocalObjectReference{
 				Name: "secret-name",
 			},
@@ -65,8 +65,8 @@ var (
 		},
 	}
 
-	// Bucket, Sink, GCSSecret, and PullSubscriptionSecret
-	withPullSubscriptionSecret = StorageSpec{
+	// Bucket, Sink, Secret, and PubSubSecret
+	withPubSubSecret = StorageSpec{
 		Bucket: "my-test-bucket",
 		SourceSpec: duckv1beta1.SourceSpec{
 			Sink: apisv1alpha1.Destination{
@@ -78,13 +78,13 @@ var (
 				},
 			},
 		},
-		GCSSecret: corev1.SecretKeySelector{
+		Secret: &corev1.SecretKeySelector{
 			LocalObjectReference: corev1.LocalObjectReference{
 				Name: "gcs-secret-name",
 			},
 			Key: "gcs-secret-key",
 		},
-		PullSubscriptionSecret: &corev1.SecretKeySelector{
+		PubSubSecret: &corev1.SecretKeySelector{
 			LocalObjectReference: corev1.LocalObjectReference{
 				Name: "pullsubscription-secret-name",
 			},
@@ -174,13 +174,13 @@ func TestSpecValidationFields(t *testing.T) {
 					},
 				},
 			},
-			GCSSecret: corev1.SecretKeySelector{
+			Secret: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{},
 				Key:                  "secret-test-key",
 			},
 		},
 		want: func() *apis.FieldError {
-			fe := apis.ErrMissingField("gcsSecret.name")
+			fe := apis.ErrMissingField("secret.name")
 			return fe
 		}(),
 	}, {
@@ -197,12 +197,12 @@ func TestSpecValidationFields(t *testing.T) {
 					},
 				},
 			},
-			GCSSecret: corev1.SecretKeySelector{
+			Secret: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{Name: "gcs-test-secret"},
 			},
 		},
 		want: func() *apis.FieldError {
-			fe := apis.ErrMissingField("gcsSecret.key")
+			fe := apis.ErrMissingField("secret.key")
 			return fe
 		}(),
 	}, {
@@ -219,7 +219,7 @@ func TestSpecValidationFields(t *testing.T) {
 					},
 				},
 			},
-			PullSubscriptionSecret: &corev1.SecretKeySelector{
+			PubSubSecret: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{},
 				Key:                  "secret-test-key",
 			},
@@ -242,7 +242,7 @@ func TestSpecValidationFields(t *testing.T) {
 					},
 				},
 			},
-			PullSubscriptionSecret: &corev1.SecretKeySelector{
+			PubSubSecret: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{Name: "gcs-test-secret"},
 			},
 		},

--- a/pkg/apis/events/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/events/v1alpha1/zz_generated.deepcopy.go
@@ -90,9 +90,13 @@ func (in *StorageList) DeepCopyObject() runtime.Object {
 func (in *StorageSpec) DeepCopyInto(out *StorageSpec) {
 	*out = *in
 	in.SourceSpec.DeepCopyInto(&out.SourceSpec)
-	in.GCSSecret.DeepCopyInto(&out.GCSSecret)
-	if in.PullSubscriptionSecret != nil {
-		in, out := &in.PullSubscriptionSecret, &out.PullSubscriptionSecret
+	if in.Secret != nil {
+		in, out := &in.Secret, &out.Secret
+		*out = new(v1.SecretKeySelector)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.PubSubSecret != nil {
+		in, out := &in.PubSubSecret, &out.PubSubSecret
 		*out = new(v1.SecretKeySelector)
 		(*in).DeepCopyInto(*out)
 	}

--- a/pkg/operations/storage/notification.go
+++ b/pkg/operations/storage/notification.go
@@ -153,7 +153,7 @@ type NotificationOps struct {
 	// Topic is the environment variable containing the PubSub Topic being
 	// subscribed to's name. In the form that is unique within the project.
 	// E.g. 'laconia', not 'projects/my-gcp-project/topics/laconia'.
-	Topic string `envconfig:"PUBSUB_TOPIC_ID" required:"true"`
+	Topic string `envconfig:"PUBSUB_TOPIC_ID" required:"false"`
 
 	// Bucket to operate on
 	Bucket string `envconfig:"BUCKET" required:"true"`

--- a/pkg/reconciler/storage/resources/pullsubscription.go
+++ b/pkg/reconciler/storage/resources/pullsubscription.go
@@ -31,9 +31,9 @@ func MakePullSubscription(source *v1alpha1.Storage, topic string) *pubsubv1alpha
 		"receive-adapter": "storage.events.cloud.run",
 	}
 
-	pubsubSecret := source.Spec.GCSSecret
-	if source.Spec.PullSubscriptionSecret != nil {
-		pubsubSecret = *source.Spec.PullSubscriptionSecret
+	pubsubSecret := source.Spec.Secret
+	if source.Spec.PubSubSecret != nil {
+		pubsubSecret = source.Spec.PubSubSecret
 	}
 
 	ps := &pubsubv1alpha1.PullSubscription{
@@ -46,7 +46,7 @@ func MakePullSubscription(source *v1alpha1.Storage, topic string) *pubsubv1alpha
 			},
 		},
 		Spec: pubsubv1alpha1.PullSubscriptionSpec{
-			Secret:  &pubsubSecret,
+			Secret:  pubsubSecret,
 			Project: source.Spec.Project,
 			Topic:   topic,
 			Sink:    source.Spec.Sink,

--- a/pkg/reconciler/storage/resources/pullsubscription_test.go
+++ b/pkg/reconciler/storage/resources/pullsubscription_test.go
@@ -39,7 +39,7 @@ func TestMakePullSubscription(t *testing.T) {
 		Spec: v1alpha1.StorageSpec{
 			Bucket:  "this-bucket",
 			Project: "project-123",
-			GCSSecret: corev1.SecretKeySelector{
+			Secret: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "eventing-secret-name",
 				},

--- a/pkg/reconciler/storage/resources/topic.go
+++ b/pkg/reconciler/storage/resources/topic.go
@@ -31,9 +31,9 @@ func MakeTopic(source *v1alpha1.Storage, topic string) *pubsubv1alpha1.Topic {
 		"receive-adapter": "storage.events.cloud.run",
 	}
 
-	pubsubSecret := source.Spec.GCSSecret
-	if source.Spec.PullSubscriptionSecret != nil {
-		pubsubSecret = *source.Spec.PullSubscriptionSecret
+	pubsubSecret := source.Spec.Secret
+	if source.Spec.PubSubSecret != nil {
+		pubsubSecret = source.Spec.PubSubSecret
 	}
 
 	return &pubsubv1alpha1.Topic{
@@ -46,7 +46,7 @@ func MakeTopic(source *v1alpha1.Storage, topic string) *pubsubv1alpha1.Topic {
 			},
 		},
 		Spec: pubsubv1alpha1.TopicSpec{
-			Secret:            &pubsubSecret,
+			Secret:            pubsubSecret,
 			Project:           source.Spec.Project,
 			Topic:             topic,
 			PropagationPolicy: pubsubv1alpha1.TopicPolicyCreateDelete,

--- a/pkg/reconciler/storage/resources/topic_test.go
+++ b/pkg/reconciler/storage/resources/topic_test.go
@@ -39,7 +39,7 @@ func TestMakeTopic(t *testing.T) {
 		Spec: v1alpha1.StorageSpec{
 			Bucket:  "this-bucket",
 			Project: "project-123",
-			GCSSecret: corev1.SecretKeySelector{
+			Secret: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "eventing-secret-name",
 				},

--- a/pkg/reconciler/storage/storage.go
+++ b/pkg/reconciler/storage/storage.go
@@ -231,11 +231,11 @@ func (c *Reconciler) reconcile(ctx context.Context, csr *v1alpha1.Storage) error
 	if err != nil {
 		// TODO: Update status with this...
 		c.Logger.Infof("Failed to reconcile Storage Notification: %s", err)
-		csr.Status.MarkGCSNotReady("GCSNotReady", "Failed to create Storage notification: %s", err)
+		csr.Status.MarkNotificationNotReady("GCSNotReady", "Failed to create Storage notification: %s", err)
 		return err
 	}
 
-	csr.Status.MarkGCSReady()
+	csr.Status.MarkNotificationReady()
 
 	c.Logger.Infof("Reconciled Storage notification: %+v", notification)
 	csr.Status.NotificationID = notification
@@ -286,7 +286,7 @@ func (c *Reconciler) EnsureNotification(ctx context.Context, UID string, owner k
 }
 
 func (c *Reconciler) reconcileNotification(ctx context.Context, storage *v1alpha1.Storage) (string, error) {
-	state, err := c.EnsureNotification(ctx, string(storage.UID), storage, storage.Spec.GCSSecret, storage.Status.ProjectID, storage.Spec.Bucket, storage.Status.TopicID)
+	state, err := c.EnsureNotification(ctx, string(storage.UID), storage, *storage.Spec.Secret, storage.Status.ProjectID, storage.Spec.Bucket, storage.Status.TopicID)
 
 	if state == ops.OpsJobCreateFailed || state == ops.OpsJobCompleteFailed {
 		return "", fmt.Errorf("Job %q failed to create or job failed", storage.Name)
@@ -368,7 +368,7 @@ func (c *Reconciler) deleteNotification(ctx context.Context, storage *v1alpha1.S
 		return nil
 	}
 
-	state, err := c.EnsureNotificationDeleted(ctx, string(storage.UID), storage, storage.Spec.GCSSecret, storage.Spec.Project, storage.Spec.Bucket, storage.Status.NotificationID)
+	state, err := c.EnsureNotificationDeleted(ctx, string(storage.UID), storage, *storage.Spec.Secret, storage.Spec.Project, storage.Spec.Bucket, storage.Status.NotificationID)
 
 	if state != ops.OpsJobCompleteSuccessful {
 		return fmt.Errorf("Job %q has not completed yet", storage.Name)

--- a/pkg/reconciler/storage/storage_test.go
+++ b/pkg/reconciler/storage/storage_test.go
@@ -670,7 +670,7 @@ func TestAllCases(t *testing.T) {
 				WithInitStorageConditions,
 				WithStorageTopicReady(testTopicID),
 				WithStoragePullSubscriptionReady(),
-				WithStorageGCSReady(),
+				WithStorageNotificationReady(),
 				WithStorageSinkURI(storageSinkURL),
 				WithStorageNotificationID(notificationId),
 				WithStorageProjectID(testProject),

--- a/pkg/reconciler/testing/storage.go
+++ b/pkg/reconciler/testing/storage.go
@@ -103,19 +103,19 @@ func WithStoragePullSubscriptionReady() StorageOption {
 	}
 }
 
-// WithStorageGCSNotReady marks the condition that the
-// topic is not ready
+// WithStorageNotificationNotReady marks the condition that the
+// GCS Notification is not ready.
 func WithStorageGCSNotReady(reason, message string) StorageOption {
 	return func(s *v1alpha1.Storage) {
-		s.Status.MarkGCSNotReady(reason, message)
+		s.Status.MarkNotificationNotReady(reason, message)
 	}
 }
 
-// WithStorageGCSNotReady marks the condition that the
-// topic is not ready
-func WithStorageGCSReady() StorageOption {
+// WithStorageNotificationReady marks the condition that the GCS
+// notification is ready.
+func WithStorageNotificationReady() StorageOption {
 	return func(s *v1alpha1.Storage) {
-		s.Status.MarkGCSReady()
+		s.Status.MarkNotificationReady()
 	}
 }
 


### PR DESCRIPTION
Changing couple of externally visible field names for consistency. 
** This is a breaking change**
You have to delete existing ones before upgrading.

Storage.Spec.GCSSecret => Secret
Storage.Spec.PullSubscriptionSecret => PubSubSecret

Rename some internal conditions for shorter names.