### PR TITLE
Add ClusterRole to get, list and watch pullsubscriptions and storages

### DIFF
--- a/config/201-clusterrole.yaml
+++ b/config/201-clusterrole.yaml
@@ -144,7 +144,7 @@ metadata:
     duck.knative.dev/source: "true"
 rules:
   - apiGroups:
-      - "pubsub.cloud.run"
+      - "pubsub.cloud.google.com"
     resources:
       - "pullsubscriptions"
     verbs:
@@ -163,9 +163,10 @@ metadata:
     duck.knative.dev/source: "true"
 rules:
   - apiGroups:
-      - "events.cloud.run"
+      - "events.cloud.google.com"
     resources:
       - "storages"
+      - "pubsubs"
     verbs:
       - get
       - list

--- a/config/201-clusterrole.yaml
+++ b/config/201-clusterrole.yaml
@@ -132,3 +132,41 @@ rules:
   resources:
     - eventtypes
   verbs: *everything
+
+# The role is needed for the aggregated role source-resolver in knative-eventing to provide readonly access to "Sources"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-gcp-pullsubscription-resolver
+  labels:
+    eventing.knative.dev/release: devel
+    duck.knative.dev/sourceObserver: "true"
+rules:
+  - apiGroups:
+      - "pubsub.cloud.run"
+    resources:
+      - "pullsubscriptions"
+    verbs:
+      - get
+      - list
+      - watch
+
+# The role is needed for the aggregated role source-resolver in knative-eventing to provide readonly access to "Sources"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-gcp-storage-resolver
+  labels:
+    eventing.knative.dev/release: devel
+    duck.knative.dev/sourceObserver: "true"
+rules:
+  - apiGroups:
+      - "events.cloud.run"
+    resources:
+      - "storages"
+    verbs:
+      - get
+      - list
+      - watch

--- a/config/201-clusterrole.yaml
+++ b/config/201-clusterrole.yaml
@@ -138,10 +138,10 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: knative-gcp-pullsubscription-resolver
+  name: knative-gcp-pullsubscription-observer
   labels:
     eventing.knative.dev/release: devel
-    duck.knative.dev/sourceObserver: "true"
+    duck.knative.dev/source: "true"
 rules:
   - apiGroups:
       - "pubsub.cloud.run"

--- a/config/201-clusterrole.yaml
+++ b/config/201-clusterrole.yaml
@@ -157,10 +157,10 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: knative-gcp-storage-resolver
+  name: knative-gcp-storage-observer
   labels:
     eventing.knative.dev/release: devel
-    duck.knative.dev/sourceObserver: "true"
+    duck.knative.dev/source: "true"
 rules:
   - apiGroups:
       - "events.cloud.run"

--- a/config/201-clusterrole.yaml
+++ b/config/201-clusterrole.yaml
@@ -133,8 +133,10 @@ rules:
     - eventtypes
   verbs: *everything
 
-# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources"
+
 ---
+# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".
+# See https://github.com/knative/eventing/blob/master/config/200-source-observer-clusterrole.yaml.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -152,8 +154,9 @@ rules:
       - list
       - watch
 
-# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources"
 ---
+# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".
+# See https://github.com/knative/eventing/blob/master/config/200-source-observer-clusterrole.yaml.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/config/201-clusterrole.yaml
+++ b/config/201-clusterrole.yaml
@@ -133,7 +133,7 @@ rules:
     - eventtypes
   verbs: *everything
 
-# The role is needed for the aggregated role source-resolver in knative-eventing to provide readonly access to "Sources"
+# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -152,7 +152,7 @@ rules:
       - list
       - watch
 
-# The role is needed for the aggregated role source-resolver in knative-eventing to provide readonly access to "Sources"
+# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Fixes #252  

## Proposed Changes

  * Add ClusterRole to get, list and watch pullsubscriptions and storages
  *
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
None
```