### PR TITLE
Propagate pubsub subscription/topic failure reason from job pod

### DIFF
--- a/pkg/reconciler/testing/pullsubscription.go
+++ b/pkg/reconciler/testing/pullsubscription.go
@@ -168,6 +168,13 @@ func WithPullSubscriptionReady(sink string) PullSubscriptionOption {
 //	}
 //}
 
+func WithPullSubscriptionJobFailure(subscriptionID, reason, message string) PullSubscriptionOption {
+	return func(s *v1alpha1.PullSubscription) {
+		s.Status.SubscriptionID = subscriptionID
+		s.Status.MarkNoSubscription(reason, message)
+	}
+}
+
 func WithPullSubscriptionSinkNotFound() PullSubscriptionOption {
 	return func(s *v1alpha1.PullSubscription) {
 		s.Status.MarkNoSink("InvalidSink", `sinks.testing.cloud.google.com "sink" not found`)

--- a/pkg/reconciler/testing/topic.go
+++ b/pkg/reconciler/testing/topic.go
@@ -98,6 +98,13 @@ func WithTopicTopicDeleted(topicID string) TopicOption {
 	}
 }
 
+func WithTopicJobFailure(topicID, reason, message string) TopicOption {
+	return func(s *v1alpha1.Topic) {
+		s.Status.TopicID = topicID
+		s.Status.MarkNoTopic(reason, message)
+	}
+}
+
 func WithTopicAddress(uri string) TopicOption {
 	return func(s *v1alpha1.Topic) {
 		if uri != "" {


### PR DESCRIPTION
To fix https://github.com/google/knative-gcp/issues/313
---
1. Added "reason" to subscription/topic job pod termination message
2. Refactored some common code to retrieve termination reason