### PR TITLE
Metrics: passing the ResourceGroup to ReceiveAdapter

### DIFF
--- a/pkg/pubsub/adapter/adapter.go
+++ b/pkg/pubsub/adapter/adapter.go
@@ -81,6 +81,9 @@ type Adapter struct {
 	// Environment variable containing the name.
 	Name string `envconfig:"NAME" required:"true"`
 
+	// Environment variable containing the resource group. E.g., storages.events.cloud.run.
+	ResourceGroup string `envconfig:"RESOURCE_GROUP" default:"pullsubscriptions.pubsub.cloud.run" required:"true"`
+
 	// inbound is the cloudevents client to use to receive events.
 	inbound cloudevents.Client
 
@@ -142,15 +145,14 @@ func (a *Adapter) Start(ctx context.Context) error {
 func (a *Adapter) receive(ctx context.Context, event cloudevents.Event, resp *cloudevents.EventResponse) error {
 	logger := logging.FromContext(ctx).With(zap.Any("event.id", event.ID()), zap.Any("sink", a.Sink))
 
-	// TODO Name might cause problems in the near future, as we might use a single receive-adapter for multiple
-	//  source objects. Same with Namespace, when doing multi-tenancy.
+	// TODO Name and ResourceGroup might cause problems in the near future, as we might use a single receive-adapter
+	//  for multiple source objects. Same with Namespace, when doing multi-tenancy.
 	args := &ReportArgs{
-		Name:        a.Name,
-		Namespace:   a.Namespace,
-		EventType:   event.Type(),
-		EventSource: event.Source(),
-		// TODO this conversion doesn't work for Channel.
-		ResourceGroup: converters.ResourceGroupFrom(event.Type()),
+		Name:          a.Name,
+		Namespace:     a.Namespace,
+		EventType:     event.Type(),
+		EventSource:   event.Source(),
+		ResourceGroup: a.ResourceGroup,
 	}
 
 	// If a transformer has been configured, then transform the message.

--- a/pkg/pubsub/adapter/converters/converters.go
+++ b/pkg/pubsub/adapter/converters/converters.go
@@ -73,16 +73,3 @@ func Convert(ctx context.Context, msg *cepubsub.Message, sendMode ModeType) (*cl
 	// pubsub is the default one.
 	return convertPubsub(ctx, msg, sendMode)
 }
-
-// TODO move it to a better place and refactor.
-// ResourceGroupFrom returns the resource group for the given eventType.
-func ResourceGroupFrom(eventType string) string {
-	switch eventType {
-	case storageFinalize, storageDelete, storageArchive, storageMetadataUpdate:
-		return storageResourceGroup
-	case pubSubPublish:
-		return pubSubResourceGroup
-	default:
-		return pubSubResourceGroup
-	}
-}

--- a/pkg/pubsub/adapter/converters/pubsub.go
+++ b/pkg/pubsub/adapter/converters/pubsub.go
@@ -27,8 +27,6 @@ import (
 
 const (
 	pubSubPublish = "google.pubsub.topic.publish"
-
-	pubSubResourceGroup = "pullsubscriptions.pubsub.cloud.run"
 )
 
 func convertPubsub(ctx context.Context, msg *cepubsub.Message, sendMode ModeType) (*cloudevents.Event, error) {

--- a/pkg/pubsub/adapter/converters/storage.go
+++ b/pkg/pubsub/adapter/converters/storage.go
@@ -50,8 +50,6 @@ const (
 	storageArchive        = "google.storage.object.archive"
 	storageDelete         = "google.storage.object.delete"
 	storageMetadataUpdate = "google.storage.object.metadataUpdate"
-
-	storageResourceGroup = "storages.events.cloud.run"
 )
 
 func storageSource(bucket string) string {

--- a/pkg/reconciler/channel/channel.go
+++ b/pkg/reconciler/channel/channel.go
@@ -255,7 +255,7 @@ func (c *Reconciler) syncSubscribers(ctx context.Context, channel *v1alpha1.Chan
 			Topic:       channel.Status.TopicID,
 			Secret:      channel.Spec.Secret,
 			Labels:      resources.GetPullSubscriptionLabels(controllerAgentName, channel.Name, genName, string(channel.UID)),
-			Annotations: resources.GetPullSubscriptionAnnotations(),
+			Annotations: resources.GetPullSubscriptionAnnotations(channel.Name),
 			Subscriber:  s,
 		})
 		ps, err := c.RunClientSet.PubsubV1alpha1().PullSubscriptions(channel.Namespace).Create(ps)
@@ -282,7 +282,7 @@ func (c *Reconciler) syncSubscribers(ctx context.Context, channel *v1alpha1.Chan
 			Topic:       channel.Status.TopicID,
 			Secret:      channel.Spec.Secret,
 			Labels:      resources.GetPullSubscriptionLabels(controllerAgentName, channel.Name, genName, string(channel.UID)),
-			Annotations: resources.GetPullSubscriptionAnnotations(),
+			Annotations: resources.GetPullSubscriptionAnnotations(channel.Name),
 			Subscriber:  s,
 		})
 

--- a/pkg/reconciler/channel/channel.go
+++ b/pkg/reconciler/channel/channel.go
@@ -249,13 +249,14 @@ func (c *Reconciler) syncSubscribers(ctx context.Context, channel *v1alpha1.Chan
 		c.Logger.Infof("Channel %q will create subscription %s", channel.Name, genName)
 
 		ps := resources.MakePullSubscription(&resources.PullSubscriptionArgs{
-			Owner:      channel,
-			Name:       genName,
-			Project:    channel.Spec.Project,
-			Topic:      channel.Status.TopicID,
-			Secret:     channel.Spec.Secret,
-			Labels:     resources.GetPullSubscriptionLabels(controllerAgentName, channel.Name, genName, string(channel.UID)),
-			Subscriber: s,
+			Owner:       channel,
+			Name:        genName,
+			Project:     channel.Spec.Project,
+			Topic:       channel.Status.TopicID,
+			Secret:      channel.Spec.Secret,
+			Labels:      resources.GetPullSubscriptionLabels(controllerAgentName, channel.Name, genName, string(channel.UID)),
+			Annotations: resources.GetPullSubscriptionAnnotations(),
+			Subscriber:  s,
 		})
 		ps, err := c.RunClientSet.PubsubV1alpha1().PullSubscriptions(channel.Namespace).Create(ps)
 		if err != nil {
@@ -275,13 +276,14 @@ func (c *Reconciler) syncSubscribers(ctx context.Context, channel *v1alpha1.Chan
 		c.Logger.Infof("Channel %q will update subscription %s", channel.Name, genName)
 
 		ps := resources.MakePullSubscription(&resources.PullSubscriptionArgs{
-			Owner:      channel,
-			Name:       genName,
-			Project:    channel.Spec.Project,
-			Topic:      channel.Status.TopicID,
-			Secret:     channel.Spec.Secret,
-			Labels:     resources.GetPullSubscriptionLabels(controllerAgentName, channel.Name, genName, string(channel.UID)),
-			Subscriber: s,
+			Owner:       channel,
+			Name:        genName,
+			Project:     channel.Spec.Project,
+			Topic:       channel.Status.TopicID,
+			Secret:      channel.Spec.Secret,
+			Labels:      resources.GetPullSubscriptionLabels(controllerAgentName, channel.Name, genName, string(channel.UID)),
+			Annotations: resources.GetPullSubscriptionAnnotations(),
+			Subscriber:  s,
 		})
 
 		existingPs, found := pullsubs[genName]

--- a/pkg/reconciler/channel/channel_test.go
+++ b/pkg/reconciler/channel/channel_test.go
@@ -407,7 +407,7 @@ func newPullSubscription(subscriber eventingduck.SubscriberSpec) *pubsubv1alpha1
 		Topic:       channel.Status.TopicID,
 		Secret:      channel.Spec.Secret,
 		Labels:      resources.GetPullSubscriptionLabels(controllerAgentName, channel.Name, resources.GenerateSubscriptionName(subscriber.UID), string(channel.UID)),
-		Annotations: resources.GetPullSubscriptionAnnotations(),
+		Annotations: resources.GetPullSubscriptionAnnotations(channel.Name),
 		Subscriber:  subscriber,
 	})
 }

--- a/pkg/reconciler/channel/channel_test.go
+++ b/pkg/reconciler/channel/channel_test.go
@@ -401,12 +401,13 @@ func newPullSubscription(subscriber eventingduck.SubscriberSpec) *pubsubv1alpha1
 		WithChannelDefaults)
 
 	return resources.MakePullSubscription(&resources.PullSubscriptionArgs{
-		Owner:      channel,
-		Name:       resources.GenerateSubscriptionName(subscriber.UID),
-		Project:    channel.Spec.Project,
-		Topic:      channel.Status.TopicID,
-		Secret:     channel.Spec.Secret,
-		Labels:     resources.GetPullSubscriptionLabels(controllerAgentName, channel.Name, resources.GenerateSubscriptionName(subscriber.UID), string(channel.UID)),
-		Subscriber: subscriber,
+		Owner:       channel,
+		Name:        resources.GenerateSubscriptionName(subscriber.UID),
+		Project:     channel.Spec.Project,
+		Topic:       channel.Status.TopicID,
+		Secret:      channel.Spec.Secret,
+		Labels:      resources.GetPullSubscriptionLabels(controllerAgentName, channel.Name, resources.GenerateSubscriptionName(subscriber.UID), string(channel.UID)),
+		Annotations: resources.GetPullSubscriptionAnnotations(),
+		Subscriber:  subscriber,
 	})
 }

--- a/pkg/reconciler/channel/resources/annotations.go
+++ b/pkg/reconciler/channel/resources/annotations.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+func GetPullSubscriptionAnnotations() map[string]string {
+	return map[string]string{"metrics-resource-group": "channels.messaging.cloud.run"}
+}

--- a/pkg/reconciler/channel/resources/annotations.go
+++ b/pkg/reconciler/channel/resources/annotations.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package resources
 
-func GetPullSubscriptionAnnotations() map[string]string {
-	return map[string]string{"metrics-resource-group": "channels.messaging.cloud.run"}
+func GetPullSubscriptionAnnotations(channel string) map[string]string {
+	return map[string]string{
+		"metrics-resource-group": "channels.messaging.cloud.run",
+		"metrics-resource-name":  channel}
 }

--- a/pkg/reconciler/channel/resources/annotations_test.go
+++ b/pkg/reconciler/channel/resources/annotations_test.go
@@ -24,9 +24,10 @@ import (
 
 func TestGetPullSubscriptionAnnotations(t *testing.T) {
 	want := map[string]string{
+		"metrics-resource-name":  "my-channel",
 		"metrics-resource-group": "channels.messaging.cloud.run",
 	}
-	got := GetPullSubscriptionAnnotations()
+	got := GetPullSubscriptionAnnotations("my-channel")
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unexpected (-want, +got) = %v", diff)

--- a/pkg/reconciler/channel/resources/annotations_test.go
+++ b/pkg/reconciler/channel/resources/annotations_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetPullSubscriptionAnnotations(t *testing.T) {
+	want := map[string]string{
+		"metrics-resource-group": "channels.messaging.cloud.run",
+	}
+	got := GetPullSubscriptionAnnotations()
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected (-want, +got) = %v", diff)
+	}
+}

--- a/pkg/reconciler/channel/resources/pullsubscription.go
+++ b/pkg/reconciler/channel/resources/pullsubscription.go
@@ -30,13 +30,14 @@ import (
 // PullSubscriptionArgs are the arguments needed to create a Channel Subscriber.
 // Every field is required.
 type PullSubscriptionArgs struct {
-	Owner      kmeta.OwnerRefable
-	Name       string
-	Project    string
-	Topic      string
-	Secret     *corev1.SecretKeySelector
-	Labels     map[string]string
-	Subscriber duckv1alpha1.SubscriberSpec
+	Owner       kmeta.OwnerRefable
+	Name        string
+	Project     string
+	Topic       string
+	Secret      *corev1.SecretKeySelector
+	Labels      map[string]string
+	Annotations map[string]string
+	Subscriber  duckv1alpha1.SubscriberSpec
 }
 
 // MakePullSubscription generates (but does not insert into K8s) the
@@ -95,6 +96,7 @@ func MakePullSubscription(args *PullSubscriptionArgs) *v1alpha1.PullSubscription
 			Namespace:       args.Owner.GetObjectMeta().GetNamespace(),
 			Name:            args.Name,
 			Labels:          args.Labels,
+			Annotations:     args.Annotations,
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(args.Owner)},
 		},
 		Spec: spec,

--- a/pkg/reconciler/pubsub_reconciler.go
+++ b/pkg/reconciler/pubsub_reconciler.go
@@ -45,7 +45,7 @@ type PubSubBase struct {
 // "TopicReady", and "PullSubscriptionReady"
 // Also sets the following fields in the pubsubable.Status upon success
 // TopicID, ProjectID, and SinkURI
-func (psb *PubSubBase) ReconcilePubSub(ctx context.Context, pubsubable duck.PubSubable, topic string) (*pubsubsourcev1alpha1.Topic, *pubsubsourcev1alpha1.PullSubscription, error) {
+func (psb *PubSubBase) ReconcilePubSub(ctx context.Context, pubsubable duck.PubSubable, topic, resourceGroup string) (*pubsubsourcev1alpha1.Topic, *pubsubsourcev1alpha1.PullSubscription, error) {
 	if pubsubable == nil {
 		return nil, nil, fmt.Errorf("nil pubsubable passed in")
 	}
@@ -104,7 +104,7 @@ func (psb *PubSubBase) ReconcilePubSub(ctx context.Context, pubsubable duck.PubS
 			psb.Logger.Infof("Failed to get PullSubscriptions: %s", err)
 			return t, nil, fmt.Errorf("failed to get pullsubscriptions: %s", err)
 		}
-		newPS := resources.MakePullSubscription(namespace, name, spec, pubsubable, topic, psb.receiveAdapterName)
+		newPS := resources.MakePullSubscription(namespace, name, spec, pubsubable, topic, psb.receiveAdapterName, resourceGroup)
 		psb.Logger.Infof("Creating pullsubscription %+v", newPS)
 		ps, err = pullSubscriptions.Create(newPS)
 		if err != nil {

--- a/pkg/reconciler/pubsub_reconciler_test.go
+++ b/pkg/reconciler/pubsub_reconciler_test.go
@@ -42,6 +42,7 @@ const (
 	testTopicID        = "topic"
 	testProjectID      = "project"
 	receiveAdapterName = "test-receive-adapter"
+	resourceGroup      = "test-resource-group"
 	sinkName           = "sink"
 )
 
@@ -243,6 +244,9 @@ func TestCreates(t *testing.T) {
 			rectesting.WithPullSubscriptionLabels(map[string]string{
 				"receive-adapter": receiveAdapterName,
 			}),
+			rectesting.WithPullSubscriptionAnnotations(map[string]string{
+				"metrics-resource-group": resourceGroup,
+			}),
 			rectesting.WithPullSubscriptionOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 		),
 		expectedErr: "pullsubscription not ready",
@@ -254,6 +258,9 @@ func TestCreates(t *testing.T) {
 				}),
 				rectesting.WithPullSubscriptionLabels(map[string]string{
 					"receive-adapter": receiveAdapterName,
+				}),
+				rectesting.WithPullSubscriptionAnnotations(map[string]string{
+					"metrics-resource-group": resourceGroup,
 				}),
 				rectesting.WithPullSubscriptionOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			),
@@ -282,6 +289,9 @@ func TestCreates(t *testing.T) {
 				rectesting.WithPullSubscriptionLabels(map[string]string{
 					"receive-adapter": receiveAdapterName,
 				}),
+				rectesting.WithPullSubscriptionAnnotations(map[string]string{
+					"metrics-resource-group": resourceGroup,
+				}),
 				rectesting.WithPullSubscriptionOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			),
 		},
@@ -307,6 +317,9 @@ func TestCreates(t *testing.T) {
 			}),
 			rectesting.WithPullSubscriptionLabels(map[string]string{
 				"receive-adapter": receiveAdapterName,
+			}),
+			rectesting.WithPullSubscriptionAnnotations(map[string]string{
+				"metrics-resource-group": resourceGroup,
 			}),
 			rectesting.WithPullSubscriptionOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 		),
@@ -336,6 +349,9 @@ func TestCreates(t *testing.T) {
 				rectesting.WithPullSubscriptionLabels(map[string]string{
 					"receive-adapter": receiveAdapterName,
 				}),
+				rectesting.WithPullSubscriptionAnnotations(map[string]string{
+					"metrics-resource-group": resourceGroup,
+				}),
 				rectesting.WithPullSubscriptionOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 				rectesting.WithPullSubscriptionReady("http://example.com"),
 			),
@@ -363,6 +379,9 @@ func TestCreates(t *testing.T) {
 			rectesting.WithPullSubscriptionLabels(map[string]string{
 				"receive-adapter": receiveAdapterName,
 			}),
+			rectesting.WithPullSubscriptionAnnotations(map[string]string{
+				"metrics-resource-group": resourceGroup,
+			}),
 			rectesting.WithPullSubscriptionOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			rectesting.WithPullSubscriptionReady("http://example.com"),
 		),
@@ -383,7 +402,7 @@ func TestCreates(t *testing.T) {
 		psBase.Logger = logtesting.TestLogger(t)
 
 		arl := pkgtesting.ActionRecorderList{cs}
-		topic, ps, err := psBase.ReconcilePubSub(context.Background(), pubsubable, testTopicID)
+		topic, ps, err := psBase.ReconcilePubSub(context.Background(), pubsubable, testTopicID, resourceGroup)
 
 		if (tc.expectedErr != "" && err == nil) ||
 			(tc.expectedErr == "" && err != nil) ||

--- a/pkg/reconciler/pullsubscription/resources/receive_adapter.go
+++ b/pkg/reconciler/pullsubscription/resources/receive_adapter.go
@@ -47,9 +47,10 @@ type ReceiveAdapterArgs struct {
 }
 
 const (
-	credsVolume    = "google-cloud-key"
-	credsMountPath = "/var/secrets/google"
-	metricsDomain  = "cloud.run/events"
+	credsVolume          = "google-cloud-key"
+	credsMountPath       = "/var/secrets/google"
+	metricsDomain        = "cloud.run/events"
+	defaultResourceGroup = "pullsubscriptions.pubsub.cloud.run"
 )
 
 // MakeReceiveAdapter generates (but does not insert into K8s) the Receive Adapter Deployment for
@@ -78,6 +79,11 @@ func MakeReceiveAdapter(ctx context.Context, args *ReceiveAdapterArgs) *v1.Deplo
 		mode = converters.Structured
 	case v1alpha1.ModePushCompatible:
 		mode = converters.Push
+	}
+
+	var resourceGroup = defaultResourceGroup
+	if rg, ok := args.Source.Annotations["metrics-resource-group"]; ok {
+		resourceGroup = rg
 	}
 
 	credsFile := fmt.Sprintf("%s/%s", credsMountPath, secret.Key)
@@ -139,6 +145,9 @@ func MakeReceiveAdapter(ctx context.Context, args *ReceiveAdapterArgs) *v1.Deplo
 						}, {
 							Name:  "NAMESPACE",
 							Value: args.Source.Namespace,
+						}, {
+							Name:  "RESOURCE_GROUP",
+							Value: resourceGroup,
 						}, {
 							Name:  "METRICS_DOMAIN",
 							Value: metricsDomain,

--- a/pkg/reconciler/pullsubscription/resources/receive_adapter.go
+++ b/pkg/reconciler/pullsubscription/resources/receive_adapter.go
@@ -85,6 +85,11 @@ func MakeReceiveAdapter(ctx context.Context, args *ReceiveAdapterArgs) *v1.Deplo
 	if rg, ok := args.Source.Annotations["metrics-resource-group"]; ok {
 		resourceGroup = rg
 	}
+	// Needed for Channels, as we use a generate name for the PullSubscription.
+	var resourceName = args.Source.Name
+	if rn, ok := args.Source.Annotations["metrics-resource-name"]; ok {
+		resourceName = rn
+	}
 
 	credsFile := fmt.Sprintf("%s/%s", credsMountPath, secret.Key)
 	replicas := int32(1)
@@ -141,7 +146,7 @@ func MakeReceiveAdapter(ctx context.Context, args *ReceiveAdapterArgs) *v1.Deplo
 							Value: args.LoggingConfig,
 						}, {
 							Name:  "NAME",
-							Value: args.Source.Name,
+							Value: resourceName,
 						}, {
 							Name:  "NAMESPACE",
 							Value: args.Source.Namespace,

--- a/pkg/reconciler/pullsubscription/resources/receive_adapter_test.go
+++ b/pkg/reconciler/pullsubscription/resources/receive_adapter_test.go
@@ -131,6 +131,9 @@ func TestMakeMinimumReceiveAdapter(t *testing.T) {
 							Name:  "NAMESPACE",
 							Value: "source-namespace",
 						}, {
+							Name:  "RESOURCE_GROUP",
+							Value: defaultResourceGroup,
+						}, {
 							Name:  "METRICS_DOMAIN",
 							Value: metricsDomain,
 						}},
@@ -163,6 +166,9 @@ func TestMakeFullReceiveAdapter(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "source-name",
 			Namespace: "source-namespace",
+			Annotations: map[string]string{
+				"metrics-resource-group": "test-resource-group",
+			},
 		},
 		Spec: v1alpha1.PullSubscriptionSpec{
 			Project: "eventing-name",
@@ -268,6 +274,9 @@ func TestMakeFullReceiveAdapter(t *testing.T) {
 						}, {
 							Name:  "NAMESPACE",
 							Value: "source-namespace",
+						}, {
+							Name:  "RESOURCE_GROUP",
+							Value: "test-resource-group",
 						}, {
 							Name:  "METRICS_DOMAIN",
 							Value: metricsDomain,

--- a/pkg/reconciler/resources/pullsubscription.go
+++ b/pkg/reconciler/resources/pullsubscription.go
@@ -26,9 +26,13 @@ import (
 
 // MakePullSubscription creates the spec for, but does not create, a GCP PullSubscription
 // for a given GCS.
-func MakePullSubscription(namespace, name string, spec *duckv1alpha1.PubSubSpec, owner kmeta.OwnerRefable, topic, receiveAdapterName string) *pubsubv1alpha1.PullSubscription {
+func MakePullSubscription(namespace, name string, spec *duckv1alpha1.PubSubSpec, owner kmeta.OwnerRefable, topic, receiveAdapterName, resourceGroup string) *pubsubv1alpha1.PullSubscription {
 	labels := map[string]string{
 		"receive-adapter": receiveAdapterName,
+	}
+
+	annotations := map[string]string{
+		"metrics-resource-group": resourceGroup,
 	}
 
 	pubsubSecret := spec.Secret
@@ -41,6 +45,7 @@ func MakePullSubscription(namespace, name string, spec *duckv1alpha1.PubSubSpec,
 			Name:            name,
 			Namespace:       namespace,
 			Labels:          labels,
+			Annotations:     annotations,
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(owner)},
 		},
 		Spec: pubsubv1alpha1.PullSubscriptionSpec{

--- a/pkg/reconciler/resources/pullsubscription_test.go
+++ b/pkg/reconciler/resources/pullsubscription_test.go
@@ -64,7 +64,7 @@ func TestMakePullSubscription(t *testing.T) {
 		},
 	}
 
-	got := MakePullSubscription(source.Namespace, source.Name, &source.Spec.PubSubSpec, source, "topic-abc", "storage.events.cloud.run")
+	got := MakePullSubscription(source.Namespace, source.Name, &source.Spec.PubSubSpec, source, "topic-abc", "storage.events.cloud.run", "storages.events.cloud.run")
 
 	yes := true
 	want := &pubsubv1alpha1.PullSubscription{
@@ -73,6 +73,9 @@ func TestMakePullSubscription(t *testing.T) {
 			Name:      "bucket-name",
 			Labels: map[string]string{
 				"receive-adapter": "storage.events.cloud.run",
+			},
+			Annotations: map[string]string{
+				"metrics-resource-group": "storages.events.cloud.run",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion:         "events.cloud.run/v1alpha1",

--- a/pkg/reconciler/scheduler/scheduler.go
+++ b/pkg/reconciler/scheduler/scheduler.go
@@ -49,6 +49,8 @@ const (
 	ReconcilerName = "Scheduler"
 
 	finalizerName = controllerAgentName
+
+	resourceGroup = "schedulers.events.cloud.run"
 )
 
 // Reconciler is the controller implementation for Google Cloud Scheduler Jobs.
@@ -142,7 +144,7 @@ func (c *Reconciler) reconcile(ctx context.Context, s *v1alpha1.Scheduler) error
 		return err
 	}
 
-	t, ps, err := c.PubSubBase.ReconcilePubSub(ctx, s, topic)
+	t, ps, err := c.PubSubBase.ReconcilePubSub(ctx, s, topic, resourceGroup)
 	if err != nil {
 		c.Logger.Infof("Failed to reconcile PubSub: %s", err)
 		return err

--- a/pkg/reconciler/scheduler/scheduler_test.go
+++ b/pkg/reconciler/scheduler/scheduler_test.go
@@ -353,6 +353,9 @@ func TestAllCases(t *testing.T) {
 				WithPullSubscriptionLabels(map[string]string{
 					"receive-adapter": "scheduler.events.cloud.run",
 				}),
+				WithPullSubscriptionAnnotations(map[string]string{
+					"metrics-resource-group": "schedulers.events.cloud.run",
+				}),
 				WithPullSubscriptionOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			),
 		},

--- a/pkg/reconciler/storage/storage.go
+++ b/pkg/reconciler/storage/storage.go
@@ -49,6 +49,8 @@ const (
 	ReconcilerName = "Storage"
 
 	finalizerName = controllerAgentName
+
+	resourceGroup = "storages.events.cloud.run"
 )
 
 // Reconciler is the controller implementation for Google Cloud Storage (GCS) event
@@ -152,7 +154,7 @@ func (c *Reconciler) reconcile(ctx context.Context, csr *v1alpha1.Storage) error
 		return err
 	}
 
-	t, ps, err := c.PubSubBase.ReconcilePubSub(ctx, csr, topic)
+	t, ps, err := c.PubSubBase.ReconcilePubSub(ctx, csr, topic, resourceGroup)
 	if err != nil {
 		c.Logger.Infof("Failed to reconcile PubSub: %s", err)
 		return err

--- a/pkg/reconciler/storage/storage_test.go
+++ b/pkg/reconciler/storage/storage_test.go
@@ -350,6 +350,9 @@ func TestAllCases(t *testing.T) {
 				WithPullSubscriptionLabels(map[string]string{
 					"receive-adapter": "storage.events.cloud.run",
 				}),
+				WithPullSubscriptionAnnotations(map[string]string{
+					"metrics-resource-group": "storages.events.cloud.run",
+				}),
 				WithPullSubscriptionOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			),
 		},

--- a/pkg/reconciler/testing/pullsubscription.go
+++ b/pkg/reconciler/testing/pullsubscription.go
@@ -190,6 +190,12 @@ func WithPullSubscriptionLabels(labels map[string]string) PullSubscriptionOption
 	}
 }
 
+func WithPullSubscriptionAnnotations(annotations map[string]string) PullSubscriptionOption {
+	return func(c *v1alpha1.PullSubscription) {
+		c.ObjectMeta.Annotations = annotations
+	}
+}
+
 func WithPullSubscriptionFinalizers(finalizers ...string) PullSubscriptionOption {
 	return func(s *v1alpha1.PullSubscription) {
 		s.Finalizers = finalizers


### PR DESCRIPTION
- Given that the receive adapter is the data plane piece for many constructs (Channel, PullSubscription, Storage, ...), the metrics need to properly tag which resource group the metric refers to. We are passing that along as an env variable.
- Note that this works for now, but when we coalesce all those objects to use the same receive adapter instance, it won't. We need to figure out a way to properly do this... There are some TODOs in the code for that.
