### PR TITLE
Pubsubable into an interface for easier use.

### DIFF
--- a/pkg/apis/events/v1alpha1/scheduler_types.go
+++ b/pkg/apis/events/v1alpha1/scheduler_types.go
@@ -93,12 +93,17 @@ func (scheduler *Scheduler) GetGroupVersionKind() schema.GroupVersionKind {
 }
 
 // Methods for pubsubable interface
+// PubSubSpec returns the PubSubSpec portion of the Spec.
 func (s *Scheduler) PubSubSpec() *duckv1alpha1.PubSubSpec {
 	return &s.Spec.PubSubSpec
 }
+
+// PubSubStatus returns the PubSubStatus portion of the Status.
 func (s *Scheduler) PubSubStatus() *duckv1alpha1.PubSubStatus {
 	return &s.Status.PubSubStatus
 }
+
+// ConditionSet returns the apis.ConditionSet of the embedding object
 func (s *Scheduler) ConditionSet() *apis.ConditionSet {
 	return &StorageCondSet
 }

--- a/pkg/apis/events/v1alpha1/scheduler_types.go
+++ b/pkg/apis/events/v1alpha1/scheduler_types.go
@@ -92,6 +92,17 @@ func (scheduler *Scheduler) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("Scheduler")
 }
 
+// Methods for pubsubable interface
+func (s *Scheduler) PubSubSpec() *duckv1alpha1.PubSubSpec {
+	return &s.Spec.PubSubSpec
+}
+func (s *Scheduler) PubSubStatus() *duckv1alpha1.PubSubStatus {
+	return &s.Status.PubSubStatus
+}
+func (s *Scheduler) ConditionSet() *apis.ConditionSet {
+	return &StorageCondSet
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // SchedulerList is a list of Scheduler resources

--- a/pkg/apis/events/v1alpha1/storage_types.go
+++ b/pkg/apis/events/v1alpha1/storage_types.go
@@ -81,7 +81,7 @@ const (
 	// StorageConditionReady has status True when the Storage is ready to send events.
 	StorageConditionReady = apis.ConditionReady
 
-	// StorageNotificationReady has status True when GCS has been configured properly to
+	// NotificationReady has status True when GCS has been configured properly to
 	// send Notification events
 	NotificationReady apis.ConditionType = "NotificationReady"
 )
@@ -107,12 +107,18 @@ func (storage *Storage) GetGroupVersionKind() schema.GroupVersionKind {
 }
 
 // Methods for pubsubable interface
+
+// PubSubSpec returns the PubSubSpec portion of the Spec.
 func (s *Storage) PubSubSpec() *duckv1alpha1.PubSubSpec {
 	return &s.Spec.PubSubSpec
 }
+
+// PubSubStatus returns the PubSubStatus portion of the Status.
 func (s *Storage) PubSubStatus() *duckv1alpha1.PubSubStatus {
 	return &s.Status.PubSubStatus
 }
+
+// ConditionSet returns the apis.ConditionSet of the embedding object
 func (s *Storage) ConditionSet() *apis.ConditionSet {
 	return &StorageCondSet
 }

--- a/pkg/apis/events/v1alpha1/storage_types.go
+++ b/pkg/apis/events/v1alpha1/storage_types.go
@@ -106,6 +106,17 @@ func (storage *Storage) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("Storage")
 }
 
