### PR TITLE
Only fail if the project ID is missing when doing create

### DIFF
--- a/pkg/operations/storage/notification.go
+++ b/pkg/operations/storage/notification.go
@@ -101,9 +101,6 @@ func NewNotificationOps(arg NotificationArgs) (*batchv1.Job, error) {
 		Name:  "ACTION",
 		Value: arg.Action,
 	}, {
-		Name:  "PROJECT_ID",
-		Value: arg.ProjectID,
-	}, {
 		Name:  "BUCKET",
 		Value: arg.Bucket,
 	}}
@@ -117,6 +114,9 @@ func NewNotificationOps(arg NotificationArgs) (*batchv1.Job, error) {
 			}, {
 				Name:  "PUBSUB_TOPIC_ID",
 				Value: arg.TopicID,
+			}, {
+				Name:  "PROJECT_ID",
+				Value: arg.ProjectID,
 			}}...)
 	case operations.ActionDelete:
 		env = append(env, []corev1.EnvVar{{
@@ -324,9 +324,6 @@ func validateArgs(arg NotificationArgs) error {
 	if arg.Action == "" {
 		return fmt.Errorf("missing Action")
 	}
-	if arg.ProjectID == "" {
-		return fmt.Errorf("missing ProjectID")
-	}
 	if arg.Bucket == "" {
 		return fmt.Errorf("missing Bucket")
 	}
@@ -341,6 +338,9 @@ func validateArgs(arg NotificationArgs) error {
 	case operations.ActionCreate:
 		if arg.TopicID == "" {
 			return fmt.Errorf("missing TopicID")
+		}
+		if arg.ProjectID == "" {
+			return fmt.Errorf("missing ProjectID")
 		}
 		if len(arg.EventTypes) == 0 {
 			return fmt.Errorf("missing EventTypes")

--- a/pkg/operations/storage/notification_test.go
+++ b/pkg/operations/storage/notification_test.go
@@ -87,14 +87,6 @@ func TestValidateArgs(t *testing.T) {
 		},
 		expectedErr: "missing Action",
 	}, {
-		name: "missing ProjectID",
-		args: NotificationArgs{
-			UID:    "uid",
-			Image:  testImage,
-			Action: "create",
-		},
-		expectedErr: "missing ProjectID",
-	}, {
 		name: "missing Bucket",
 		args: NotificationArgs{
 			UID:       "uid",
@@ -142,6 +134,21 @@ func TestValidateArgs(t *testing.T) {
 			Owner: reconcilertesting.NewStorage(storageName, testNS),
 		},
 		expectedErr: "missing TopicID",
+	}, {
+		name: "missing ProjectID on create",
+		args: NotificationArgs{
+			UID:       "uid",
+			Image:     testImage,
+			Action:    "create",
+			Bucket:    bucket,
+			TopicID:   topicID,
+			Secret: corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+				Key:                  "key.json",
+			},
+			Owner: reconcilertesting.NewStorage(storageName, testNS),
+		},
+		expectedErr: "missing ProjectID",
 	}, {
 		name: "missing eventTypes on create",
 		args: NotificationArgs{
@@ -196,7 +203,6 @@ func TestValidateArgs(t *testing.T) {
 			UID:       "uid",
 			Image:     testImage,
 			Action:    "delete",
-			ProjectID: projectId,
 			Bucket:    bucket,
 			Secret: corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
@@ -299,7 +305,6 @@ func validDeleteArgs() NotificationArgs {
 		UID:            storageUID,
 		Image:          testImage,
 		Action:         "delete",
-		ProjectID:      projectId,
 		NotificationId: notificationId,
 		Bucket:         bucket,
 		Secret: corev1.SecretKeySelector{
@@ -336,9 +341,6 @@ func podTemplate(action string) corev1.PodTemplateSpec {
 			Name:  "ACTION",
 			Value: action,
 		}, {
-			Name:  "PROJECT_ID",
-			Value: projectId,
-		}, {
 			Name:  "BUCKET",
 			Value: bucket,
 		},
@@ -352,6 +354,9 @@ func podTemplate(action string) corev1.PodTemplateSpec {
 			}, {
 				Name:  "PUBSUB_TOPIC_ID",
 				Value: topicID,
+			}, {
+				Name:  "PROJECT_ID",
+				Value: projectId,
 			},
 		}
 		env = append(env, createEnv...)


### PR DESCRIPTION
reopen PR #273

When trying to delete storage, it will fail for notification was unable to delete. Error: missing project_ID will be returned
Sync with @vaikas-google, only fail if the project ID is missing when doing a Create operation for notification (not for Delete operation)