### PR TITLE
remove skip to run E2E test for storage source

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -77,7 +77,6 @@ func TestSmokePullSubscription(t *testing.T) {
 func TestPullSubscriptionWithTarget(t *testing.T) {
 	cancel := logstream.Start(t)
 	defer cancel()
-
 	PullSubscriptionWithTargetTestImpl(t, packageToImageConfig)
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -77,12 +77,12 @@ func TestSmokePullSubscription(t *testing.T) {
 func TestPullSubscriptionWithTarget(t *testing.T) {
 	cancel := logstream.Start(t)
 	defer cancel()
+
 	PullSubscriptionWithTargetTestImpl(t, packageToImageConfig)
 }
 
 // TestStorage tests we can knock down a target fot storage
 func TestStorage(t *testing.T) {
-	t.Skip("currently doesn't work in PROW, needs investigation")
 	cancel := logstream.Start(t)
 	defer cancel()
 	StorageWithTestImpl(t, packageToImageConfig)


### PR DESCRIPTION
Thank @Fredy-Z for adding roles for SAs in PR: https://github.com/knative/test-infra/pull/1363
Remove the skip to run e2e storage source test.