### PR TITLE
Changing APIGroups

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@ To get started, [install Knative with GCP](./docs/install/README.md).
 
 Then use one of the implemented `Source` resource,
 
-- [Storage (events.cloud.run)](docs/storage/README.md)
-- [Scheduler (events.cloud.run)](docs/scheduler/README.md)
+- [Storage (events.cloud.google.com)](docs/storage/README.md)
+- [Scheduler (events.cloud.google.com)](docs/scheduler/README.md)
 
 To use a Knative Eventing Channel backed by Pub/Sub:
 
-- [Channel (messaging.cloud.run)](docs/channel/README.md)
+- [Channel (messaging.cloud.google.com)](docs/channel/README.md)
 
 To leverage Pub/Sub directly, Pub/Sub resources:
 
-- [PullSubscription (pubsub.cloud.run)](docs/pullsubscription/README.md)
-- [Topic (pubsub.cloud.run)](docs/topic/README.md)
+- [PullSubscription (pubsub.cloud.google.com)](docs/pullsubscription/README.md)
+- [Topic (pubsub.cloud.google.com)](docs/topic/README.md)
 
 _Note:_ This repo is still in development apis and resource names are subject to
 change in the future.

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -60,7 +60,7 @@ func SharedMain(resourceHandlers map[schema.GroupVersionKind]webhook.GenericCRD)
 	}
 	logger, atomicLevel := logging.NewLoggerFromConfig(config, component)
 	defer logger.Sync()
-	logger = logger.With(zap.String("cloud.run/events", component))
+	logger = logger.With(zap.String("cloud.google.com/events", component))
 
 	logger.Info("Starting the Cloud Run Events Webhook")
 
@@ -105,7 +105,7 @@ func SharedMain(resourceHandlers map[schema.GroupVersionKind]webhook.GenericCRD)
 		Namespace:                       system.Namespace(),
 		Port:                            8443,
 		SecretName:                      "webhook-certs",
-		ResourceMutatingWebhookName:     fmt.Sprintf("webhook.%s.events.cloud.run", system.Namespace()),
+		ResourceMutatingWebhookName:     fmt.Sprintf("webhook.%s.events.cloud.google.com", system.Namespace()),
 		ResourceAdmissionControllerPath: "/",
 	}
 

--- a/config/100-namespace.yaml
+++ b/config/100-namespace.yaml
@@ -17,4 +17,4 @@ kind: Namespace
 metadata:
   name: cloud-run-events
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel

--- a/config/200-serviceaccount.yaml
+++ b/config/200-serviceaccount.yaml
@@ -18,4 +18,4 @@ metadata:
   name: controller
   namespace: cloud-run-events
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel

--- a/config/201-addressable-resolvers-clusterrole.yaml
+++ b/config/201-addressable-resolvers-clusterrole.yaml
@@ -19,7 +19,7 @@ kind: ClusterRole
 metadata:
   name: addressable-resolver
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -33,7 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: service-addressable-resolver
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel
     duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
@@ -54,7 +54,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kservice-addressable-resolver
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel
     duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
@@ -77,12 +77,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pubsub-topic-addressable-resolver
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel
     duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
   - apiGroups:
-      - pubsub.cloud.run
+      - pubsub.cloud.google.com
     resources:
       - topics
       - topics/status
@@ -98,12 +98,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: events-channel-addressable-resolver
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel
     duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
   - apiGroups:
-      - messaging.cloud.run
+      - messaging.cloud.google.com
     resources:
       - channels
       - channels/status

--- a/config/201-channelable-manipulator-clusterrole.yaml
+++ b/config/201-channelable-manipulator-clusterrole.yaml
@@ -19,12 +19,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: events-channel-addressable-resolver
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel
     duck.knative.dev/channelable: "true"
 # Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:
   - apiGroups:
-      - messaging.cloud.run
+      - messaging.cloud.google.com
     resources:
       - channels
     verbs:

--- a/config/201-clusterrole.yaml
+++ b/config/201-clusterrole.yaml
@@ -17,11 +17,11 @@ kind: ClusterRole
 metadata:
   name: cloud-run-events-controller
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel
 rules:
 
 - apiGroups:
-    - pubsub.cloud.run
+    - pubsub.cloud.google.com
   resources:
     - pullsubscriptions
     - topics
@@ -35,7 +35,7 @@ rules:
     - delete
 
 - apiGroups:
-    - pubsub.cloud.run
+    - pubsub.cloud.google.com
   resources:
     - pullsubscriptions/status
     - topics/status
@@ -45,14 +45,14 @@ rules:
     - patch
 
 - apiGroups:
-    - messaging.cloud.run
+    - messaging.cloud.google.com
   resources:
     - channels
     - decorators
   verbs: *everything
 
 - apiGroups:
-    - messaging.cloud.run
+    - messaging.cloud.google.com
   resources:
     - channels/status
     - decorators/status
@@ -62,7 +62,7 @@ rules:
     - patch
 
 - apiGroups:
-    - events.cloud.run
+    - events.cloud.google.com
   resources:
     - storages
     - schedulers
@@ -70,7 +70,7 @@ rules:
   verbs: *everything
 
 - apiGroups:
-    - events.cloud.run
+    - events.cloud.google.com
   resources:
     - storages/status
     - schedulers/status

--- a/config/201-role.yaml
+++ b/config/201-role.yaml
@@ -19,7 +19,7 @@ metadata:
   name: cloud-run-events-controller
   namespace: cloud-run-events
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel
 rules:
 - apiGroups:
     - ""

--- a/config/202-clusterrolebinding.yaml
+++ b/config/202-clusterrolebinding.yaml
@@ -17,7 +17,7 @@ kind: ClusterRoleBinding
 metadata:
   name: cloud-run-events-controller
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel
 subjects:
 - kind: ServiceAccount
   name: controller
@@ -34,7 +34,7 @@ kind: ClusterRoleBinding
 metadata:
   name: cloud-run-events-controller-resolver
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel
 subjects:
 - kind: ServiceAccount
   name: controller

--- a/config/202-rolebinding.yaml
+++ b/config/202-rolebinding.yaml
@@ -18,7 +18,7 @@ metadata:
   name: cloud-run-events-controller
   namespace: cloud-run-events
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel
 subjects:
 - kind: ServiceAccount
   name: controller

--- a/config/300-channel.yaml
+++ b/config/300-channel.yaml
@@ -14,13 +14,13 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
- name: channels.messaging.cloud.run
+ name: channels.messaging.cloud.google.com
  labels:
-   events.cloud.run/release: devel
-   events.cloud.run/crd-install: "true"
+   events.cloud.google.com/release: devel
+   events.cloud.google.com/crd-install: "true"
    messaging.knative.dev/subscribable: "true"
 spec:
-  group: messaging.cloud.run
+  group: messaging.cloud.google.com
   version: v1alpha1
   names:
     kind: Channel

--- a/config/300-decorator.yaml
+++ b/config/300-decorator.yaml
@@ -14,13 +14,13 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
- name: decorators.messaging.cloud.run
+ name: decorators.messaging.cloud.google.com
  labels:
-   events.cloud.run/release: devel
-   events.cloud.run/crd-install: "true"
+   events.cloud.google.com/release: devel
+   events.cloud.google.com/crd-install: "true"
    messaging.knative.dev/subscribable: "true"
 spec:
-  group: messaging.cloud.run
+  group: messaging.cloud.google.com
   version: v1alpha1
   names:
     kind: Decorator

--- a/config/300-pubsub.yaml
+++ b/config/300-pubsub.yaml
@@ -17,16 +17,16 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     eventing.knative.dev/source: "true"
-    events.cloud.run/release: devel
-    events.cloud.run/crd-install: "true"
+    events.cloud.google.com/release: devel
+    events.cloud.google.com/crd-install: "true"
   annotations:
-    registry.cloud.run/eventTypes: |
+    registry.cloud.google.com/eventTypes: |
       [
         { "type": "google.pubsub.topic.publish", "description": "This event is sent when a message is published to a Cloud Pub/Sub topic."}
       ]
-  name: pubsubs.events.cloud.run
+  name: pubsubs.events.cloud.google.com
 spec:
-  group: events.cloud.run
+  group: events.cloud.google.com
   version: v1alpha1
   names:
     categories:

--- a/config/300-pullsubscription.yaml
+++ b/config/300-pullsubscription.yaml
@@ -17,16 +17,16 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     eventing.knative.dev/source: "true"
-    events.cloud.run/release: devel
-    events.cloud.run/crd-install: "true"
+    events.cloud.google.com/release: devel
+    events.cloud.google.com/crd-install: "true"
   annotations:
-    registry.cloud.run/eventTypes: |
+    registry.cloud.google.com/eventTypes: |
       [
         { "type": "google.pubsub.topic.publish", "description": "This event is sent when a message is published to a Cloud Pub/Sub topic."}
       ]
-  name: pullsubscriptions.pubsub.cloud.run
+  name: pullsubscriptions.pubsub.cloud.google.com
 spec:
-  group: pubsub.cloud.run
+  group: pubsub.cloud.google.com
   version: v1alpha1
   names:
     categories:

--- a/config/300-scheduler.yaml
+++ b/config/300-scheduler.yaml
@@ -17,17 +17,17 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     eventing.knative.dev/source: "true"
-    events.cloud.run/release: devel
-    events.cloud.run/crd-install: "true"
+    events.cloud.google.com/release: devel
+    events.cloud.google.com/crd-install: "true"
   annotations:
     # TODO properly define type, schema, and description.
-    registry.cloud.run/eventTypes: |
+    registry.cloud.google.com/eventTypes: |
       [
         { "type": "google.pubsub.topic.publish", "description": "This event is sent when a message is published to a Cloud Pub/Sub topic."}
       ]
-  name: schedulers.events.cloud.run
+  name: schedulers.events.cloud.google.com
 spec:
-  group: events.cloud.run
+  group: events.cloud.google.com
   version: v1alpha1
   names:
     categories:

--- a/config/300-storage.yaml
+++ b/config/300-storage.yaml
@@ -17,19 +17,19 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     eventing.knative.dev/source: "true"
-    events.cloud.run/release: devel
-    events.cloud.run/crd-install: "true"
+    events.cloud.google.com/release: devel
+    events.cloud.google.com/crd-install: "true"
   annotations:
