### PR TITLE
Add slash to secret finalizer name

### DIFF
--- a/pkg/reconciler/pullsubscription/pullsubscription.go
+++ b/pkg/reconciler/pullsubscription/pullsubscription.go
@@ -63,6 +63,9 @@ const (
 	channelComponent = "channel"
 
 	finalizerName = controllerAgentName
+
+	// Custom secret finalizer requires at least one slash
+	secretFinalizerName = controllerAgentName + "/secret"
 )
 
 // Reconciler implements controller.Reconciler for PullSubscription resources.
@@ -355,7 +358,7 @@ func (c *Reconciler) updateSecretFinalizer(ctx context.Context, desired *v1alpha
 	}
 	existing := secret.DeepCopy()
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	hasFinalizer := existingFinalizers.Has(finalizerName)
+	hasFinalizer := existingFinalizers.Has(secretFinalizerName)
 
 	if ensureFinalizer == hasFinalizer {
 		return nil
@@ -363,9 +366,9 @@ func (c *Reconciler) updateSecretFinalizer(ctx context.Context, desired *v1alpha
 
 	var desiredFinalizers []string
 	if ensureFinalizer {
-		desiredFinalizers = append(existing.Finalizers, finalizerName)
+		desiredFinalizers = append(existing.Finalizers, secretFinalizerName)
 	} else {
-		existingFinalizers.Delete(finalizerName)
+		existingFinalizers.Delete(secretFinalizerName)
 		desiredFinalizers = existingFinalizers.List()
 	}
 

--- a/pkg/reconciler/topic/topic.go
+++ b/pkg/reconciler/topic/topic.go
@@ -56,6 +56,9 @@ const (
 	ReconcilerName = "Topics"
 
 	finalizerName = controllerAgentName
+
+	// Custom secret finalizer requires at least one slash
+	secretFinalizerName = controllerAgentName + "/secret"
 )
 
 // Reconciler implements controller.Reconciler for Topic resources.
@@ -347,7 +350,7 @@ func (c *Reconciler) updateSecretFinailizer(ctx context.Context, desired *v1alph
 	}
 	existing := secret.DeepCopy()
 	existingFinalizers := sets.NewString(existing.Finalizers...)
-	hasFinalizer := existingFinalizers.Has(finalizerName)
+	hasFinalizer := existingFinalizers.Has(secretFinalizerName)
 
 	if ensureFinalizer == hasFinalizer {
 		return nil
@@ -355,9 +358,9 @@ func (c *Reconciler) updateSecretFinailizer(ctx context.Context, desired *v1alph
 
 	var desiredFinalizers []string
 	if ensureFinalizer {
-		desiredFinalizers = append(existing.Finalizers, finalizerName)
+		desiredFinalizers = append(existing.Finalizers, secretFinalizerName)
 	} else {
-		existingFinalizers.Delete(finalizerName)
+		existingFinalizers.Delete(secretFinalizerName)
 		desiredFinalizers = existingFinalizers.List()
 	}
 


### PR DESCRIPTION
To fix: https://github.com/google/knative-gcp/issues/378

According to:

kubernetes/kubernetes:pkg/apis/core/validation/validation.go@3698100#L5314-L5320

The API requires the secret finalizer to have at least one slash /.