### PR TITLE
Update pkg to 0.10 release and fix webhook

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1238,7 +1238,7 @@
 
 [[projects]]
   branch = "release-0.10"
-  digest = "1:60eb83b6db703546cbddab378c2e8675237726dba71f883feeaec6ad45ba0659"
+  digest = "1:d91a27f79bca7f71b57bdc3581542d646c90dca75862c38d21ad7b1aca6c22aa"
   name = "knative.dev/pkg"
   packages = [
     "apis",
@@ -1309,7 +1309,7 @@
     "webhook",
   ]
   pruneopts = "T"
-  revision = "2a3fc371d3266d59a0ae7e29a724ccc9a0550793"
+  revision = "cad41c40ccb5a40de7a3b65097649703c8d96e0b"
 
 [[projects]]
   branch = "master"

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"log"
 
 	"go.uber.org/zap"
@@ -101,11 +100,10 @@ func SharedMain(resourceHandlers map[schema.GroupVersionKind]webhook.GenericCRD)
 
 	options := webhook.ControllerOptions{
 		ServiceName:                     "webhook",
-		DeploymentName:                  "webhook",
 		Namespace:                       system.Namespace(),
 		Port:                            8443,
 		SecretName:                      "webhook-certs",
-		ResourceMutatingWebhookName:     fmt.Sprintf("webhook.%s.events.cloud.google.com", system.Namespace()),
+		ResourceMutatingWebhookName:     "webhook.events.cloud.google.com",
 		ResourceAdmissionControllerPath: "/",
 	}
 

--- a/config/500-webhook-configuration.yaml
+++ b/config/500-webhook-configuration.yaml
@@ -1,0 +1,29 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: webhook.events.cloud.google.com
+  labels:
+    events.cloud.google.com/release: devel
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook
+      namespace: cloud-run-events
+  failurePolicy: Fail
+  name: webhook.events.cloud.google.com

--- a/vendor/knative.dev/pkg/Gopkg.lock
+++ b/vendor/knative.dev/pkg/Gopkg.lock
@@ -1260,14 +1260,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:988757b6c3d2df3248703c76ae0c63654319672fe368321a191cbbee88b12e69"
+  digest = "1:15b833e870afd578a79069324b74c9cc2ac07b5547f34d54516d90f781c37461"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "11b4f85e9c2714c45dda40abc5279b63f706f039"
+  revision = "385c6ecc17489d72a2e0927d4552bcdc1f0d08e0"
 
 [[projects]]
   digest = "1:8730e0150dfb2b7e173890c8b9868e7a273082ef8e39f4940e3506a481cf895c"