+// Methods for pubsubable interface
+func (s *Storage) PubSubSpec() *duckv1alpha1.PubSubSpec {
+	return &s.Spec.PubSubSpec
+}
+func (s *Storage) PubSubStatus() *duckv1alpha1.PubSubStatus {
+	return &s.Status.PubSubStatus
+}
+func (s *Storage) ConditionSet() *apis.ConditionSet {
+	return &StorageCondSet
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // StorageList is a list of Storage resources

--- a/pkg/duck/pubsubable.go
+++ b/pkg/duck/pubsubable.go
@@ -23,9 +23,18 @@ import (
 	"knative.dev/pkg/kmeta"
 )
 
+// PubSubable is an interface that each duckv1alpha1.PubSub duck type must
+// support in order to get reconciled properly in a generic way.
 type PubSubable interface {
 	kmeta.OwnerRefable
+	// PubSubSpec returns the PubSubSpec portion of the Spec.
 	PubSubSpec() *duckv1alpha1.PubSubSpec
+	// PubSubStatus returns the PubSubStatus portion of the Status.
 	PubSubStatus() *duckv1alpha1.PubSubStatus
+	// ConditionSet returns the apis.ConditionSet of the embedding object
+	// This Set must have the following Conditions defined in it.
+	// "TopicReady",
+	// "PullSubscriptionReady",
+	// Which will be set appropriately automagically by the pubsub_reconciler.go
 	ConditionSet() *apis.ConditionSet
 }

--- a/pkg/duck/pubsubable.go
+++ b/pkg/duck/pubsubable.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package duck
+
+import (
+	duckv1alpha1 "github.com/google/knative-gcp/pkg/apis/duck/v1alpha1"
+
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/kmeta"
+)
+
+type PubSubable interface {
+	kmeta.OwnerRefable
+	PubSubSpec() *duckv1alpha1.PubSubSpec
+	PubSubStatus() *duckv1alpha1.PubSubStatus
+	ConditionSet() *apis.ConditionSet
+}

--- a/pkg/reconciler/pubsub_reconciler.go
+++ b/pkg/reconciler/pubsub_reconciler.go
@@ -41,6 +41,10 @@ type PubSubBase struct {
 }
 
 // ReconcilePubSub reconciles Topic / PullSubscription given a PubSubSpec.
+// Sets the following Conditions in the Status field appropriately:
+// "TopicReady", and "PullSubscriptionReady"
+// Also sets the following fields in the pubsubable.Status upon success
+// TopicID, ProjectID, and SinkURI
 func (psb *PubSubBase) ReconcilePubSub(ctx context.Context, pubsubable duck.PubSubable, topic string) (*pubsubsourcev1alpha1.Topic, *pubsubsourcev1alpha1.PullSubscription, error) {
 	if pubsubable == nil {
 		return nil, nil, fmt.Errorf("nil pubsubable passed in")

--- a/pkg/reconciler/scheduler/scheduler.go
+++ b/pkg/reconciler/scheduler/scheduler.go
@@ -142,7 +142,7 @@ func (c *Reconciler) reconcile(ctx context.Context, s *v1alpha1.Scheduler) error
 		return err
 	}
 
-	t, ps, err := c.PubSubBase.ReconcilePubSub(ctx, s.Namespace, s.Name, &s.Spec.PubSubSpec, &s.Status.PubSubStatus, &v1alpha1.StorageCondSet, s, topic)
+	t, ps, err := c.PubSubBase.ReconcilePubSub(ctx, s, topic)
 	if err != nil {
 		c.Logger.Infof("Failed to reconcile PubSub: %s", err)
 		return err

--- a/pkg/reconciler/storage/storage.go
+++ b/pkg/reconciler/storage/storage.go
@@ -152,7 +152,7 @@ func (c *Reconciler) reconcile(ctx context.Context, csr *v1alpha1.Storage) error
 		return err
 	}
 
-	t, ps, err := c.PubSubBase.ReconcilePubSub(ctx, csr.Namespace, csr.Name, &csr.Spec.PubSubSpec, &csr.Status.PubSubStatus, &v1alpha1.StorageCondSet, csr, topic)
+	t, ps, err := c.PubSubBase.ReconcilePubSub(ctx, csr, topic)
 	if err != nil {
 		c.Logger.Infof("Failed to reconcile PubSub: %s", err)
 		return err


### PR DESCRIPTION
Now with the combination of using the PubSub duck type and implementing the PubSubable interface, you can call the pubsub_reconciler ReconcilePubSub with the original object rather than pull it apart yourself