-    registry.cloud.run/eventTypes: |
+    registry.cloud.google.com/eventTypes: |
       [
         { "type": "google.storage.object.finalize", "schema": "https://raw.githubusercontent.com/google/knative-gcp/master/schemas/storage/schema.json", "description": "Sent when a new object (or a new generation of an existing object) is successfully created in the bucket. This includes copying or rewriting an existing object. A failed upload does not trigger this event." },
         { "type": "google.storage.object.delete", "schema": "https://raw.githubusercontent.com/google/knative-gcp/master/schemas/storage/schema.json", "description": "Sent when an object has been permanently deleted. This includes objects that are overwritten or are deleted as part of the bucket's lifecycle configuration. For buckets with object versioning enabled, this is not sent when an object is archived."},
         { "type": "google.storage.object.archive", "schema": "https://raw.githubusercontent.com/google/knative-gcp/master/schemas/storage/schema.json", "description": "Only sent when a bucket has enabled object versioning. This event indicates that the live version of an object has become an archived version, either because it was archived or because it was overwritten by the upload of an object of the same name."},
         { "type": "google.storage.object.metadataUpdate", "schema": "https://raw.githubusercontent.com/google/knative-gcp/master/schemas/storage/schema.json", "description": "Sent when the metadata of an existing object changes." }
       ]
-  name: storages.events.cloud.run
+  name: storages.events.cloud.google.com
 spec:
-  group: events.cloud.run
+  group: events.cloud.google.com
   version: v1alpha1
   names:
     categories:

--- a/config/300-topic.yaml
+++ b/config/300-topic.yaml
@@ -14,12 +14,12 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
- name: topics.pubsub.cloud.run
+ name: topics.pubsub.cloud.google.com
  labels:
-   events.cloud.run/release: devel
-   events.cloud.run/crd-install: "true"
+   events.cloud.google.com/release: devel
+   events.cloud.google.com/crd-install: "true"
 spec:
-  group: pubsub.cloud.run
+  group: pubsub.cloud.google.com
   version: v1alpha1
   names:
     kind: Topic

--- a/config/400-controller-service.yaml
+++ b/config/400-controller-service.yaml
@@ -18,7 +18,7 @@ metadata:
   name: controller
   namespace: cloud-run-events
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel
     app: cloud-run-events-controller
 spec:
   selector:

--- a/config/400-webhook-service.yaml
+++ b/config/400-webhook-service.yaml
@@ -17,7 +17,7 @@ kind: Service
 metadata:
   labels:
     role: webhook
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel
   name: webhook
   namespace: cloud-run-events
 spec:

--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -18,7 +18,7 @@ metadata:
   name: controller
   namespace: cloud-run-events
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel
 spec:
   replicas: 1
   selector:
@@ -60,7 +60,7 @@ spec:
         - name: CONFIG_OBSERVABILITY_NAME
           value: config-observability
         - name: METRICS_DOMAIN
-          value: cloud.run/events
+          value: cloud.google.com/events
         volumeMounts:
         - name: config-logging
           mountPath: /etc/config-logging

--- a/config/500-webhook.yaml
+++ b/config/500-webhook.yaml
@@ -18,7 +18,7 @@ metadata:
   name: webhook
   namespace: cloud-run-events
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel
 spec:
   replicas: 1
   selector:
@@ -30,7 +30,7 @@ spec:
       labels:
         app: cloud-run-events
         role: webhook
-        events.cloud.run/release: devel
+        events.cloud.google.com/release: devel
     spec:
       serviceAccountName: controller
       containers:

--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -18,7 +18,7 @@ metadata:
   name: config-logging
   namespace: cloud-run-events
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel
 
 data:
   _example: |

--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -18,7 +18,7 @@ metadata:
   name: config-observability
   namespace: cloud-run-events
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel
 
 data:
   _example: |

--- a/config/istio/600-istioegress.yaml
+++ b/config/istio/600-istioegress.yaml
@@ -18,7 +18,7 @@ kind: ServiceEntry
 metadata:
   name: cloud-run-events-googleapis-ext
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel
 spec:
   hosts:
   - "*.googleapis.com"

