### PR TITLE
updated Status.ObservedGeneration for pullsubscription and storage

### DIFF
--- a/pkg/reconciler/pullsubscription/pullsubscription.go
+++ b/pkg/reconciler/pullsubscription/pullsubscription.go
@@ -157,6 +157,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 func (c *Reconciler) reconcile(ctx context.Context, source *v1alpha1.PullSubscription) error {
 	logger := logging.FromContext(ctx)
 
+	source.Status.ObservedGeneration = source.Generation
 	source.Status.InitializeConditions()
 
 	if source.GetDeletionTimestamp() != nil {

--- a/pkg/reconciler/pullsubscription/pullsubscription_test.go
+++ b/pkg/reconciler/pullsubscription/pullsubscription_test.go
@@ -64,6 +64,7 @@ const (
 	testProject        = "test-project-id"
 	testTopicID        = sourceUID + "-TOPIC"
 	testSubscriptionID = "cre-pull-" + sourceUID
+	generation = 1
 )
 
 var (
@@ -121,6 +122,7 @@ func TestAllCases(t *testing.T) {
 		Objects: []runtime.Object{
 			NewPullSubscription(sourceName, testNS,
 				WithPullSubscriptionUID(sourceUID),
+				WithPullSubscriptionObjectMetaGeneration(generation),
 				WithPullSubscriptionSpec(pubsubv1alpha1.PullSubscriptionSpec{
 					Project: testProject,
 					Topic:   testTopicID,
@@ -140,6 +142,7 @@ func TestAllCases(t *testing.T) {
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewPullSubscription(sourceName, testNS,
 				WithPullSubscriptionUID(sourceUID),
+				WithPullSubscriptionObjectMetaGeneration(generation),
 				WithPullSubscriptionSpec(pubsubv1alpha1.PullSubscriptionSpec{
 					Project: testProject,
 					Topic:   testTopicID,
@@ -149,6 +152,7 @@ func TestAllCases(t *testing.T) {
 				WithPullSubscriptionSink(sinkGVK, sinkName),
 				WithPullSubscriptionMarkSink(sinkURI),
 				// Updates
+				WithPullSubscriptionStatusObservedGeneration(generation),
 				WithPullSubscriptionMarkSubscribing(testSubscriptionID),
 			),
 		}},
@@ -164,6 +168,7 @@ func TestAllCases(t *testing.T) {
 			Objects: []runtime.Object{
 				NewPullSubscription(sourceName, testNS,
 					WithPullSubscriptionUID(sourceUID),
+					WithPullSubscriptionObjectMetaGeneration(generation),
 					WithPullSubscriptionSpec(pubsubv1alpha1.PullSubscriptionSpec{
 						Project: testProject,
 						Topic:   testTopicID,
@@ -181,6 +186,7 @@ func TestAllCases(t *testing.T) {
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewPullSubscription(sourceName, testNS,
 					WithPullSubscriptionUID(sourceUID),
+					WithPullSubscriptionObjectMetaGeneration(generation),
 					WithPullSubscriptionSpec(pubsubv1alpha1.PullSubscriptionSpec{
 						Project: testProject,
 						Topic:   testTopicID,
@@ -188,6 +194,7 @@ func TestAllCases(t *testing.T) {
 					WithPullSubscriptionSink(sinkGVK, sinkName),
 					WithPullSubscriptionSubscription(testSubscriptionID),
 					// Updates
+					WithPullSubscriptionStatusObservedGeneration(generation),
 					WithInitPullSubscriptionConditions,
 					WithPullSubscriptionReady(sinkURI),
 				),
@@ -200,6 +207,7 @@ func TestAllCases(t *testing.T) {
 			Objects: []runtime.Object{
 				NewPullSubscription(sourceName, testNS,
 					WithPullSubscriptionUID(sourceUID),
+					WithPullSubscriptionObjectMetaGeneration(generation),
 					WithPullSubscriptionSpec(pubsubv1alpha1.PullSubscriptionSpec{
 						Project: testProject,
 						Topic:   testTopicID,
@@ -218,6 +226,7 @@ func TestAllCases(t *testing.T) {
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewPullSubscription(sourceName, testNS,
 					WithPullSubscriptionUID(sourceUID),
+					WithPullSubscriptionObjectMetaGeneration(generation),
 					WithPullSubscriptionSpec(pubsubv1alpha1.PullSubscriptionSpec{
 						Project: testProject,
 						Topic:   testTopicID,
@@ -225,6 +234,7 @@ func TestAllCases(t *testing.T) {
 					WithPullSubscriptionSink(sinkGVK, sinkName),
 					WithPullSubscriptionSubscription(testSubscriptionID),
 					// Updates
+					WithPullSubscriptionStatusObservedGeneration(generation),
 					WithInitPullSubscriptionConditions,
 					WithPullSubscriptionReady(sinkURI),
 				),
@@ -234,6 +244,7 @@ func TestAllCases(t *testing.T) {
 			Objects: []runtime.Object{
 				NewPullSubscription(sourceName, testNS,
 					WithPullSubscriptionUID(sourceUID),
+					WithPullSubscriptionObjectMetaGeneration(generation),
 					WithPullSubscriptionSpec(pubsubv1alpha1.PullSubscriptionSpec{
 						Project: testProject,
 						Topic:   testTopicID,
@@ -260,6 +271,7 @@ func TestAllCases(t *testing.T) {
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewPullSubscription(sourceName, testNS,
 					WithPullSubscriptionUID(sourceUID),
+					WithPullSubscriptionObjectMetaGeneration(generation),
 					WithPullSubscriptionSpec(pubsubv1alpha1.PullSubscriptionSpec{
 						Project: testProject,
 						Topic:   testTopicID,
@@ -267,6 +279,7 @@ func TestAllCases(t *testing.T) {
 					WithPullSubscriptionSink(sinkGVK, sinkName),
 					WithPullSubscriptionSubscription(testSubscriptionID),
 					// Updates
+					WithPullSubscriptionStatusObservedGeneration(generation),
 					WithInitPullSubscriptionConditions,
 					WithPullSubscriptionReady(sinkURI),
 				),
@@ -275,6 +288,7 @@ func TestAllCases(t *testing.T) {
 			Name: "cannot get sink",
 			Objects: []runtime.Object{
 				NewPullSubscription(sourceName, testNS,
+					WithPullSubscriptionObjectMetaGeneration(generation),
 					WithPullSubscriptionSpec(pubsubv1alpha1.PullSubscriptionSpec{
 						Project: testProject,
 						Topic:   testTopicID,
@@ -289,12 +303,14 @@ func TestAllCases(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewPullSubscription(sourceName, testNS,
+					WithPullSubscriptionObjectMetaGeneration(generation),
 					WithPullSubscriptionSpec(pubsubv1alpha1.PullSubscriptionSpec{
 						Project: testProject,
 						Topic:   testTopicID,
 					}),
 					WithPullSubscriptionSink(sinkGVK, sinkName),
 					// updates
+					WithPullSubscriptionStatusObservedGeneration(generation),
 					WithInitPullSubscriptionConditions,
 					WithPullSubscriptionSinkNotFound(),
 				),
@@ -305,6 +321,7 @@ func TestAllCases(t *testing.T) {
 			Objects: []runtime.Object{
 				NewPullSubscription(sourceName, testNS,
 					WithPullSubscriptionUID(sourceUID),
+					WithPullSubscriptionObjectMetaGeneration(generation),
 					WithPullSubscriptionSpec(pubsubv1alpha1.PullSubscriptionSpec{
 						Project: testProject,
 						Topic:   testTopicID,
@@ -324,6 +341,7 @@ func TestAllCases(t *testing.T) {
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewPullSubscription(sourceName, testNS,
 					WithPullSubscriptionUID(sourceUID),
+					WithPullSubscriptionObjectMetaGeneration(generation),
 					WithPullSubscriptionSpec(pubsubv1alpha1.PullSubscriptionSpec{
 						Project: testProject,
 						Topic:   testTopicID,
@@ -335,6 +353,7 @@ func TestAllCases(t *testing.T) {
 					WithPullSubscriptionFinalizers(finalizerName),
 					WithPullSubscriptionDeleted,
 					// updates
+					WithPullSubscriptionStatusObservedGeneration(generation),
 					WithPullSubscriptionMarkUnsubscribing(testSubscriptionID),
 				),
 			}},
@@ -347,6 +366,7 @@ func TestAllCases(t *testing.T) {
 			Objects: []runtime.Object{
 				NewPullSubscription(sourceName, testNS,
 					WithPullSubscriptionUID(sourceUID),
+					WithPullSubscriptionObjectMetaGeneration(generation),
 					WithPullSubscriptionSpec(pubsubv1alpha1.PullSubscriptionSpec{
 						Project: testProject,
 						Topic:   testTopicID,
@@ -368,6 +388,7 @@ func TestAllCases(t *testing.T) {
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewPullSubscription(sourceName, testNS,
 					WithPullSubscriptionUID(sourceUID),
+					WithPullSubscriptionObjectMetaGeneration(generation),
 					WithPullSubscriptionSpec(pubsubv1alpha1.PullSubscriptionSpec{
 						Project: testProject,
 						Topic:   testTopicID,
@@ -379,6 +400,7 @@ func TestAllCases(t *testing.T) {
 					WithPullSubscriptionSubscription(testSubscriptionID),
 					WithPullSubscriptionFinalizers(finalizerName),
 					// updates
+					WithPullSubscriptionStatusObservedGeneration(generation),
 					WithPullSubscriptionMarkNoSubscription(testSubscriptionID),
 				),
 			}},

--- a/pkg/reconciler/storage/storage.go
+++ b/pkg/reconciler/storage/storage.go
@@ -116,6 +116,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 }
 
 func (c *Reconciler) reconcile(ctx context.Context, csr *v1alpha1.Storage) error {
+	csr.Status.ObservedGeneration = csr.Generation
 	// If notification / topic has been already configured, stash them here
 	// since right below we remove them.
 	notificationID := csr.Status.NotificationID

--- a/pkg/reconciler/storage/storage_test.go
+++ b/pkg/reconciler/storage/storage_test.go
@@ -59,6 +59,7 @@ const (
 	testProject  = "test-project-id"
 	testTopicID  = "storage-" + storageUID
 	testTopicURI = "http://" + storageName + "-topic." + testNS + ".svc.cluster.local"
+	generation = 1
 )
 
 var (
@@ -181,6 +182,7 @@ func TestAllCases(t *testing.T) {
 		Name: "topic created, not ready",
 		Objects: []runtime.Object{
 			NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 			),
@@ -190,6 +192,8 @@ func TestAllCases(t *testing.T) {
 		WantErr: true,
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
+				WithStorageStatusObservedGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithInitStorageConditions,
@@ -215,6 +219,7 @@ func TestAllCases(t *testing.T) {
 		Name: "topic exists, topic not ready",
 		Objects: []runtime.Object{
 			NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
@@ -228,10 +233,13 @@ func TestAllCases(t *testing.T) {
 		WantErr: true,
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
+				WithStorageStatusObservedGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
 				WithInitStorageConditions,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageTopicNotReady("TopicNotReady", topicNotReadyMsg),
 			),
 		}},
@@ -239,6 +247,7 @@ func TestAllCases(t *testing.T) {
 		Name: "topic exists and is ready, no projectid",
 		Objects: []runtime.Object{
 			NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
@@ -253,9 +262,12 @@ func TestAllCases(t *testing.T) {
 		WantErr: true,
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
+				WithStorageStatusObservedGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithInitStorageConditions,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageTopicNotReady("TopicNotReady", "Topic testnamespace/my-test-storage did not expose projectid"),
 				WithStorageFinalizers(finalizerName),
 			),
@@ -264,6 +276,7 @@ func TestAllCases(t *testing.T) {
 		Name: "topic exists and is ready, no topicid",
 		Objects: []runtime.Object{
 			NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
@@ -279,9 +292,12 @@ func TestAllCases(t *testing.T) {
 		WantErr: true,
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
+				WithStorageStatusObservedGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithInitStorageConditions,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageTopicNotReady("TopicNotReady", "Topic testnamespace/my-test-storage did not expose topicid"),
 				WithStorageFinalizers(finalizerName),
 			),
@@ -290,6 +306,7 @@ func TestAllCases(t *testing.T) {
 		Name: "topic exists and is ready, unexpected topicid",
 		Objects: []runtime.Object{
 			NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
@@ -305,17 +322,22 @@ func TestAllCases(t *testing.T) {
 		WantErr: true,
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
+				WithStorageStatusObservedGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithInitStorageConditions,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageTopicNotReady("TopicNotReady", `Topic testnamespace/my-test-storage topic mismatch expected "storage-test-storage-uid" got "garbaaaaage"`),
 				WithStorageFinalizers(finalizerName),
+				WithStorageStatusObservedGeneration(generation),
 			),
 		}},
 	}, {
 		Name: "topic exists and is ready, pullsubscription created",
 		Objects: []runtime.Object{
 			NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
@@ -331,9 +353,12 @@ func TestAllCases(t *testing.T) {
 		WantErr: true,
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
+				WithStorageStatusObservedGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithInitStorageConditions,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageTopicReady(testTopicID),
 				WithStorageProjectID(testProject),
 				WithStorageFinalizers(finalizerName),
@@ -360,6 +385,7 @@ func TestAllCases(t *testing.T) {
 		Name: "topic exists and ready, pullsubscription exists but is not ready",
 		Objects: []runtime.Object{
 			NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
@@ -376,10 +402,13 @@ func TestAllCases(t *testing.T) {
 		WantErr: true,
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
+				WithStorageStatusObservedGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
 				WithInitStorageConditions,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageTopicReady(testTopicID),
 				WithStorageProjectID(testProject),
 				WithStoragePullSubscriptionNotReady("PullSubscriptionNotReady", pullSubscriptionNotReadyMsg),
@@ -389,6 +418,7 @@ func TestAllCases(t *testing.T) {
 		Name: "topic and pullsubscription exist and ready, notification job created",
 		Objects: []runtime.Object{
 			NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageEventTypes([]string{"finalize"}),
@@ -408,11 +438,14 @@ func TestAllCases(t *testing.T) {
 		WantErr: true,
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
+				WithStorageStatusObservedGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageEventTypes([]string{"finalize"}),
 				WithStorageFinalizers(finalizerName),
 				WithInitStorageConditions,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageTopicReady(testTopicID),
 				WithStorageProjectID(testProject),
 				WithStoragePullSubscriptionReady(),
@@ -427,9 +460,11 @@ func TestAllCases(t *testing.T) {
 		Name: "topic and pullsubscription exist and ready, notification job not finished",
 		Objects: []runtime.Object{
 			NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
+				WithStorageObjectMetaGeneration(generation),
 			),
 			NewTopic(storageName, testNS,
 				WithTopicReady(testTopicID),
@@ -446,10 +481,13 @@ func TestAllCases(t *testing.T) {
 		WantErr: true,
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
+				WithStorageStatusObservedGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
 				WithInitStorageConditions,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageTopicReady(testTopicID),
 				WithStorageProjectID(testProject),
 				WithStoragePullSubscriptionReady(),
@@ -461,9 +499,11 @@ func TestAllCases(t *testing.T) {
 		Name: "topic and pullsubscription exist and ready, notification job failed",
 		Objects: []runtime.Object{
 			NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
+				WithStorageObjectMetaGeneration(generation),
 			),
 			NewTopic(storageName, testNS,
 				WithTopicReady(testTopicID),
@@ -480,10 +520,13 @@ func TestAllCases(t *testing.T) {
 		WantErr: true,
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
+				WithStorageStatusObservedGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
 				WithInitStorageConditions,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageTopicReady(testTopicID),
 				WithStorageProjectID(testProject),
 				WithStoragePullSubscriptionReady(),
@@ -495,6 +538,7 @@ func TestAllCases(t *testing.T) {
 		Name: "topic and pullsubscription exist and ready, notification job finished, no pods found",
 		Objects: []runtime.Object{
 			NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
@@ -514,6 +558,8 @@ func TestAllCases(t *testing.T) {
 		WantErr: true,
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
+				WithStorageStatusObservedGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
@@ -529,6 +575,7 @@ func TestAllCases(t *testing.T) {
 		Name: "topic and pullsubscription exist and ready, notification job finished, no termination msg on pod",
 		Objects: []runtime.Object{
 			NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
@@ -549,6 +596,8 @@ func TestAllCases(t *testing.T) {
 		WantErr: true,
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
+				WithStorageStatusObservedGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
@@ -564,6 +613,7 @@ func TestAllCases(t *testing.T) {
 		Name: "topic and pullsubscription exist and ready, notification job finished, invalid termination msg on pod",
 		Objects: []runtime.Object{
 			NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
@@ -584,6 +634,8 @@ func TestAllCases(t *testing.T) {
 		WantErr: true,
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
+				WithStorageStatusObservedGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
@@ -599,6 +651,7 @@ func TestAllCases(t *testing.T) {
 		Name: "topic and pullsubscription exist and ready, notification job finished, notification creation failed",
 		Objects: []runtime.Object{
 			NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
@@ -619,6 +672,8 @@ func TestAllCases(t *testing.T) {
 		WantErr: true,
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
+				WithStorageStatusObservedGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
@@ -634,6 +689,7 @@ func TestAllCases(t *testing.T) {
 		Name: "topic and pullsubscription exist and ready, notification job finished, notification created successfully",
 		Objects: []runtime.Object{
 			NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),
@@ -654,6 +710,8 @@ func TestAllCases(t *testing.T) {
 		WantErr: false,
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewStorage(storageName, testNS,
+				WithStorageObjectMetaGeneration(generation),
+				WithStorageStatusObservedGeneration(generation),
 				WithStorageBucket(bucket),
 				WithStorageSink(sinkGVK, sinkName),
 				WithStorageFinalizers(finalizerName),

--- a/pkg/reconciler/testing/pullsubscription.go
+++ b/pkg/reconciler/testing/pullsubscription.go
@@ -201,3 +201,15 @@ func WithPullSubscriptionFinalizers(finalizers ...string) PullSubscriptionOption
 		s.Finalizers = finalizers
 	}
 }
+
+func WithPullSubscriptionStatusObservedGeneration(generation int64) PullSubscriptionOption {
+	return func(s *v1alpha1.PullSubscription) {
+		s.Status.Status.ObservedGeneration = generation
+	}
+}
+
+func WithPullSubscriptionObjectMetaGeneration(generation int64) PullSubscriptionOption {
+	return func(s *v1alpha1.PullSubscription) {
+		s.ObjectMeta.Generation = generation
+	}
+}

--- a/pkg/reconciler/testing/storage.go
+++ b/pkg/reconciler/testing/storage.go
@@ -151,3 +151,15 @@ func WithStorageFinalizers(finalizers ...string) StorageOption {
 		s.Finalizers = finalizers
 	}
 }
+
+func WithStorageStatusObservedGeneration(generation int64) StorageOption {
+	return func(s *v1alpha1.Storage) {
+		s.Status.Status.ObservedGeneration = generation
+	}
+}
+
+func WithStorageObjectMetaGeneration(generation int64) StorageOption {
+	return func(s *v1alpha1.Storage) {
+		s.ObjectMeta.Generation = generation
+	}
+}


### PR DESCRIPTION
Fixes #272 
## Proposed Changes

- Update status.ObservedGeneration for sources resources when sources resources get reconciled successfully
- Added unit tests
-

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```
