### PR TITLE
Allow cloud-run-events service account to patch secrets

### DIFF
--- a/config/201-clusterrole.yaml
+++ b/config/201-clusterrole.yaml
@@ -115,6 +115,15 @@ rules:
     - ""
   resources:
     - secrets # TODO: Does it really need global secrets access?
+  verbs:
+    - get
+    - list
+    - watch
+    - finalize
+
+- apiGroups:
+    - ""
+  resources:
     - configmaps
     - pods # For reading termination messages
   verbs: &readOnly


### PR DESCRIPTION
Allow cloud-run-events service account to patch secrets so that it can add finalizer to secrets
To fix: https://github.com/google/knative-gcp/issues/375