--- a/vendor/knative.dev/pkg/apis/duck/README.md
+++ b/vendor/knative.dev/pkg/apis/duck/README.md
@@ -1,0 +1,95 @@
+# Duck Types
+
+Knative leverages duck-typing to interact with resources inside of Kubernetes
+without explicit knowlage of the full resource shape. `knative/pkg` defines two
+duck types that are used throughout Knative: `Addressable` and `Source`.
+
+For APIs leveraging `ObjectReference`, the context of the resource in question
+identifies the duck-type. To enable the case where no `ObjectRefrence` is used,
+we have labeled the Custom Resource Definition with the duck-type. Those labels
+are as follows:
+
+| Label                               | Duck-Type                                                                     |
+| ----------------------------------- | ----------------------------------------------------------------------------- |
+| `duck.knative.dev/addressable=true` | [Addressable](https://godoc.org/knative.dev/pkg/apis/duck/v1#AddressableType) |
+| `duck.knative.dev/source=true`      | [Source](https://godoc.org/knative.dev/pkg/apis/duck/v1#Source)               |
+
+## Addressable Shape
+
+Addressable is expected to be the following shape:
+
+```yaml
+apiVersion: group/version
+kind: Kind
+status:
+  address:
+    url: http://host/path?query
+```
+
+## Source Shape
+
+Source is expected to be in the following shape:
+
+(with ref sink)
+
+```yaml
+apiVersion: group/version
+kind: Kind
+spec:
+  sink:
+    ref:
+      apiVersion: group/version
+      kind: AnAddressableKind
+      name: a-name
+  ceOverrides:
+    extensions:
+      key: value
+status:
+  observedGeneration: 1
+  conditions:
+    - type: Ready
+      status: "True"
+  sinkUri: http://host
+```
+
+(with uri sink)
+
+```yaml
+apiVersion: group/version
+kind: Kind
+spec:
+  sink:
+    uri: http://host/path?query
+  ceOverrides:
+    extensions:
+      key: value
+status:
+  observedGeneration: 1
+  conditions:
+    - type: Ready
+      status: "True"
+  sinkUri: http://host/path?query
+```
+
+(with ref and uri sink)
+
+```yaml
+apiVersion: group/version
+kind: Kind
+spec:
+  sink:
+    ref:
+      apiVersion: group/version
+      kind: AnAddressableKind
+      name: a-name
+    uri: /path?query
+  ceOverrides:
+    extensions:
+      key: value
+status:
+  observedGeneration: 1
+  conditions:
+    - type: Ready
+      status: "True"
+  sinkUri: http://host/path?query
+```

--- a/vendor/knative.dev/pkg/metrics/config.go
+++ b/vendor/knative.dev/pkg/metrics/config.go
@@ -44,8 +44,13 @@ const (
 	AllowStackdriverCustomMetricsKey    = "metrics.allow-stackdriver-custom-metrics"
 	BackendDestinationKey               = "metrics.backend-destination"
 	ReportingPeriodKey                  = "metrics.reporting-period-seconds"
-	StackdriverProjectIDKey             = "metrics.stackdriver-project-id"
 	StackdriverCustomMetricSubDomainKey = "metrics.stackdriver-custom-metrics-subdomain"
+	// Stackdriver client configuration keys
+	stackdriverProjectIDKey          = "metrics.stackdriver-project-id"
+	stackdriverGCPLocationKey        = "metrics.stackdriver-gcp-location"
+	stackdriverClusterNameKey        = "metrics.stackdriver-cluster-name"
+	stackdriverGCPSecretNameKey      = "metrics.stackdriver-gcp-secret-name"
+	stackdriverGCPSecretNamespaceKey = "metrics.stackdriver-gcp-secret-namespace"
 
 	// Stackdriver is used for Stackdriver backend
 	Stackdriver metricsBackend = "stackdriver"
@@ -76,9 +81,6 @@ type metricsConfig struct {
 	prometheusPort int
 
 	// ---- Stackdriver specific below ----
-	// stackdriverProjectID is the stackdriver project ID where the stats data are
-	// uploaded to. This is not the GCP project ID.
-	stackdriverProjectID string
 	// allowStackdriverCustomMetrics indicates whether it is allowed to send metrics to
 	// Stackdriver using "global" resource type and custom metric type if the
 	// metrics are not supported by the registered monitored resource types. Setting this
@@ -100,6 +102,42 @@ type metricsConfig struct {
 	// E.g., "custom.googleapis.com/<subdomain>/<component>".
 	// Store this in a variable to reduce string join operations.
 	stackdriverCustomMetricTypePrefix string
+	// stackdriverClientConfig is the metadata to configure the metrics exporter's Stackdriver client.
+	stackdriverClientConfig stackdriverClientConfig
+}
+
+// stackdriverClientConfig encapsulates the metadata required to configure a Stackdriver client.
+type stackdriverClientConfig struct {
+	// ProjectID is the stackdriver project ID to which data is uploaded.
+	// This is not necessarily the GCP project ID where the Kubernetes cluster is hosted.
+	// Required when the Kubernetes cluster is not hosted on GCE.
+	ProjectID string
+	// GCPLocation is the GCP region or zone to which data is uploaded.
+	// This is not necessarily the GCP location where the Kubernetes cluster is hosted.
+	// Required when the Kubernetes cluster is not hosted on GCE.
+	GCPLocation string
+	// ClusterName is the cluster name with which the data will be associated in Stackdriver.
+	// Required when the Kubernetes cluster is not hosted on GCE.
+	ClusterName string
+	// GCPSecretName is the optional GCP service account key which will be used to
+	// authenticate with Stackdriver. If not provided, Google Application Default Credentials
+	// will be used (https://cloud.google.com/docs/authentication/production).
+	GCPSecretName string
+	// GCPSecretNamespace is the Kubernetes namespace where GCPSecretName is located.
+	// The Kubernetes ServiceAccount used by the pod that is exporting data to
+	// Stackdriver should have access to Secrets in this namespace.
+	GCPSecretNamespace string
+}
+
+// newStackdriverClientConfigFromMap creates a stackdriverClientConfig from the given map
+func newStackdriverClientConfigFromMap(config map[string]string) *stackdriverClientConfig {
+	return &stackdriverClientConfig{
+		ProjectID:          config[stackdriverProjectIDKey],
+		GCPLocation:        config[stackdriverGCPLocationKey],
+		ClusterName:        config[stackdriverClusterNameKey],
+		GCPSecretName:      config[stackdriverGCPSecretNameKey],
+		GCPSecretNamespace: config[stackdriverGCPSecretNamespaceKey],
+	}
 }
 
 func createMetricsConfig(ops ExporterOptions, logger *zap.SugaredLogger) (*metricsConfig, error) {
@@ -148,11 +186,12 @@ func createMetricsConfig(ops ExporterOptions, logger *zap.SugaredLogger) (*metri
 		mc.prometheusPort = pp
 	}
 
-	// If stackdriverProjectIDKey is not provided for stackdriver backend destination, OpenCensus will try to
+	// If stackdriverClientConfig is not provided for stackdriver backend destination, OpenCensus will try to
 	// use the application default credentials. If that is not available, Opencensus would fail to create the
 	// metrics exporter.
 	if mc.backendDestination == Stackdriver {
-		mc.stackdriverProjectID = m[StackdriverProjectIDKey]
+		scc := newStackdriverClientConfigFromMap(m)
+		mc.stackdriverClientConfig = *scc
 		mc.isStackdriverBackend = true
 		mc.stackdriverMetricTypePrefix = path.Join(mc.domain, mc.component)
 

--- a/vendor/knative.dev/pkg/metrics/exporter.go
+++ b/vendor/knative.dev/pkg/metrics/exporter.go
@@ -79,12 +79,9 @@ func UpdateExporterFromConfigMap(component string, logger *zap.SugaredLogger) fu
 // to prevent a race condition between reading the current configuration
 // and updating the current exporter.
 func UpdateExporter(ops ExporterOptions, logger *zap.SugaredLogger) error {
-	metricsMux.Lock()
-	defer metricsMux.Unlock()
-
 	newConfig, err := createMetricsConfig(ops, logger)
 	if err != nil {
-		if curMetricsExporter == nil {
+		if getCurMetricsConfig() == nil {
 			// Fail the process if there doesn't exist an exporter.
 			logger.Errorw("Failed to get a valid metrics config", zap.Error(err))
 		} else {
@@ -95,18 +92,18 @@ func UpdateExporter(ops ExporterOptions, logger *zap.SugaredLogger) error {
 
 	if isNewExporterRequired(newConfig) {
 		logger.Info("Flushing the existing exporter before setting up the new exporter.")
-		flushExporterUnlocked(curMetricsExporter)
+		FlushExporter()
 		e, err := newMetricsExporter(newConfig, logger)
 		if err != nil {
 			logger.Errorf("Failed to update a new metrics exporter based on metric config %v. error: %v", newConfig, err)
 			return err
 		}
-		existingConfig := curMetricsConfig
-		setCurMetricsExporterUnlocked(e)
+		existingConfig := getCurMetricsConfig()
+		setCurMetricsExporter(e)
 		logger.Infof("Successfully updated the metrics exporter; old config: %v; new config %v", existingConfig, newConfig)
 	}
 
-	setCurMetricsConfigUnlocked(newConfig)
+	setCurMetricsConfig(newConfig)
 	return nil
 }
 
@@ -114,18 +111,18 @@ func UpdateExporter(ops ExporterOptions, logger *zap.SugaredLogger) error {
 // or stackdriver project ID changes for stackdriver backend, we need to update the metrics exporter.
 // This function is not implicitly thread-safe.
 func isNewExporterRequired(newConfig *metricsConfig) bool {
-	cc := curMetricsConfig
+	cc := getCurMetricsConfig()
 	if cc == nil || newConfig.backendDestination != cc.backendDestination {
 		return true
 	}
 
-	return newConfig.backendDestination == Stackdriver && newConfig.stackdriverProjectID != cc.stackdriverProjectID
+	return newConfig.backendDestination == Stackdriver && newConfig.stackdriverClientConfig != cc.stackdriverClientConfig
 }
 
 // newMetricsExporter gets a metrics exporter based on the config.
 // This function is not implicitly thread-safe.
 func newMetricsExporter(config *metricsConfig, logger *zap.SugaredLogger) (view.Exporter, error) {
-	ce := curMetricsExporter
+	ce := getCurMetricsExporter()
 	// If there is a Prometheus Exporter server running, stop it.
 	resetCurPromSrv()
 
@@ -159,10 +156,6 @@ func getCurMetricsExporter() view.Exporter {
 func setCurMetricsExporter(e view.Exporter) {
 	metricsMux.Lock()
 	defer metricsMux.Unlock()
-	setCurMetricsExporterUnlocked(e)
-}
-
-func setCurMetricsExporterUnlocked(e view.Exporter) {
 	view.RegisterExporter(e)
 	curMetricsExporter = e
 }
@@ -176,10 +169,6 @@ func getCurMetricsConfig() *metricsConfig {
 func setCurMetricsConfig(c *metricsConfig) {
 	metricsMux.Lock()
 	defer metricsMux.Unlock()
-	setCurMetricsConfigUnlocked(c)
-}
-
-func setCurMetricsConfigUnlocked(c *metricsConfig) {
 	if c != nil {
 		view.SetReportingPeriod(c.reportingPeriod)
 	} else {
@@ -194,10 +183,6 @@ func setCurMetricsConfigUnlocked(c *metricsConfig) {
 // Return value indicates whether the exporter is flushable or not.
 func FlushExporter() bool {
 	e := getCurMetricsExporter()
-	return flushExporterUnlocked(e)
-}
-
-func flushExporterUnlocked(e view.Exporter) bool {
 	if e == nil {
 		return false
 	}

--- a/vendor/knative.dev/pkg/metrics/gcp_metadata.go
+++ b/vendor/knative.dev/pkg/metrics/gcp_metadata.go
@@ -33,17 +33,21 @@ func retrieveGCPMetadata() *gcpMetadata {
 		location: metricskey.ValueUnknown,
 		cluster:  metricskey.ValueUnknown,
 	}
-	project, err := metadata.NumericProjectID()
-	if err == nil && project != "" {
-		gm.project = project
+
+	if metadata.OnGCE() {
+		project, err := metadata.NumericProjectID()
+		if err == nil && project != "" {
+			gm.project = project
+		}
+		location, err := metadata.InstanceAttributeValue("cluster-location")
+		if err == nil && location != "" {
+			gm.location = location
+		}
+		cluster, err := metadata.InstanceAttributeValue("cluster-name")
+		if err == nil && cluster != "" {
+			gm.cluster = cluster
+		}
 	}
-	location, err := metadata.InstanceAttributeValue("cluster-location")
-	if err == nil && location != "" {
-		gm.location = location
-	}
-	cluster, err := metadata.InstanceAttributeValue("cluster-name")
-	if err == nil && cluster != "" {
-		gm.cluster = cluster
-	}
+
 	return &gm
 }

--- a/vendor/knative.dev/pkg/resolver/addressable_resolver.go
+++ b/vendor/knative.dev/pkg/resolver/addressable_resolver.go
@@ -65,14 +65,14 @@ func NewURIResolver(ctx context.Context, callback func(types.NamespacedName)) *U
 // URIFromDestination resolves a Destination into a URI string.
 func (r *URIResolver) URIFromDestination(dest apisv1alpha1.Destination, parent interface{}) (string, error) {
 	var deprecatedObjectReference *corev1.ObjectReference
-	if dest.DeprecatedAPIVersion == "" && dest.DeprecatedKind == "" && dest.DeprecatedName == "" && dest.DeprecatedNamespace == ""{
+	if dest.DeprecatedAPIVersion == "" && dest.DeprecatedKind == "" && dest.DeprecatedName == "" && dest.DeprecatedNamespace == "" {
 		deprecatedObjectReference = nil
 	} else {
 		deprecatedObjectReference = &corev1.ObjectReference{
-			Kind:            dest.DeprecatedKind,
-			APIVersion:       dest.DeprecatedAPIVersion,
-			Name:            dest.DeprecatedName,
-			Namespace:       dest.DeprecatedNamespace,
+			Kind:       dest.DeprecatedKind,
+			APIVersion: dest.DeprecatedAPIVersion,
+			Name:       dest.DeprecatedName,
+			Namespace:  dest.DeprecatedNamespace,
 		}
 	}
 	if dest.Ref != nil && deprecatedObjectReference != nil {

--- a/vendor/knative.dev/pkg/test/mako/alerter/github/issue.go
+++ b/vendor/knative.dev/pkg/test/mako/alerter/github/issue.go
@@ -44,18 +44,17 @@ const (
 	// issueBodyTemplate is a template for issue body
 	issueBodyTemplate = `
 ### Auto-generated issue tracking performance regression
-* **Test name**: %s
-* **Repository name**: %s`
+* **Repository name**: %s
+* **Test name**: %s`
 
 	// issueSummaryCommentTemplate is a template for the summary of an issue
 	issueSummaryCommentTemplate = `
 A new regression for this test has been detected:
 %s`
 
-	// reopenIssueCommentTemplate is a template for the comment of an issue that is reopened
-	reopenIssueCommentTemplate = `
-New regression has been detected, reopening this issue:
-%s`
+	// reopenIssueComment is the comment of an issue when it is reopened
+	reopenIssueComment = `
+New regression has been detected, reopening this issue.`
 
 	// closeIssueComment is the comment of an issue when it is closed
 	closeIssueComment = `
@@ -101,7 +100,7 @@ func (gih *IssueHandler) CreateIssueForTest(testName, desc string) error {
 	}
 	// If the issue hasn't been created, create one
 	if issue == nil {
-		commentBody := fmt.Sprintf(issueBodyTemplate, testName, gih.config.repo)
+		commentBody := fmt.Sprintf(issueBodyTemplate, gih.config.repo, testName)
 		issue, err := gih.createNewIssue(title, commentBody)
 		if err != nil {
 			return fmt.Errorf("failed to create a new issue for test %q: %v", testName, err)
@@ -121,8 +120,7 @@ func (gih *IssueHandler) CreateIssueForTest(testName, desc string) error {
 		if err := gih.reopenIssue(issueNumber); err != nil {
 			return fmt.Errorf("failed to reopen issue %d: %v", issueNumber, err)
 		}
-		commentBody := fmt.Sprintf(reopenIssueCommentTemplate, desc)
-		if err := gih.addComment(issueNumber, commentBody); err != nil {
+		if err := gih.addComment(issueNumber, reopenIssueComment); err != nil {
 			return fmt.Errorf("failed to add comment for reopened issue %d: %v", issueNumber, err)
 		}
 	}
@@ -132,11 +130,11 @@ func (gih *IssueHandler) CreateIssueForTest(testName, desc string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get comments from issue %d: %v", issueNumber, err)
 	}
-	if len(comments) < 2 {
+	if len(comments) < 1 {
 		return fmt.Errorf("existing issue %d is malformed, cannot update", issueNumber)
 	}
 	commentBody := fmt.Sprintf(issueSummaryCommentTemplate, desc)
-	if err := gih.editComment(issueNumber, *comments[1].ID, commentBody); err != nil {
+	if err := gih.editComment(issueNumber, *comments[0].ID, commentBody); err != nil {
 		return fmt.Errorf("failed to edit the comment for issue %d: %v", issueNumber, err)
 	}
 

--- a/vendor/knative.dev/pkg/webhook/config_validation_controller.go
+++ b/vendor/knative.dev/pkg/webhook/config_validation_controller.go
@@ -22,13 +22,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"strings"
 
-	"github.com/markbates/inflect"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
@@ -36,6 +33,7 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
+	"knative.dev/pkg/ptr"
 )
 
 // ConfigValidationController implements the AdmissionController for ConfigMaps
@@ -81,84 +79,53 @@ func (ac *ConfigValidationController) Admit(ctx context.Context, request *admiss
 func (ac *ConfigValidationController) Register(ctx context.Context, kubeClient kubernetes.Interface, caCert []byte) error {
 	client := kubeClient.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations()
 	logger := logging.FromContext(ctx)
-	failurePolicy := admissionregistrationv1beta1.Fail
-
-	resourceGVK := corev1.SchemeGroupVersion.WithKind("ConfigMap")
-	var rules []admissionregistrationv1beta1.RuleWithOperations
-	plural := strings.ToLower(inflect.Pluralize(resourceGVK.Kind))
 
 	ruleScope := admissionregistrationv1beta1.NamespacedScope
-	rules = append(rules, admissionregistrationv1beta1.RuleWithOperations{
+	rules := []admissionregistrationv1beta1.RuleWithOperations{{
 		Operations: []admissionregistrationv1beta1.OperationType{
 			admissionregistrationv1beta1.Create,
 			admissionregistrationv1beta1.Update,
 		},
 		Rule: admissionregistrationv1beta1.Rule{
-			APIGroups:   []string{resourceGVK.Group},
-			APIVersions: []string{resourceGVK.Version},
-			Resources:   []string{plural + "/*"},
+			APIGroups:   []string{""},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"configmaps/*"},
 			Scope:       &ruleScope,
 		},
-	})
+	}}
 
-	webhook := &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ac.options.ConfigValidationWebhookName,
-		},
-		Webhooks: []admissionregistrationv1beta1.ValidatingWebhook{{
-			Name:  ac.options.ConfigValidationWebhookName,
-			Rules: rules,
-			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
-				Service: &admissionregistrationv1beta1.ServiceReference{
-					Namespace: ac.options.Namespace,
-					Name:      ac.options.ServiceName,
-					Path:      &ac.options.ConfigValidationControllerPath,
-				},
-				CABundle: caCert,
-			},
-			NamespaceSelector: &metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{{
-					Key:      ac.options.ConfigValidationNamespaceLabel,
-					Operator: metav1.LabelSelectorOpExists,
-				}},
-			},
-			FailurePolicy: &failurePolicy,
-		}},
+	configuredWebhook, err := client.Get(ac.options.ConfigValidationWebhookName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error retrieving webhook: %v", err)
 	}
 
-	// Set the owner to our deployment.
-	deployment, err := kubeClient.AppsV1().Deployments(ac.options.Namespace).Get(ac.options.DeploymentName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to fetch our deployment: %v", err)
-	}
-	deploymentRef := metav1.NewControllerRef(deployment, deploymentKind)
-	webhook.OwnerReferences = append(webhook.OwnerReferences, *deploymentRef)
+	webhook := configuredWebhook.DeepCopy()
 
-	// Try to create the webhook and if it already exists validate webhook rules.
-	_, err = client.Create(webhook)
-	if err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("failed to create a webhook: %v", err)
+	// Clear out any previous (bad) OwnerReferences.
+	// See: https://github.com/knative/serving/issues/5845
+	webhook.OwnerReferences = nil
+
+	for i, wh := range webhook.Webhooks {
+		if wh.Name != webhook.Name {
+			continue
 		}
-		logger.Info("Webhook already exists")
-		configuredWebhook, err := client.Get(ac.options.ConfigValidationWebhookName, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("error retrieving webhook: %v", err)
+		webhook.Webhooks[i].Rules = rules
+		webhook.Webhooks[i].ClientConfig.CABundle = caCert
+		if webhook.Webhooks[i].ClientConfig.Service == nil {
+			return fmt.Errorf("missing service reference for webhook: %s", wh.Name)
 		}
-		if ok, err := kmp.SafeEqual(configuredWebhook.Webhooks, webhook.Webhooks); err != nil {
-			return fmt.Errorf("error diffing webhooks: %v", err)
-		} else if !ok {
-			logger.Info("Updating webhook")
-			// Set the ResourceVersion as required by update.
-			webhook.ObjectMeta.ResourceVersion = configuredWebhook.ObjectMeta.ResourceVersion
-			if _, err := client.Update(webhook); err != nil {
-				return fmt.Errorf("failed to update webhook: %s", err)
-			}
-		} else {
-			logger.Info("Webhook is already valid")
+		webhook.Webhooks[i].ClientConfig.Service.Path = ptr.String(ac.options.ConfigValidationControllerPath)
+	}
+
+	if ok, err := kmp.SafeEqual(configuredWebhook, webhook); err != nil {
+		return fmt.Errorf("error diffing webhooks: %v", err)
+	} else if !ok {
+		logger.Info("Updating webhook")
+		if _, err := client.Update(webhook); err != nil {
+			return fmt.Errorf("failed to update webhook: %v", err)
 		}
 	} else {
-		logger.Info("Created a webhook")
+		logger.Info("Webhook is valid")
 	}
 
 	return nil

--- a/vendor/knative.dev/pkg/webhook/resource_admission_controller.go
+++ b/vendor/knative.dev/pkg/webhook/resource_admission_controller.go
@@ -32,7 +32,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 
@@ -40,6 +39,7 @@ import (
 	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
+	"knative.dev/pkg/ptr"
 )
 
 // ResourceCallback defines a signature for resource specific (Route, Configuration, etc.)
@@ -108,7 +108,6 @@ func (ac *ResourceAdmissionController) Admit(ctx context.Context, request *admis
 func (ac *ResourceAdmissionController) Register(ctx context.Context, kubeClient kubernetes.Interface, caCert []byte) error {
 	client := kubeClient.AdmissionregistrationV1beta1().MutatingWebhookConfigurations()
 	logger := logging.FromContext(ctx)
-	failurePolicy := admissionregistrationv1beta1.Fail
 
 	var rules []admissionregistrationv1beta1.RuleWithOperations
 	for gvk := range ac.handlers {
@@ -139,58 +138,39 @@ func (ac *ResourceAdmissionController) Register(ctx context.Context, kubeClient 
 		return lhs.Resources[0] < rhs.Resources[0]
 	})
 
-	webhook := &admissionregistrationv1beta1.MutatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ac.options.ResourceMutatingWebhookName,
-		},
-		Webhooks: []admissionregistrationv1beta1.MutatingWebhook{{
-			Name:  ac.options.ResourceMutatingWebhookName,
-			Rules: rules,
-			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
-				Service: &admissionregistrationv1beta1.ServiceReference{
-					Namespace: ac.options.Namespace,
-					Name:      ac.options.ServiceName,
-					Path:      &ac.options.ResourceAdmissionControllerPath,
-				},
-				CABundle: caCert,
-			},
-			FailurePolicy: &failurePolicy,
-		}},
+	configuredWebhook, err := client.Get(ac.options.ResourceMutatingWebhookName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error retrieving webhook: %v", err)
 	}
 
-	// Set the owner to our deployment.
-	deployment, err := kubeClient.AppsV1().Deployments(ac.options.Namespace).Get(ac.options.DeploymentName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to fetch our deployment: %v", err)
-	}
-	deploymentRef := metav1.NewControllerRef(deployment, deploymentKind)
-	webhook.OwnerReferences = append(webhook.OwnerReferences, *deploymentRef)
+	webhook := configuredWebhook.DeepCopy()
 
-	// Try to create the webhook and if it already exists validate webhook rules.
-	_, err = client.Create(webhook)
-	if err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("failed to create a webhook: %v", err)
+	// Clear out any previous (bad) OwnerReferences.
+	// See: https://github.com/knative/serving/issues/5845
+	webhook.OwnerReferences = nil
+
+	for i, wh := range webhook.Webhooks {
+		if wh.Name != webhook.Name {
+			continue
 		}
-		logger.Info("Webhook already exists")
-		configuredWebhook, err := client.Get(ac.options.ResourceMutatingWebhookName, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("error retrieving webhook: %v", err)
+		webhook.Webhooks[i].Rules = rules
+		webhook.Webhooks[i].ClientConfig.CABundle = caCert
+		if webhook.Webhooks[i].ClientConfig.Service == nil {
+			return fmt.Errorf("missing service reference for webhook: %s", wh.Name)
 		}
-		if ok, err := kmp.SafeEqual(configuredWebhook.Webhooks, webhook.Webhooks); err != nil {
-			return fmt.Errorf("error diffing webhooks: %v", err)
-		} else if !ok {
-			logger.Info("Updating webhook")
-			// Set the ResourceVersion as required by update.
-			webhook.ObjectMeta.ResourceVersion = configuredWebhook.ObjectMeta.ResourceVersion
-			if _, err := client.Update(webhook); err != nil {
-				return fmt.Errorf("failed to update webhook: %s", err)
-			}
-		} else {
-			logger.Info("Webhook is already valid")
+		webhook.Webhooks[i].ClientConfig.Service.Path = ptr.String(
+			ac.options.ResourceAdmissionControllerPath)
+	}
+
+	if ok, err := kmp.SafeEqual(configuredWebhook, webhook); err != nil {
+		return fmt.Errorf("error diffing webhooks: %v", err)
+	} else if !ok {
+		logger.Info("Updating webhook")
+		if _, err := client.Update(webhook); err != nil {
+			return fmt.Errorf("failed to update webhook: %v", err)
 		}
 	} else {
-		logger.Info("Created a webhook")
+		logger.Info("Webhook is valid")
 	}
 	return nil
 }


### PR DESCRIPTION
The version of pkg that eventually became release-0.10 is newer than the version of pkg in knative-gcp release-0.10 branch. This PR updates to the same version of pkg that serving and eventing 0.10 released with, and updates the webhook configuration to match the changes from https://github.com/knative/pkg/pull/802.

Replaces #389 in favor of fewer webhook changes.