--- a/config/monitoring/metrics/README.md
+++ b/config/monitoring/metrics/README.md
@@ -123,11 +123,11 @@ Then, access the [Grafana Dashboard](http://localhost:3000)
 
 Add `metrics.backend-destination: stackdriver`,
 `metrics.allow-stackdriver-custom-metrics: "true"` and
-`metrics.stackdriver-custom-metrics-subdomain: "cloud.run/events"` to the `data`
+`metrics.stackdriver-custom-metrics-subdomain: "cloud.google.com/events"` to the `data`
 field.  
  You can find detailed information in `data._example` field in the `ConfigMap` you
 are editing.
 
 1. Open the StackDriver UI and see your resource metrics in the StackDriver
    Metrics Explorer. You should be able to see metrics with the prefix
-   `custom.googleapis.com/cloud.run/events`.
+   `custom.googleapis.com/cloud.google.com/events`.

--- a/config/transformers/pubsub-push.yaml
+++ b/config/transformers/pubsub-push.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: pubsub-push
   labels:
-    events.cloud.run/release: devel
+    events.cloud.google.com/release: devel
 spec:
   template:
     spec:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
 ## Table of Contents
 
 1. [Installing Knative with GCP](./install/README.md)
-1. [Using PullSubscription (pubsub.cloud.run/v1alpha1)](./pullsubscription/README.md)
+1. [Using PullSubscription (pubsub.cloud.google.com/v1alpha1)](./pullsubscription/README.md)

--- a/docs/channel/channel.yaml
+++ b/docs/channel/channel.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: messaging.cloud.run/v1alpha1
+apiVersion: messaging.cloud.google.com/v1alpha1
 kind: Channel
 metadata:
   name: demo

--- a/docs/channel/source.yaml
+++ b/docs/channel/source.yaml
@@ -20,6 +20,6 @@ spec:
   data: '{"hello":"world"}'
   schedule: '*/1 * * * *'
   sink:
-    apiVersion: messaging.cloud.run/v1alpha1
+    apiVersion: messaging.cloud.google.com/v1alpha1
     kind: Channel
     name: demo

--- a/docs/channel/subscription.yaml
+++ b/docs/channel/subscription.yaml
@@ -18,7 +18,7 @@ metadata:
   name: demo
 spec:
   channel:
-    apiVersion: messaging.cloud.run/v1alpha1
+    apiVersion: messaging.cloud.google.com/v1alpha1
     kind: Channel
     name: demo
   subscriber:

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -12,11 +12,11 @@ Applying the `config` dir will:
 
 - create a new namespace, `cloud-run-events`.
 - install new CRDs,
-  - `channel.messaging.cloud.run`
-  - `decorator.messaging.cloud.run`
-  - `storages.events.cloud.run`
-  - `pullsubscriptions.pubsub.cloud.run`
-  - `topics.pubsub.cloud.run`
+  - `channel.messaging.cloud.google.com`
+  - `decorator.messaging.cloud.google.com`
+  - `storages.events.cloud.google.com`
+  - `pullsubscriptions.pubsub.cloud.google.com`
+  - `topics.pubsub.cloud.google.com`
 - install a controller to operate on the new resources,
   `cloud-run-events/cloud-run-events-controller`.
 - install a new service account, `cloud-run-events/cloud-run-events-controller`.
@@ -40,11 +40,11 @@ Applying the `config` dir will:
 
 - create a new namespace, `cloud-run-events`.
 - install new CRDs,
-  - `channel.messaging.cloud.run`
-  - `decorator.messaging.cloud.run`
-  - `storages.events.cloud.run`
-  - `pullsubscriptions.pubsub.cloud.run`
-  - `topics.pubsub.cloud.run`
+  - `channel.messaging.cloud.google.com`
+  - `decorator.messaging.cloud.google.com`
+  - `storages.events.cloud.google.com`
+  - `pullsubscriptions.pubsub.cloud.google.com`
+  - `topics.pubsub.cloud.google.com`
 - install a controller to operate on the new resources,
   `cloud-run-events/cloud-run-events-controller`.
 - install a new service account, `cloud-run-events/cloud-run-events-controller`.

--- a/docs/pullsubscription/pullsubscription.yaml
+++ b/docs/pullsubscription/pullsubscription.yaml
@@ -16,7 +16,7 @@
 #   TOPIC_NAME: Replace with the Cloud PubSub Topic name.
 #   MY_PROJECT: Replace with the Google Cloud Project's ID.
 
-apiVersion: pubsub.cloud.run/v1alpha1
+apiVersion: pubsub.cloud.google.com/v1alpha1
 kind: PullSubscription
 metadata:
   name: TOPIC_NAME-source

--- a/docs/scheduler/scheduler.yaml
+++ b/docs/scheduler/scheduler.yaml
@@ -1,4 +1,4 @@
-apiVersion: events.cloud.run/v1alpha1
+apiVersion: events.cloud.google.com/v1alpha1
 kind: Scheduler
 metadata:
   name: scheduler-test

--- a/docs/storage/storage.yaml
+++ b/docs/storage/storage.yaml
@@ -16,7 +16,7 @@
 #   TOPIC_NAME: Replace with the Cloud PubSub Topic name.
 #   MY_PROJECT: Replace with the Google Cloud Project's ID.
 
-apiVersion: events.cloud.run/v1alpha1
+apiVersion: events.cloud.google.com/v1alpha1
 kind: Storage
 metadata:
   name: storage-source

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -32,8 +32,8 @@ readonly RELEASES
 function build_release() {
   # Update release labels if this is a tagged release
   if [[ -n "${TAG}" ]]; then
-    echo "Tagged release, updating release labels to events.cloud.run/release: \"${TAG}\""
-    LABEL_YAML_CMD=(sed -e "s|events.cloud.run/release: devel|events.cloud.run/release: \"${TAG}\"|")
+    echo "Tagged release, updating release labels to events.cloud.google.com/release: \"${TAG}\""
+    LABEL_YAML_CMD=(sed -e "s|events.cloud.google.com/release: devel|events.cloud.google.com/release: \"${TAG}\"|")
   else
     echo "Untagged release, will NOT update release labels"
     LABEL_YAML_CMD=(cat)

--- a/pkg/apis/duck/register.go
+++ b/pkg/apis/duck/register.go
@@ -17,5 +17,5 @@ limitations under the License.
 package duck
 
 const (
-	GroupName = "duck.cloud.run"
+	GroupName = "duck.cloud.google.com"
 )

--- a/pkg/apis/duck/v1alpha1/doc.go
+++ b/pkg/apis/duck/v1alpha1/doc.go
@@ -19,5 +19,5 @@ limitations under the License.
 // of the same resource
 
 // +k8s:deepcopy-gen=package
-// +groupName=duck.cloud.run
+// +groupName=duck.cloud.google.com
 package v1alpha1

--- a/pkg/apis/events/register.go
+++ b/pkg/apis/events/register.go
@@ -18,5 +18,5 @@ limitations under the License.
 package events
 
 const (
-	GroupName = "events.cloud.run"
+	GroupName = "events.cloud.google.com"
 )

--- a/pkg/apis/events/v1alpha1/doc.go
+++ b/pkg/apis/events/v1alpha1/doc.go
@@ -19,5 +19,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/google/knative-gcp/pkg/apis/events
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=events.cloud.run
+// +groupName=events.cloud.google.com
 package v1alpha1

--- a/pkg/apis/events/v1alpha1/pubsub_types_test.go
+++ b/pkg/apis/events/v1alpha1/pubsub_types_test.go
@@ -38,7 +38,7 @@ func TestPubSubEventSource(t *testing.T) {
 
 func TestPubSubGetGroupVersionKind(t *testing.T) {
 	want := schema.GroupVersionKind{
-		Group:   "events.cloud.run",
+		Group:   "events.cloud.google.com",
 		Version: "v1alpha1",
 		Kind:    "PubSub",
 	}

--- a/pkg/apis/events/v1alpha1/scheduler_types_test.go
+++ b/pkg/apis/events/v1alpha1/scheduler_types_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestSchedulerGetGroupVersionKind(t *testing.T) {
 	want := schema.GroupVersionKind{
-		Group:   "events.cloud.run",
+		Group:   "events.cloud.google.com",
 		Version: "v1alpha1",
 		Kind:    "Scheduler",
 	}

--- a/pkg/apis/events/v1alpha1/storage_types_test.go
+++ b/pkg/apis/events/v1alpha1/storage_types_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestGetGroupVersionKind(t *testing.T) {
 	want := schema.GroupVersionKind{
-		Group:   "events.cloud.run",
+		Group:   "events.cloud.google.com",
 		Version: "v1alpha1",
 		Kind:    "Storage",
 	}

--- a/pkg/apis/messaging/register.go
+++ b/pkg/apis/messaging/register.go
@@ -18,5 +18,5 @@ limitations under the License.
 package messaging
 
 const (
-	GroupName = "messaging.cloud.run"
+	GroupName = "messaging.cloud.google.com"
 )

--- a/pkg/apis/messaging/v1alpha1/channel_types_test.go
+++ b/pkg/apis/messaging/v1alpha1/channel_types_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestChannelGetGroupVersionKind(t *testing.T) {
 	want := schema.GroupVersionKind{
-		Group:   "messaging.cloud.run",
+		Group:   "messaging.cloud.google.com",
 		Version: "v1alpha1",
 		Kind:    "Channel",
 	}

--- a/pkg/apis/messaging/v1alpha1/decorator_types_test.go
+++ b/pkg/apis/messaging/v1alpha1/decorator_types_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestDecoratorGetGroupVersionKind(t *testing.T) {
 	want := schema.GroupVersionKind{
-		Group:   "messaging.cloud.run",
+		Group:   "messaging.cloud.google.com",
 		Version: "v1alpha1",
 		Kind:    "Decorator",
 	}

--- a/pkg/apis/messaging/v1alpha1/doc.go
+++ b/pkg/apis/messaging/v1alpha1/doc.go
@@ -19,5 +19,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/google/knative-gcp/pkg/apis/messaging
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=messaging.cloud.run
+// +groupName=messaging.cloud.google.com
 package v1alpha1

--- a/pkg/apis/messaging/v1alpha1/register_test.go
+++ b/pkg/apis/messaging/v1alpha1/register_test.go
@@ -27,7 +27,7 @@ import (
 // Resource takes an unqualified resource and returns a Group qualified GroupResource
 func TestResource(t *testing.T) {
 	want := schema.GroupResource{
-		Group:    "messaging.cloud.run",
+		Group:    "messaging.cloud.google.com",
 		Resource: "foo",
 	}
 
@@ -40,7 +40,7 @@ func TestResource(t *testing.T) {
 
 func TestKind(t *testing.T) {
 	want := schema.GroupKind{
-		Group: "messaging.cloud.run",
+		Group: "messaging.cloud.google.com",
 		Kind:  "foo",
 	}
 

--- a/pkg/apis/pubsub/register.go
+++ b/pkg/apis/pubsub/register.go
@@ -18,5 +18,5 @@ limitations under the License.
 package pubsub
 
 const (
-	GroupName = "pubsub.cloud.run"
+	GroupName = "pubsub.cloud.google.com"
 )

--- a/pkg/apis/pubsub/v1alpha1/doc.go
+++ b/pkg/apis/pubsub/v1alpha1/doc.go
@@ -19,5 +19,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/google/knative-gcp/pkg/apis/pubsub
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=pubsub.cloud.run
+// +groupName=pubsub.cloud.google.com
 package v1alpha1

--- a/pkg/apis/pubsub/v1alpha1/pull_subscription_types_test.go
+++ b/pkg/apis/pubsub/v1alpha1/pull_subscription_types_test.go
@@ -38,7 +38,7 @@ func TestPubSubEventSource(t *testing.T) {
 
 func TestPullSubscriptionGetGroupVersionKind(t *testing.T) {
 	want := schema.GroupVersionKind{
-		Group:   "pubsub.cloud.run",
+		Group:   "pubsub.cloud.google.com",
 		Version: "v1alpha1",
 		Kind:    "PullSubscription",
 	}

--- a/pkg/apis/pubsub/v1alpha1/register_test.go
+++ b/pkg/apis/pubsub/v1alpha1/register_test.go
@@ -27,7 +27,7 @@ import (
 // Resource takes an unqualified resource and returns a Group qualified GroupResource
 func TestResource(t *testing.T) {
 	want := schema.GroupResource{
-		Group:    "pubsub.cloud.run",
+		Group:    "pubsub.cloud.google.com",
 		Resource: "foo",
 	}
 
@@ -40,7 +40,7 @@ func TestResource(t *testing.T) {
 
 func TestKind(t *testing.T) {
 	want := schema.GroupKind{
-		Group: "pubsub.cloud.run",
+		Group: "pubsub.cloud.google.com",
 		Kind:  "foo",
 	}
 

--- a/pkg/apis/pubsub/v1alpha1/topic_types_test.go
+++ b/pkg/apis/pubsub/v1alpha1/topic_types_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestTopicGetGroupVersionKind(t *testing.T) {
 	want := schema.GroupVersionKind{
-		Group:   "pubsub.cloud.run",
+		Group:   "pubsub.cloud.google.com",
 		Version: "v1alpha1",
 		Kind:    "Topic",
 	}

--- a/pkg/client/clientset/versioned/typed/events/v1alpha1/events_client.go
+++ b/pkg/client/clientset/versioned/typed/events/v1alpha1/events_client.go
@@ -31,7 +31,7 @@ type EventsV1alpha1Interface interface {
 	StoragesGetter
 }
 
-// EventsV1alpha1Client is used to interact with features provided by the events.cloud.run group.
+// EventsV1alpha1Client is used to interact with features provided by the events.cloud.google.com group.
 type EventsV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/pkg/client/clientset/versioned/typed/events/v1alpha1/fake/fake_pubsub.go
+++ b/pkg/client/clientset/versioned/typed/events/v1alpha1/fake/fake_pubsub.go
@@ -34,9 +34,9 @@ type FakePubSubs struct {
 	ns   string
 }
 
-var pubsubsResource = schema.GroupVersionResource{Group: "events.cloud.run", Version: "v1alpha1", Resource: "pubsubs"}
+var pubsubsResource = schema.GroupVersionResource{Group: "events.cloud.google.com", Version: "v1alpha1", Resource: "pubsubs"}
 
-var pubsubsKind = schema.GroupVersionKind{Group: "events.cloud.run", Version: "v1alpha1", Kind: "PubSub"}
+var pubsubsKind = schema.GroupVersionKind{Group: "events.cloud.google.com", Version: "v1alpha1", Kind: "PubSub"}
 
 // Get takes name of the pubSub, and returns the corresponding pubSub object, and an error if there is any.
 func (c *FakePubSubs) Get(name string, options v1.GetOptions) (result *v1alpha1.PubSub, err error) {

--- a/pkg/client/clientset/versioned/typed/events/v1alpha1/fake/fake_scheduler.go
+++ b/pkg/client/clientset/versioned/typed/events/v1alpha1/fake/fake_scheduler.go
@@ -34,9 +34,9 @@ type FakeSchedulers struct {
 	ns   string
 }
 
-var schedulersResource = schema.GroupVersionResource{Group: "events.cloud.run", Version: "v1alpha1", Resource: "schedulers"}
+var schedulersResource = schema.GroupVersionResource{Group: "events.cloud.google.com", Version: "v1alpha1", Resource: "schedulers"}
 
-var schedulersKind = schema.GroupVersionKind{Group: "events.cloud.run", Version: "v1alpha1", Kind: "Scheduler"}
+var schedulersKind = schema.GroupVersionKind{Group: "events.cloud.google.com", Version: "v1alpha1", Kind: "Scheduler"}
 
 // Get takes name of the scheduler, and returns the corresponding scheduler object, and an error if there is any.
 func (c *FakeSchedulers) Get(name string, options v1.GetOptions) (result *v1alpha1.Scheduler, err error) {

--- a/pkg/client/clientset/versioned/typed/events/v1alpha1/fake/fake_storage.go
+++ b/pkg/client/clientset/versioned/typed/events/v1alpha1/fake/fake_storage.go
@@ -34,9 +34,9 @@ type FakeStorages struct {
 	ns   string
 }
 
-var storagesResource = schema.GroupVersionResource{Group: "events.cloud.run", Version: "v1alpha1", Resource: "storages"}
+var storagesResource = schema.GroupVersionResource{Group: "events.cloud.google.com", Version: "v1alpha1", Resource: "storages"}
 
-var storagesKind = schema.GroupVersionKind{Group: "events.cloud.run", Version: "v1alpha1", Kind: "Storage"}
+var storagesKind = schema.GroupVersionKind{Group: "events.cloud.google.com", Version: "v1alpha1", Kind: "Storage"}
 
 // Get takes name of the storage, and returns the corresponding storage object, and an error if there is any.
 func (c *FakeStorages) Get(name string, options v1.GetOptions) (result *v1alpha1.Storage, err error) {

--- a/pkg/client/clientset/versioned/typed/messaging/v1alpha1/fake/fake_channel.go
+++ b/pkg/client/clientset/versioned/typed/messaging/v1alpha1/fake/fake_channel.go
@@ -34,9 +34,9 @@ type FakeChannels struct {
 	ns   string
 }
 
-var channelsResource = schema.GroupVersionResource{Group: "messaging.cloud.run", Version: "v1alpha1", Resource: "channels"}
+var channelsResource = schema.GroupVersionResource{Group: "messaging.cloud.google.com", Version: "v1alpha1", Resource: "channels"}
 
-var channelsKind = schema.GroupVersionKind{Group: "messaging.cloud.run", Version: "v1alpha1", Kind: "Channel"}
+var channelsKind = schema.GroupVersionKind{Group: "messaging.cloud.google.com", Version: "v1alpha1", Kind: "Channel"}
 
 // Get takes name of the channel, and returns the corresponding channel object, and an error if there is any.
 func (c *FakeChannels) Get(name string, options v1.GetOptions) (result *v1alpha1.Channel, err error) {

--- a/pkg/client/clientset/versioned/typed/messaging/v1alpha1/fake/fake_decorator.go
+++ b/pkg/client/clientset/versioned/typed/messaging/v1alpha1/fake/fake_decorator.go
@@ -34,9 +34,9 @@ type FakeDecorators struct {
 	ns   string
 }
 
-var decoratorsResource = schema.GroupVersionResource{Group: "messaging.cloud.run", Version: "v1alpha1", Resource: "decorators"}
+var decoratorsResource = schema.GroupVersionResource{Group: "messaging.cloud.google.com", Version: "v1alpha1", Resource: "decorators"}
 
-var decoratorsKind = schema.GroupVersionKind{Group: "messaging.cloud.run", Version: "v1alpha1", Kind: "Decorator"}
+var decoratorsKind = schema.GroupVersionKind{Group: "messaging.cloud.google.com", Version: "v1alpha1", Kind: "Decorator"}
 
 // Get takes name of the decorator, and returns the corresponding decorator object, and an error if there is any.
 func (c *FakeDecorators) Get(name string, options v1.GetOptions) (result *v1alpha1.Decorator, err error) {

--- a/pkg/client/clientset/versioned/typed/messaging/v1alpha1/messaging_client.go
+++ b/pkg/client/clientset/versioned/typed/messaging/v1alpha1/messaging_client.go
@@ -30,7 +30,7 @@ type MessagingV1alpha1Interface interface {
 	DecoratorsGetter
 }
 
-// MessagingV1alpha1Client is used to interact with features provided by the messaging.cloud.run group.
+// MessagingV1alpha1Client is used to interact with features provided by the messaging.cloud.google.com group.
 type MessagingV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/pkg/client/clientset/versioned/typed/pubsub/v1alpha1/fake/fake_pullsubscription.go
+++ b/pkg/client/clientset/versioned/typed/pubsub/v1alpha1/fake/fake_pullsubscription.go
@@ -34,9 +34,9 @@ type FakePullSubscriptions struct {
 	ns   string
 }
 
-var pullsubscriptionsResource = schema.GroupVersionResource{Group: "pubsub.cloud.run", Version: "v1alpha1", Resource: "pullsubscriptions"}
+var pullsubscriptionsResource = schema.GroupVersionResource{Group: "pubsub.cloud.google.com", Version: "v1alpha1", Resource: "pullsubscriptions"}
 
-var pullsubscriptionsKind = schema.GroupVersionKind{Group: "pubsub.cloud.run", Version: "v1alpha1", Kind: "PullSubscription"}
+var pullsubscriptionsKind = schema.GroupVersionKind{Group: "pubsub.cloud.google.com", Version: "v1alpha1", Kind: "PullSubscription"}
 
 // Get takes name of the pullSubscription, and returns the corresponding pullSubscription object, and an error if there is any.
 func (c *FakePullSubscriptions) Get(name string, options v1.GetOptions) (result *v1alpha1.PullSubscription, err error) {

--- a/pkg/client/clientset/versioned/typed/pubsub/v1alpha1/fake/fake_topic.go
+++ b/pkg/client/clientset/versioned/typed/pubsub/v1alpha1/fake/fake_topic.go
@@ -34,9 +34,9 @@ type FakeTopics struct {
 	ns   string
 }
 
-var topicsResource = schema.GroupVersionResource{Group: "pubsub.cloud.run", Version: "v1alpha1", Resource: "topics"}
+var topicsResource = schema.GroupVersionResource{Group: "pubsub.cloud.google.com", Version: "v1alpha1", Resource: "topics"}
 
-var topicsKind = schema.GroupVersionKind{Group: "pubsub.cloud.run", Version: "v1alpha1", Kind: "Topic"}
+var topicsKind = schema.GroupVersionKind{Group: "pubsub.cloud.google.com", Version: "v1alpha1", Kind: "Topic"}
 
 // Get takes name of the topic, and returns the corresponding topic object, and an error if there is any.
 func (c *FakeTopics) Get(name string, options v1.GetOptions) (result *v1alpha1.Topic, err error) {

--- a/pkg/client/clientset/versioned/typed/pubsub/v1alpha1/pubsub_client.go
+++ b/pkg/client/clientset/versioned/typed/pubsub/v1alpha1/pubsub_client.go
@@ -30,7 +30,7 @@ type PubsubV1alpha1Interface interface {
 	TopicsGetter
 }
 
-// PubsubV1alpha1Client is used to interact with features provided by the pubsub.cloud.run group.
+// PubsubV1alpha1Client is used to interact with features provided by the pubsub.cloud.google.com group.
 type PubsubV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -54,7 +54,7 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=events.cloud.run, Version=v1alpha1
+	// Group=events.cloud.google.com, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithResource("pubsubs"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Events().V1alpha1().PubSubs().Informer()}, nil
 	case v1alpha1.SchemeGroupVersion.WithResource("schedulers"):
@@ -62,13 +62,13 @@ func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource
 	case v1alpha1.SchemeGroupVersion.WithResource("storages"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Events().V1alpha1().Storages().Informer()}, nil
 
-		// Group=messaging.cloud.run, Version=v1alpha1
+		// Group=messaging.cloud.google.com, Version=v1alpha1
 	case messagingv1alpha1.SchemeGroupVersion.WithResource("channels"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Messaging().V1alpha1().Channels().Informer()}, nil
 	case messagingv1alpha1.SchemeGroupVersion.WithResource("decorators"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Messaging().V1alpha1().Decorators().Informer()}, nil
 
-		// Group=pubsub.cloud.run, Version=v1alpha1
+		// Group=pubsub.cloud.google.com, Version=v1alpha1
 	case pubsubv1alpha1.SchemeGroupVersion.WithResource("pullsubscriptions"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Pubsub().V1alpha1().PullSubscriptions().Informer()}, nil
 	case pubsubv1alpha1.SchemeGroupVersion.WithResource("topics"):

--- a/pkg/operations/labels.go
+++ b/pkg/operations/labels.go
@@ -28,6 +28,6 @@ func JobLabels(key string, parts ...string) map[string]string {
 	value := strings.Join(append(parts), "-")
 	value = kmeta.ChildName(value, "ops")
 	return map[string]string{
-		"events.cloud.run/" + key: value,
+		"events.cloud.google.com/" + key: value,
 	}
 }

--- a/pkg/operations/scheduler/job_test.go
+++ b/pkg/operations/scheduler/job_test.go
@@ -59,7 +59,7 @@ var (
 // Returns an ownerref for the test Scheduler object
 func ownerRef() metav1.OwnerReference {
 	return metav1.OwnerReference{
-		APIVersion:         "events.cloud.run/v1alpha1",
+		APIVersion:         "events.cloud.google.com/v1alpha1",
 		Kind:               "Scheduler",
 		Name:               "my-test-scheduler",
 		UID:                schedulerUID,

--- a/pkg/operations/storage/notification_test.go
+++ b/pkg/operations/storage/notification_test.go
@@ -57,7 +57,7 @@ var (
 // Returns an ownerref for the test Scheduler object
 func ownerRef() metav1.OwnerReference {
 	return metav1.OwnerReference{
-		APIVersion:         "events.cloud.run/v1alpha1",
+		APIVersion:         "events.cloud.google.com/v1alpha1",
 		Kind:               "Storage",
 		Name:               "my-test-storage",
 		UID:                storageUID,

--- a/pkg/pubsub/adapter/adapter.go
+++ b/pkg/pubsub/adapter/adapter.go
@@ -82,8 +82,8 @@ type Adapter struct {
 	// Environment variable containing the name.
 	Name string `envconfig:"NAME" required:"true"`
 
-	// Environment variable containing the resource group. E.g., storages.events.cloud.run.
-	ResourceGroup string `envconfig:"RESOURCE_GROUP" default:"pullsubscriptions.pubsub.cloud.run" required:"true"`
+	// Environment variable containing the resource group. E.g., storages.events.cloud.google.com.
+	ResourceGroup string `envconfig:"RESOURCE_GROUP" default:"pullsubscriptions.pubsub.cloud.google.com" required:"true"`
 
 	// inbound is the cloudevents client to use to receive events.
 	inbound cloudevents.Client

--- a/pkg/pubsub/adapter/observability.go
+++ b/pkg/pubsub/adapter/observability.go
@@ -29,7 +29,7 @@ var (
 	// LatencyMs measures the latency in milliseconds for the PullSubscription
 	// adapter methods for Pub/Sub.
 	LatencyMs = stats.Float64(
-		"events.cloud.run/pubsub/adapter/latency",
+		"events.cloud.google.com/pubsub/adapter/latency",
 		"The latency in milliseconds for the PullSubscription adapter methods for Pub/Sub.",
 		"ms")
 )

--- a/pkg/reconciler/channel/channel_test.go
+++ b/pkg/reconciler/channel/channel_test.go
@@ -68,7 +68,7 @@ var (
 	topicURI = "http://" + topicDNS + "/"
 
 	sinkGVK = metav1.GroupVersionKind{
-		Group:   "testing.cloud.run",
+		Group:   "testing.cloud.google.com",
 		Version: "v1alpha1",
 		Kind:    "Sink",
 	}
@@ -89,7 +89,7 @@ func init() {
 //func newSink() *unstructured.Unstructured {
 //	return &unstructured.Unstructured{
 //		Object: map[string]interface{}{
-//			"apiVersion": "testing.cloud.run/v1alpha1",
+//			"apiVersion": "testing.cloud.google.com/v1alpha1",
 //			"kind":       "Sink",
 //			"metadata": map[string]interface{}{
 //				"namespace": testNS,
@@ -341,7 +341,7 @@ func TestAllCases(t *testing.T) {
 		}},
 		WantDeletes: []clientgotesting.DeleteActionImpl{
 			{ActionImpl: clientgotesting.ActionImpl{
-				Namespace: "testnamespace", Verb: "delete", Resource: schema.GroupVersionResource{Group: "pubsub.cloud.run", Version: "v1alpha1", Resource: "pullsubscriptions"}},
+				Namespace: "testnamespace", Verb: "delete", Resource: schema.GroupVersionResource{Group: "pubsub.cloud.google.com", Version: "v1alpha1", Resource: "pullsubscriptions"}},
 				Name: "cre-sub-testsubscription-abc-123",
 			},
 		},

--- a/pkg/reconciler/channel/resources/annotations.go
+++ b/pkg/reconciler/channel/resources/annotations.go
@@ -18,6 +18,6 @@ package resources
 
 func GetPullSubscriptionAnnotations(channel string) map[string]string {
 	return map[string]string{
-		"metrics-resource-group": "channels.messaging.cloud.run",
+		"metrics-resource-group": "channels.messaging.cloud.google.com",
 		"metrics-resource-name":  channel}
 }

--- a/pkg/reconciler/channel/resources/annotations_test.go
+++ b/pkg/reconciler/channel/resources/annotations_test.go
@@ -25,7 +25,7 @@ import (
 func TestGetPullSubscriptionAnnotations(t *testing.T) {
 	want := map[string]string{
 		"metrics-resource-name":  "my-channel",
-		"metrics-resource-group": "channels.messaging.cloud.run",
+		"metrics-resource-group": "channels.messaging.cloud.google.com",
 	}
 	got := GetPullSubscriptionAnnotations("my-channel")
 

--- a/pkg/reconciler/channel/resources/labels.go
+++ b/pkg/reconciler/channel/resources/labels.go
@@ -26,9 +26,9 @@ func GetLabelSelector(controller, channel, uid string) labels.Selector {
 
 func GetLabels(controller, channel, uid string) map[string]string {
 	return map[string]string{
-		"events.cloud.run/channel":        controller,
-		"events.cloud.run/channel-name":   channel,
-		"events.cloud.run/controller-uid": uid,
+		"events.cloud.google.com/channel":        controller,
+		"events.cloud.google.com/channel-name":   channel,
+		"events.cloud.google.com/controller-uid": uid,
 	}
 }
 
@@ -38,6 +38,6 @@ func GetPullSubscriptionLabelSelector(controller, source, subscriber, uid string
 
 func GetPullSubscriptionLabels(controller, channel, subscriber, uid string) map[string]string {
 	l := GetLabels(controller, channel, uid)
-	l["events.cloud.run/channel-subscriber"] = subscriber
+	l["events.cloud.google.com/channel-subscriber"] = subscriber
 	return l
 }

--- a/pkg/reconciler/channel/resources/labels_test.go
+++ b/pkg/reconciler/channel/resources/labels_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestGetLabelSelector(t *testing.T) {
-	want := "events.cloud.run/channel=controller,events.cloud.run/channel-name=source,events.cloud.run/controller-uid=UID"
+	want := "events.cloud.google.com/channel=controller,events.cloud.google.com/channel-name=source,events.cloud.google.com/controller-uid=UID"
 	got := GetLabelSelector("controller", "source", "UID").String()
 
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -33,9 +33,9 @@ func TestGetLabelSelector(t *testing.T) {
 
 func TestGetLabels(t *testing.T) {
 	want := map[string]string{
-		"events.cloud.run/channel":        "controller",
-		"events.cloud.run/channel-name":   "channel",
-		"events.cloud.run/controller-uid": "UID",
+		"events.cloud.google.com/channel":        "controller",
+		"events.cloud.google.com/channel-name":   "channel",
+		"events.cloud.google.com/controller-uid": "UID",
 	}
 	got := GetLabels("controller", "channel", "UID")
 
@@ -45,7 +45,7 @@ func TestGetLabels(t *testing.T) {
 }
 
 func TestGetPullSubscriptionLabelSelector(t *testing.T) {
-	want := "events.cloud.run/channel=controller,events.cloud.run/channel-name=source,events.cloud.run/channel-subscriber=subscriber,events.cloud.run/controller-uid=UID"
+	want := "events.cloud.google.com/channel=controller,events.cloud.google.com/channel-name=source,events.cloud.google.com/channel-subscriber=subscriber,events.cloud.google.com/controller-uid=UID"
 	got := GetPullSubscriptionLabelSelector("controller", "source", "subscriber", "UID").String()
 
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -55,10 +55,10 @@ func TestGetPullSubscriptionLabelSelector(t *testing.T) {
 
 func TestGetPullSubscriptionLabels(t *testing.T) {
 	want := map[string]string{
-		"events.cloud.run/channel":            "controller",
-		"events.cloud.run/channel-name":       "channel",
-		"events.cloud.run/channel-subscriber": "subscriber",
-		"events.cloud.run/controller-uid":     "UID",
+		"events.cloud.google.com/channel":            "controller",
+		"events.cloud.google.com/channel-name":       "channel",
+		"events.cloud.google.com/channel-subscriber": "subscriber",
+		"events.cloud.google.com/controller-uid":     "UID",
 	}
 	got := GetPullSubscriptionLabels("controller", "channel", "subscriber", "UID")
 

--- a/pkg/reconciler/channel/resources/pullsubscription_test.go
+++ b/pkg/reconciler/channel/resources/pullsubscription_test.go
@@ -80,7 +80,7 @@ func TestMakePullSubscription(t *testing.T) {
 				"test-key2": "test-value2",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion:         "messaging.cloud.run/v1alpha1",
+				APIVersion:         "messaging.cloud.google.com/v1alpha1",
 				Kind:               "Channel",
 				Name:               "channel-name",
 				UID:                "channel-uid",
@@ -158,7 +158,7 @@ func TestMakePullSubscription_JustSubscriber(t *testing.T) {
 				"test-key2": "test-value2",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion:         "messaging.cloud.run/v1alpha1",
+				APIVersion:         "messaging.cloud.google.com/v1alpha1",
 				Kind:               "Channel",
 				Name:               "channel-name",
 				UID:                "channel-uid",
@@ -233,7 +233,7 @@ func TestMakePullSubscription_JustReply(t *testing.T) {
 				"test-key2": "test-value2",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion:         "messaging.cloud.run/v1alpha1",
+				APIVersion:         "messaging.cloud.google.com/v1alpha1",
 				Kind:               "Channel",
 				Name:               "channel-name",
 				UID:                "channel-uid",

--- a/pkg/reconciler/channel/resources/topic_test.go
+++ b/pkg/reconciler/channel/resources/topic_test.go
@@ -70,7 +70,7 @@ func TestMakeTopic(t *testing.T) {
 				"test-key2": "test-value2",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion:         "messaging.cloud.run/v1alpha1",
+				APIVersion:         "messaging.cloud.google.com/v1alpha1",
 				Kind:               "Channel",
 				Name:               "channel-name",
 				Controller:         &yes,

--- a/pkg/reconciler/decorator/resources/decorator_test.go
+++ b/pkg/reconciler/decorator/resources/decorator_test.go
@@ -59,11 +59,11 @@ func TestMakePublisherV1alpha1(t *testing.T) {
     "namespace": "dec-namespace",
     "creationTimestamp": null,
     "labels": {
-      "messaging.cloud.run/controller": "controller-name"
+      "messaging.cloud.google.com/controller": "controller-name"
     },
     "ownerReferences": [
       {
-        "apiVersion": "messaging.cloud.run/v1alpha1",
+        "apiVersion": "messaging.cloud.google.com/v1alpha1",
         "kind": "Decorator",
         "name": "dec-name",
         "uid": "",
@@ -77,7 +77,7 @@ func TestMakePublisherV1alpha1(t *testing.T) {
       "metadata": {
         "creationTimestamp": null,
         "labels": {
-          "messaging.cloud.run/controller": "controller-name"
+          "messaging.cloud.google.com/controller": "controller-name"
         }
       },
       "spec": {

--- a/pkg/reconciler/decorator/resources/labels.go
+++ b/pkg/reconciler/decorator/resources/labels.go
@@ -18,6 +18,6 @@ package resources
 
 func GetLabels(controller string) map[string]string {
 	return map[string]string{
-		"messaging.cloud.run/controller": controller,
+		"messaging.cloud.google.com/controller": controller,
 	}
 }

--- a/pkg/reconciler/pubsub/controller.go
+++ b/pkg/reconciler/pubsub/controller.go
@@ -49,7 +49,7 @@ func NewController(
 		Base:                   reconciler.NewBase(ctx, controllerAgentName, cmw),
 		pubsubLister:           pubsubInformer.Lister(),
 		pullsubscriptionLister: pullsubscriptionInformer.Lister(),
-		receiveAdapterName:     "pubsub.events.cloud.run",
+		receiveAdapterName:     "pubsub.events.cloud.google.com",
 	}
 	impl := controller.NewImpl(c, c.Logger, ReconcilerName)
 

--- a/pkg/reconciler/pubsub/pubsub.go
+++ b/pkg/reconciler/pubsub/pubsub.go
@@ -45,7 +45,7 @@ const (
 
 	finalizerName = controllerAgentName
 
-	resourceGroup = "pubsubs.events.cloud.run"
+	resourceGroup = "pubsubs.events.cloud.google.com"
 )
 
 // Reconciler is the controller implementation for the PubSub source.

--- a/pkg/reconciler/pubsub/pubsub_test.go
+++ b/pkg/reconciler/pubsub/pubsub_test.go
@@ -59,7 +59,7 @@ var (
 	sinkURI = "http://" + sinkDNS + "/"
 
 	sinkGVK = metav1.GroupVersionKind{
-		Group:   "testing.cloud.run",
+		Group:   "testing.cloud.google.com",
 		Version: "v1alpha1",
 		Kind:    "Sink",
 	}
@@ -80,7 +80,7 @@ func init() {
 // Returns an ownerref for the test PubSub object
 func ownerRef() metav1.OwnerReference {
 	return metav1.OwnerReference{
-		APIVersion:         "events.cloud.run/v1alpha1",
+		APIVersion:         "events.cloud.google.com/v1alpha1",
 		Kind:               "PubSub",
 		Name:               pubsubName,
 		UID:                pubsubUID,
@@ -92,7 +92,7 @@ func ownerRef() metav1.OwnerReference {
 func newSink() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "testing.cloud.run/v1alpha1",
+			"apiVersion": "testing.cloud.google.com/v1alpha1",
 			"kind":       "Sink",
 			"metadata": map[string]interface{}{
 				"namespace": testNS,
@@ -159,10 +159,10 @@ func TestAllCases(t *testing.T) {
 				}),
 				WithPullSubscriptionSink(sinkGVK, sinkName),
 				WithPullSubscriptionLabels(map[string]string{
-					"receive-adapter": "pubsub.events.cloud.run",
+					"receive-adapter": "pubsub.events.cloud.google.com",
 				}),
 				WithPullSubscriptionAnnotations(map[string]string{
-					"metrics-resource-group": "pubsubs.events.cloud.run",
+					"metrics-resource-group": "pubsubs.events.cloud.google.com",
 				}),
 				WithPullSubscriptionOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			),
@@ -229,7 +229,7 @@ func TestAllCases(t *testing.T) {
 			Base:                   reconciler.NewBase(ctx, controllerAgentName, cmw),
 			pubsubLister:           listers.GetPubSubLister(),
 			pullsubscriptionLister: listers.GetPullSubscriptionLister(),
-			receiveAdapterName:     "pubsub.events.cloud.run",
+			receiveAdapterName:     "pubsub.events.cloud.google.com",
 		}
 	}))
 

--- a/pkg/reconciler/pubsub_reconciler_test.go
+++ b/pkg/reconciler/pubsub_reconciler_test.go
@@ -67,7 +67,7 @@ var (
 // Returns an ownerref for the test object
 func ownerRef() metav1.OwnerReference {
 	return metav1.OwnerReference{
-		APIVersion:         "events.cloud.run/v1alpha1",
+		APIVersion:         "events.cloud.google.com/v1alpha1",
 		Kind:               "Storage",
 		Name:               name,
 		UID:                "test-storage-uid",
@@ -453,14 +453,14 @@ func TestDeletes(t *testing.T) {
 				ActionImpl: clientgotesting.ActionImpl{
 					Namespace: testNS,
 					Verb:      "delete",
-					Resource:  schema.GroupVersionResource{Group: "pubsub.cloud.run", Version: "v1alpha1", Resource: "topics"},
+					Resource:  schema.GroupVersionResource{Group: "pubsub.cloud.google.com", Version: "v1alpha1", Resource: "topics"},
 				},
 				Name: name,
 			}, {
 				ActionImpl: clientgotesting.ActionImpl{
 					Namespace: testNS,
 					Verb:      "delete",
-					Resource:  schema.GroupVersionResource{Group: "pubsub.cloud.run", Version: "v1alpha1", Resource: "pullsubscriptions"},
+					Resource:  schema.GroupVersionResource{Group: "pubsub.cloud.google.com", Version: "v1alpha1", Resource: "pullsubscriptions"},
 				},
 				Name: name,
 			},

--- a/pkg/reconciler/pullsubscription/pullsubscription.go
+++ b/pkg/reconciler/pullsubscription/pullsubscription.go
@@ -418,7 +418,7 @@ func (r *Reconciler) createOrUpdateReceiveAdapter(ctx context.Context, src *v1al
 	if r.metricsConfig != nil {
 		component := sourceComponent
 		// Set the metric component based on PullSubscription label.
-		if _, ok := src.Labels["events.cloud.run/channel"]; ok {
+		if _, ok := src.Labels["events.cloud.google.com/channel"]; ok {
 			component = channelComponent
 		}
 		r.metricsConfig.Component = component

--- a/pkg/reconciler/pullsubscription/pullsubscription_test.go
+++ b/pkg/reconciler/pullsubscription/pullsubscription_test.go
@@ -71,7 +71,7 @@ var (
 	sinkURI = "http://" + sinkDNS
 
 	sinkGVK = metav1.GroupVersionKind{
-		Group:   "testing.cloud.run",
+		Group:   "testing.cloud.google.com",
 		Version: "v1alpha1",
 		Kind:    "Sink",
 	}
@@ -92,7 +92,7 @@ func init() {
 func newSink() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "testing.cloud.run/v1alpha1",
+			"apiVersion": "testing.cloud.google.com/v1alpha1",
 			"kind":       "Sink",
 			"metadata": map[string]interface{}{
 				"namespace": testNS,
@@ -298,7 +298,7 @@ func TestAllCases(t *testing.T) {
 			Key:     testNS + "/" + sourceName,
 			WantErr: true,
 			WantEvents: []string{
-				Eventf(corev1.EventTypeWarning, "InternalError", `sinks.testing.cloud.run "sink" not found`),
+				Eventf(corev1.EventTypeWarning, "InternalError", `sinks.testing.cloud.google.com "sink" not found`),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewPullSubscription(sourceName, testNS,

--- a/pkg/reconciler/pullsubscription/resources/labels.go
+++ b/pkg/reconciler/pullsubscription/resources/labels.go
@@ -26,7 +26,7 @@ func GetLabelSelector(controller, source string) labels.Selector {
 
 func GetLabels(controller, source string) map[string]string {
 	return map[string]string{
-		"events.cloud.run/controller":       controller,
-		"pubsub.cloud.run/pullsubscription": source,
+		"events.cloud.google.com/controller":       controller,
+		"pubsub.cloud.google.com/pullsubscription": source,
 	}
 }

--- a/pkg/reconciler/pullsubscription/resources/receive_adapter.go
+++ b/pkg/reconciler/pullsubscription/resources/receive_adapter.go
@@ -49,8 +49,8 @@ type ReceiveAdapterArgs struct {
 const (
 	credsVolume          = "google-cloud-key"
 	credsMountPath       = "/var/secrets/google"
-	metricsDomain        = "cloud.run/events"
-	defaultResourceGroup = "pullsubscriptions.pubsub.cloud.run"
+	metricsDomain        = "cloud.google.com/events"
+	defaultResourceGroup = "pullsubscriptions.pubsub.cloud.google.com"
 )
 
 // MakeReceiveAdapter generates (but does not insert into K8s) the Receive Adapter Deployment for

--- a/pkg/reconciler/pullsubscription/resources/receive_adapter_test.go
+++ b/pkg/reconciler/pullsubscription/resources/receive_adapter_test.go
@@ -70,7 +70,7 @@ func TestMakeMinimumReceiveAdapter(t *testing.T) {
 				"test-key2": "test-value2",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion:         "pubsub.cloud.run/v1alpha1",
+				APIVersion:         "pubsub.cloud.google.com/v1alpha1",
 				Kind:               "PullSubscription",
 				Name:               "source-name",
 				Controller:         &yes,
@@ -212,7 +212,7 @@ func TestMakeFullReceiveAdapter(t *testing.T) {
 				"test-key2": "test-value2",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion:         "pubsub.cloud.run/v1alpha1",
+				APIVersion:         "pubsub.cloud.google.com/v1alpha1",
 				Kind:               "PullSubscription",
 				Name:               "source-name",
 				Controller:         &yes,

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -126,7 +126,7 @@ type Base struct {
 }
 
 const (
-	ControllerType = "events.cloud.run/controller"
+	ControllerType = "events.cloud.google.com/controller"
 )
 
 // NewBase instantiates a new instance of Base implementing

--- a/pkg/reconciler/resources/pullsubscription_test.go
+++ b/pkg/reconciler/resources/pullsubscription_test.go
@@ -64,7 +64,7 @@ func TestMakePullSubscription(t *testing.T) {
 		},
 	}
 
-	got := MakePullSubscription(source.Namespace, source.Name, &source.Spec.PubSubSpec, source, "topic-abc", "storage.events.cloud.run", "storages.events.cloud.run")
+	got := MakePullSubscription(source.Namespace, source.Name, &source.Spec.PubSubSpec, source, "topic-abc", "storage.events.cloud.google.com", "storages.events.cloud.google.com")
 
 	yes := true
 	want := &pubsubv1alpha1.PullSubscription{
@@ -72,13 +72,13 @@ func TestMakePullSubscription(t *testing.T) {
 			Namespace: "bucket-namespace",
 			Name:      "bucket-name",
 			Labels: map[string]string{
-				"receive-adapter": "storage.events.cloud.run",
+				"receive-adapter": "storage.events.cloud.google.com",
 			},
 			Annotations: map[string]string{
-				"metrics-resource-group": "storages.events.cloud.run",
+				"metrics-resource-group": "storages.events.cloud.google.com",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion:         "events.cloud.run/v1alpha1",
+				APIVersion:         "events.cloud.google.com/v1alpha1",
 				Kind:               "Storage",
 				Name:               "bucket-name",
 				UID:                "bucket-uid",

--- a/pkg/reconciler/resources/topic_test.go
+++ b/pkg/reconciler/resources/topic_test.go
@@ -60,7 +60,7 @@ func TestMakeTopicWithStorage(t *testing.T) {
 		},
 	}
 
-	got := MakeTopic(source.Namespace, source.Name, &source.Spec.PubSubSpec, source, "topic-abc", "storage.events.cloud.run")
+	got := MakeTopic(source.Namespace, source.Name, &source.Spec.PubSubSpec, source, "topic-abc", "storage.events.cloud.google.com")
 
 	yes := true
 	want := &pubsubv1alpha1.Topic{
@@ -68,10 +68,10 @@ func TestMakeTopicWithStorage(t *testing.T) {
 			Namespace: "storage-namespace",
 			Name:      "storage-name",
 			Labels: map[string]string{
-				"receive-adapter": "storage.events.cloud.run",
+				"receive-adapter": "storage.events.cloud.google.com",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion:         "events.cloud.run/v1alpha1",
+				APIVersion:         "events.cloud.google.com/v1alpha1",
 				Kind:               "Storage",
 				Name:               "storage-name",
 				UID:                "storage-uid",
@@ -126,7 +126,7 @@ func TestMakeTopicWithScheduler(t *testing.T) {
 		},
 	}
 
-	got := MakeTopic(source.Namespace, source.Name, &source.Spec.PubSubSpec, source, "topic-abc", "storage.events.cloud.run")
+	got := MakeTopic(source.Namespace, source.Name, &source.Spec.PubSubSpec, source, "topic-abc", "storage.events.cloud.google.com")
 
 	yes := true
 	want := &pubsubv1alpha1.Topic{
@@ -134,10 +134,10 @@ func TestMakeTopicWithScheduler(t *testing.T) {
 			Namespace: "scheduler-namespace",
 			Name:      "scheduler-name",
 			Labels: map[string]string{
-				"receive-adapter": "storage.events.cloud.run",
+				"receive-adapter": "storage.events.cloud.google.com",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion:         "events.cloud.run/v1alpha1",
+				APIVersion:         "events.cloud.google.com/v1alpha1",
 				Kind:               "Scheduler",
 				Name:               "scheduler-name",
 				UID:                "scheduler-uid",
@@ -198,7 +198,7 @@ func TestMakeTopicWithSchedulerWithPubSubSecret(t *testing.T) {
 		},
 	}
 
-	got := MakeTopic(source.Namespace, source.Name, &source.Spec.PubSubSpec, source, "topic-abc", "scheduler.events.cloud.run")
+	got := MakeTopic(source.Namespace, source.Name, &source.Spec.PubSubSpec, source, "topic-abc", "scheduler.events.cloud.google.com")
 
 	yes := true
 	want := &pubsubv1alpha1.Topic{
@@ -206,10 +206,10 @@ func TestMakeTopicWithSchedulerWithPubSubSecret(t *testing.T) {
 			Namespace: "scheduler-namespace",
 			Name:      "scheduler-name",
 			Labels: map[string]string{
-				"receive-adapter": "scheduler.events.cloud.run",
+				"receive-adapter": "scheduler.events.cloud.google.com",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion:         "events.cloud.run/v1alpha1",
+				APIVersion:         "events.cloud.google.com/v1alpha1",
 				Kind:               "Scheduler",
 				Name:               "scheduler-name",
 				UID:                "scheduler-uid",

--- a/pkg/reconciler/scheduler/controller.go
+++ b/pkg/reconciler/scheduler/controller.go
@@ -67,7 +67,7 @@ func NewController(
 
 	c := &Reconciler{
 		SchedulerOpsImage: env.SchedulerJobOpsImage,
-		PubSubBase:        reconciler.NewPubSubBase(ctx, controllerAgentName, "scheduler.events.cloud.run", cmw),
+		PubSubBase:        reconciler.NewPubSubBase(ctx, controllerAgentName, "scheduler.events.cloud.google.com", cmw),
 		schedulerLister:   schedulerInformer.Lister(),
 		jobLister:         jobInformer.Lister(),
 	}

--- a/pkg/reconciler/scheduler/scheduler.go
+++ b/pkg/reconciler/scheduler/scheduler.go
@@ -50,7 +50,7 @@ const (
 
 	finalizerName = controllerAgentName
 
-	resourceGroup = "schedulers.events.cloud.run"
+	resourceGroup = "schedulers.events.cloud.google.com"
 )
 
 // Reconciler is the controller implementation for Google Cloud Scheduler Jobs.

--- a/pkg/reconciler/scheduler/scheduler_test.go
+++ b/pkg/reconciler/scheduler/scheduler_test.go
@@ -72,7 +72,7 @@ var (
 	sinkURI = "http://" + sinkDNS + "/"
 
 	sinkGVK = metav1.GroupVersionKind{
-		Group:   "testing.cloud.run",
+		Group:   "testing.cloud.google.com",
 		Version: "v1alpha1",
 		Kind:    "Sink",
 	}
@@ -100,7 +100,7 @@ func init() {
 // Returns an ownerref for the test Scheduler object
 func ownerRef() metav1.OwnerReference {
 	return metav1.OwnerReference{
-		APIVersion:         "events.cloud.run/v1alpha1",
+		APIVersion:         "events.cloud.google.com/v1alpha1",
 		Kind:               "Scheduler",
 		Name:               "my-test-scheduler",
 		UID:                schedulerUID,
@@ -125,7 +125,7 @@ func patchFinalizers(namespace, name string, add bool) clientgotesting.PatchActi
 func newSink() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "testing.cloud.run/v1alpha1",
+			"apiVersion": "testing.cloud.google.com/v1alpha1",
 			"kind":       "Sink",
 			"metadata": map[string]interface{}{
 				"namespace": testNS,
@@ -207,7 +207,7 @@ func TestAllCases(t *testing.T) {
 					PropagationPolicy: "CreateDelete",
 				}),
 				WithTopicLabels(map[string]string{
-					"receive-adapter": "scheduler.events.cloud.run",
+					"receive-adapter": "scheduler.events.cloud.google.com",
 				}),
 				WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			),
@@ -351,10 +351,10 @@ func TestAllCases(t *testing.T) {
 				}),
 				WithPullSubscriptionSink(sinkGVK, sinkName),
 				WithPullSubscriptionLabels(map[string]string{
-					"receive-adapter": "scheduler.events.cloud.run",
+					"receive-adapter": "scheduler.events.cloud.google.com",
 				}),
 				WithPullSubscriptionAnnotations(map[string]string{
-					"metrics-resource-group": "schedulers.events.cloud.run",
+					"metrics-resource-group": "schedulers.events.cloud.google.com",
 				}),
 				WithPullSubscriptionOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			),
@@ -671,7 +671,7 @@ func TestAllCases(t *testing.T) {
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		return &Reconciler{
 			SchedulerOpsImage: testImage,
-			PubSubBase:        reconciler.NewPubSubBase(ctx, controllerAgentName, "scheduler.events.cloud.run", cmw),
+			PubSubBase:        reconciler.NewPubSubBase(ctx, controllerAgentName, "scheduler.events.cloud.google.com", cmw),
 			schedulerLister:   listers.GetSchedulerLister(),
 			jobLister:         listers.GetJobLister(),
 		}

--- a/pkg/reconciler/storage/controller.go
+++ b/pkg/reconciler/storage/controller.go
@@ -67,7 +67,7 @@ func NewController(
 
 	c := &Reconciler{
 		NotificationOpsImage: env.NotificationOpsImage,
-		PubSubBase:           reconciler.NewPubSubBase(ctx, controllerAgentName, "storage.events.cloud.run", cmw),
+		PubSubBase:           reconciler.NewPubSubBase(ctx, controllerAgentName, "storage.events.cloud.google.com", cmw),
 		storageLister:        storageInformer.Lister(),
 		jobLister:            jobInformer.Lister(),
 	}

--- a/pkg/reconciler/storage/storage.go
+++ b/pkg/reconciler/storage/storage.go
@@ -50,7 +50,7 @@ const (
 
 	finalizerName = controllerAgentName
 
-	resourceGroup = "storages.events.cloud.run"
+	resourceGroup = "storages.events.cloud.google.com"
 )
 
 // Reconciler is the controller implementation for Google Cloud Storage (GCS) event

--- a/pkg/reconciler/storage/storage_test.go
+++ b/pkg/reconciler/storage/storage_test.go
@@ -69,7 +69,7 @@ var (
 	sinkURI = "http://" + sinkDNS + "/"
 
 	sinkGVK = metav1.GroupVersionKind{
-		Group:   "testing.cloud.run",
+		Group:   "testing.cloud.google.com",
 		Version: "v1alpha1",
 		Kind:    "Sink",
 	}
@@ -97,7 +97,7 @@ func init() {
 // Returns an ownerref for the test Storage object
 func ownerRef() metav1.OwnerReference {
 	return metav1.OwnerReference{
-		APIVersion:         "events.cloud.run/v1alpha1",
+		APIVersion:         "events.cloud.google.com/v1alpha1",
 		Kind:               "Storage",
 		Name:               "my-test-storage",
 		UID:                storageUID,
@@ -122,7 +122,7 @@ func patchFinalizers(namespace, name string, add bool) clientgotesting.PatchActi
 func newSink() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "testing.cloud.run/v1alpha1",
+			"apiVersion": "testing.cloud.google.com/v1alpha1",
 			"kind":       "Sink",
 			"metadata": map[string]interface{}{
 				"namespace": testNS,
@@ -207,7 +207,7 @@ func TestAllCases(t *testing.T) {
 					PropagationPolicy: "CreateDelete",
 				}),
 				WithTopicLabels(map[string]string{
-					"receive-adapter": "storage.events.cloud.run",
+					"receive-adapter": "storage.events.cloud.google.com",
 				}),
 				WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			),
@@ -373,10 +373,10 @@ func TestAllCases(t *testing.T) {
 				}),
 				WithPullSubscriptionSink(sinkGVK, sinkName),
 				WithPullSubscriptionLabels(map[string]string{
-					"receive-adapter": "storage.events.cloud.run",
+					"receive-adapter": "storage.events.cloud.google.com",
 				}),
 				WithPullSubscriptionAnnotations(map[string]string{
-					"metrics-resource-group": "storages.events.cloud.run",
+					"metrics-resource-group": "storages.events.cloud.google.com",
 				}),
 				WithPullSubscriptionOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			),
@@ -730,7 +730,7 @@ func TestAllCases(t *testing.T) {
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		return &Reconciler{
 			NotificationOpsImage: testImage,
-			PubSubBase:           reconciler.NewPubSubBase(ctx, controllerAgentName, "storage.events.cloud.run", cmw),
+			PubSubBase:           reconciler.NewPubSubBase(ctx, controllerAgentName, "storage.events.cloud.google.com", cmw),
 			storageLister:        listers.GetStorageLister(),
 			jobLister:            listers.GetJobLister(),
 		}

--- a/pkg/reconciler/testing/listers.go
+++ b/pkg/reconciler/testing/listers.go
@@ -52,7 +52,7 @@ import (
 )
 
 var sinkAddToScheme = func(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "testing.cloud.run", Version: "v1alpha1", Kind: "Sink"}, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "testing.cloud.google.com", Version: "v1alpha1", Kind: "Sink"}, &unstructured.Unstructured{})
 	return nil
 }
 

--- a/pkg/reconciler/testing/pullsubscription.go
+++ b/pkg/reconciler/testing/pullsubscription.go
@@ -170,7 +170,7 @@ func WithPullSubscriptionReady(sink string) PullSubscriptionOption {
 
 func WithPullSubscriptionSinkNotFound() PullSubscriptionOption {
 	return func(s *v1alpha1.PullSubscription) {
-		s.Status.MarkNoSink("InvalidSink", `sinks.testing.cloud.run "sink" not found`)
+		s.Status.MarkNoSink("InvalidSink", `sinks.testing.cloud.google.com "sink" not found`)
 	}
 }
 

--- a/pkg/reconciler/topic/resources/labels.go
+++ b/pkg/reconciler/topic/resources/labels.go
@@ -26,7 +26,7 @@ func GetLabelSelector(controller, source string) labels.Selector {
 
 func GetLabels(controller, topic string) map[string]string {
 	return map[string]string{
-		"pubsub.cloud.run/controller": controller,
-		"pubsub.cloud.run/topic":      topic,
+		"pubsub.cloud.google.com/controller": controller,
+		"pubsub.cloud.google.com/topic":      topic,
 	}
 }

--- a/pkg/reconciler/topic/resources/publisher_test.go
+++ b/pkg/reconciler/topic/resources/publisher_test.go
@@ -60,12 +60,12 @@ func TestMakePublisher(t *testing.T) {
     "namespace": "topic-namespace",
     "creationTimestamp": null,
     "labels": {
-      "pubsub.cloud.run/controller": "controller-name",
-      "pubsub.cloud.run/topic": "topic-name"
+      "pubsub.cloud.google.com/controller": "controller-name",
+      "pubsub.cloud.google.com/topic": "topic-name"
     },
     "ownerReferences": [
       {
-        "apiVersion": "pubsub.cloud.run/v1alpha1",
+        "apiVersion": "pubsub.cloud.google.com/v1alpha1",
         "kind": "Topic",
         "name": "topic-name",
         "uid": "",
@@ -79,8 +79,8 @@ func TestMakePublisher(t *testing.T) {
       "metadata": {
         "creationTimestamp": null,
         "labels": {
-          "pubsub.cloud.run/controller": "controller-name",
-          "pubsub.cloud.run/topic": "topic-name"
+          "pubsub.cloud.google.com/controller": "controller-name",
+          "pubsub.cloud.google.com/topic": "topic-name"
         }
       },
       "spec": {
@@ -133,7 +133,7 @@ func TestMakePublisher(t *testing.T) {
 func TestMakePublisherSelector(t *testing.T) {
 	selector := GetLabelSelector("controller-name", "topic-name")
 
-	want := "pubsub.cloud.run/controller=controller-name,pubsub.cloud.run/topic=topic-name"
+	want := "pubsub.cloud.google.com/controller=controller-name,pubsub.cloud.google.com/topic=topic-name"
 
 	got := selector.String()
 

--- a/pkg/reconciler/topic/topic_test.go
+++ b/pkg/reconciler/topic/topic_test.go
@@ -70,7 +70,7 @@ var (
 	sinkURI = "http://" + sinkDNS + "/"
 
 	sinkGVK = metav1.GroupVersionKind{
-		Group:   "testing.cloud.run",
+		Group:   "testing.cloud.google.com",
 		Version: "v1alpha1",
 		Kind:    "Sink",
 	}
@@ -91,7 +91,7 @@ func init() {
 func newSink() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "testing.cloud.run/v1alpha1",
+			"apiVersion": "testing.cloud.google.com/v1alpha1",
 			"kind":       "Sink",
 			"metadata": map[string]interface{}{
 				"namespace": testNS,
@@ -467,7 +467,7 @@ func patchFinalizers(namespace, name string, add bool) clientgotesting.PatchActi
 
 func ownerReferences() []metav1.OwnerReference {
 	return []metav1.OwnerReference{{
-		APIVersion:         "pubsub.cloud.run/v1alpha1",
+		APIVersion:         "pubsub.cloud.google.com/v1alpha1",
 		Kind:               "Topic",
 		Name:               topicName,
 		UID:                topicUID,

--- a/test/e2e/config/pubsub_target/pubsub.yaml
+++ b/test/e2e/config/pubsub_target/pubsub.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: events.cloud.run/v1alpha1
+apiVersion: events.cloud.google.com/v1alpha1
 kind: PubSub
 metadata:
   name: {{ .pubsub }}

--- a/test/e2e/config/pubsub_test/pubsub-test.yaml
+++ b/test/e2e/config/pubsub_test/pubsub-test.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: events.cloud.run/v1alpha1
+apiVersion: events.cloud.google.com/v1alpha1
 kind: PubSub
 metadata:
   name: {{.pubsub}}

--- a/test/e2e/config/pull_subscription_target/pull-subscription.yaml
+++ b/test/e2e/config/pull_subscription_target/pull-subscription.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: pubsub.cloud.run/v1alpha1
+apiVersion: pubsub.cloud.google.com/v1alpha1
 kind: PullSubscription
 metadata:
   name: {{ .subscription }}

--- a/test/e2e/config/pull_subscription_test/pull-subscription-test.yaml
+++ b/test/e2e/config/pull_subscription_test/pull-subscription-test.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: pubsub.cloud.run/v1alpha1
+apiVersion: pubsub.cloud.google.com/v1alpha1
 kind: PullSubscription
 metadata:
   name: {{.subscription}}

--- a/test/e2e/config/smoke_test/smoke-test.yaml
+++ b/test/e2e/config/smoke_test/smoke-test.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: messaging.cloud.run/v1alpha1
+apiVersion: messaging.cloud.google.com/v1alpha1
 kind: Channel
 metadata:
   name: e2e-smoke-test

--- a/test/e2e/config/storage_test/storage.yaml
+++ b/test/e2e/config/storage_test/storage.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: events.cloud.run/v1alpha1
+apiVersion: events.cloud.google.com/v1alpha1
 kind: Storage
 metadata:
   name: {{ .storage }}

--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -19,8 +19,8 @@ package e2e
 const (
 	ProwProjectKey = "E2E_PROJECT_ID"
 
-	eventCountMetricType     = "custom.googleapis.com/cloud.run/source/event_count"
+	eventCountMetricType     = "custom.googleapis.com/cloud.google.com/source/event_count"
 	globalMetricResourceType = "global"
-	storageResourceGroup     = "storages.events.cloud.run"
-	pubsubResourceGroup      = "pubsubs.events.cloud.run"
+	storageResourceGroup     = "storages.events.cloud.google.com"
+	pubsubResourceGroup      = "pubsubs.events.cloud.google.com"
 )

--- a/test/e2e/lifecycle.go
+++ b/test/e2e/lifecycle.go
@@ -160,7 +160,7 @@ func (c *Client) SetupStackDriverMetrics(t *testing.T) {
 		err := c.Kube.UpdateConfigMap("cloud-run-events", "config-observability", map[string]string{
 			"metrics.allow-stackdriver-custom-metrics":     "true",
 			"metrics.backend-destination":                  "stackdriver",
-			"metrics.stackdriver-custom-metrics-subdomain": "cloud.run",
+			"metrics.stackdriver-custom-metrics-subdomain": "cloud.google.com",
 			"metrics.reporting-period-seconds":             "60",
 		})
 		if err != nil {

--- a/test/e2e/test_channel.go
+++ b/test/e2e/test_channel.go
@@ -51,7 +51,7 @@ func SmokeTestChannelImpl(t *testing.T) {
 	}()
 
 	if err := client.WaitForResourceReady(client.Namespace, "e2e-smoke-test", schema.GroupVersionResource{
-		Group:    "messaging.cloud.run",
+		Group:    "messaging.cloud.google.com",
 		Version:  "v1alpha1",
 		Resource: "channels",
 	}); err != nil {

--- a/test/e2e/test_pubsub.go
+++ b/test/e2e/test_pubsub.go
@@ -68,7 +68,7 @@ func SmokePubSubTestImpl(t *testing.T) {
 	}()
 
 	if err := client.WaitForResourceReady(client.Namespace, psName, schema.GroupVersionResource{
-		Group:    "events.cloud.run",
+		Group:    "events.cloud.google.com",
 		Version:  "v1alpha1",
 		Resource: "pubsubs",
 	}); err != nil {
@@ -121,7 +121,7 @@ func PubSubWithTargetTestImpl(t *testing.T, packages map[string]string, assertMe
 	}()
 
 	gvr := schema.GroupVersionResource{
-		Group:    "events.cloud.run",
+		Group:    "events.cloud.google.com",
 		Version:  "v1alpha1",
 		Resource: "pubsubs",
 	}

--- a/test/e2e/test_pull_subscription.go
+++ b/test/e2e/test_pull_subscription.go
@@ -62,7 +62,7 @@ func SmokePullSubscriptionTestImpl(t *testing.T) {
 	}()
 
 	if err := client.WaitForResourceReady(client.Namespace, psName, schema.GroupVersionResource{
-		Group:    "pubsub.cloud.run",
+		Group:    "pubsub.cloud.google.com",
 		Version:  "v1alpha1",
 		Resource: "pullsubscriptions",
 	}); err != nil {
@@ -111,7 +111,7 @@ func PullSubscriptionWithTargetTestImpl(t *testing.T, packages map[string]string
 	}()
 
 	gvr := schema.GroupVersionResource{
-		Group:    "pubsub.cloud.run",
+		Group:    "pubsub.cloud.google.com",
 		Version:  "v1alpha1",
 		Resource: "pullsubscriptions",
 	}

--- a/test/e2e/test_storage.go
+++ b/test/e2e/test_storage.go
@@ -129,7 +129,7 @@ func StorageWithTestImpl(t *testing.T, packages map[string]string, assertMetrics
 	}()
 
 	gvr := schema.GroupVersionResource{
-		Group:    "events.cloud.run",
+		Group:    "events.cloud.google.com",
 		Version:  "v1alpha1",
 		Resource: "storages",
 	}


### PR DESCRIPTION
Fixes #331 

- Changing APIGroups from x.cloud.run to x.cloud.google.com:
  - `events.cloud.google.com` (PubSub, Storage, Scheduler)
  - `messaging.cloud.google.com` (Channel)
  - `pubsub.cloud.google.com` (Topic and PullSubscription)

/assign @vaikas-google 