### PR TITLE
Adding Title to Source Registry

### DIFF
--- a/config/300-pullsubscription.yaml
+++ b/config/300-pullsubscription.yaml
@@ -48,6 +48,7 @@ spec:
       properties:
         registry:
           type: object
+          title: "PubSub"
           description: "Internal information, users should not set this property"
           properties:
             eventTypes:

--- a/config/300-scheduler.yaml
+++ b/config/300-scheduler.yaml
@@ -48,20 +48,22 @@ spec:
       properties:
         registry:
           type: object
+          title: "Scheduler"
           description: "Internal information, users should not set this property"
           properties:
             eventTypes:
               type: object
               properties:
+                # TODO properly define type and schema.
                 publish:
                   type: object
+                  description: "This event is sent when a message is published to a Cloud Pub/Sub topic."
                   properties:
                     type:
                       type: string
                       pattern: "google.pubsub.topic.publish"
                     schema:
                       type: string
-                      pattern: "https://raw.githubusercontent.com/google/knative-gcp/master/schemas/storage/schema.json"
         spec:
           properties:
             secret:
@@ -85,15 +87,6 @@ spec:
             sink:
               type: object
               description: "Sink which receives the notifications."
-            eventTypes:
-              type: array
-              items:
-                enum:
-                  - finalize
-                  - delete
-                  - archive
-                  - metadataUpdate
-                type: string
           required:
           - location
           - schedule

--- a/config/300-storage.yaml
+++ b/config/300-storage.yaml
@@ -49,6 +49,7 @@ spec:
         registry:
           type: object
           description: "Internal information, users should not set this property"
+          title: "Storage"
           properties:
             eventTypes:
               type: object


### PR DESCRIPTION
- Using a title CRD property for tooling to use. For example, for CLI or UI display name. Cannot rely on kind because we want for example `PubSub` instead of `PullSubscription`.
- Removing eventTypes from `Scheduler`. Added a TODO to properly define its type and schema, if any.