### PR TITLE
Adding Span From TraceParent only for Channels

### DIFF
--- a/pkg/pubsub/adapter/adapter.go
+++ b/pkg/pubsub/adapter/adapter.go
@@ -27,7 +27,7 @@ import (
 
 	nethttp "net/http"
 
-	"github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
 	cepubsub "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/pubsub"

--- a/pkg/pubsub/adapter/adapter.go
+++ b/pkg/pubsub/adapter/adapter.go
@@ -27,7 +27,7 @@ import (
 
 	nethttp "net/http"
 
-	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
 	cepubsub "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/pubsub"
@@ -35,8 +35,17 @@ import (
 	"github.com/google/knative-gcp/pkg/pubsub/adapter/converters"
 	decoratorresources "github.com/google/knative-gcp/pkg/reconciler/decorator/resources"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/eventing/pkg/tracing"
 	"knative.dev/pkg/logging"
+)
+
+var (
+	channelGVR = schema.GroupVersionResource{
+		Group:    "messaging.cloud.google.com",
+		Version:  "v1alpha1",
+		Resource: "channels",
+	}
 )
 
 // Adapter implements the Pub/Sub adapter to deliver Pub/Sub messages from a
@@ -167,10 +176,15 @@ func (a *Adapter) receive(ctx context.Context, event cloudevents.Event, resp *cl
 		ResourceGroup: a.ResourceGroup,
 	}
 
-	// a.Sink is likely not exactly what we want...
-	ctx, err := tracing.AddSpanFromTraceparentAttribute(ctx, a.Sink, event)
-	if err != nil {
-		logger.Infow("Unable to attach tracing to context", zap.Error(err))
+	var err error
+	// If the resource group is the Channel one, then we attach the span from the traceparent attribute.
+	// Otherwise, it means it's a Source, thus it does not have traceparent.
+	if a.ResourceGroup == channelGVR.GroupResource().String() {
+		// a.Sink is likely not exactly what we want...
+		ctx, err = tracing.AddSpanFromTraceparentAttribute(ctx, a.Sink, event)
+		if err != nil {
+			logger.Infow("Unable to attach tracing to context", zap.Error(err))
+		}
 	}
 
 	// If a transformer has been configured, then transform the message.

--- a/pkg/pubsub/adapter/adapter.go
+++ b/pkg/pubsub/adapter/adapter.go
@@ -183,7 +183,7 @@ func (a *Adapter) receive(ctx context.Context, event cloudevents.Event, resp *cl
 		// a.Sink is likely not exactly what we want...
 		ctx, err = tracing.AddSpanFromTraceparentAttribute(ctx, a.Sink, event)
 		if err != nil {
-			logger.Infow("Unable to attach tracing to context", zap.Error(err))
+			logger.Debugw("Unable to attach tracing to context", zap.Error(err))
 		}
 	}
 

--- a/pkg/pubsub/adapter/adapter.go
+++ b/pkg/pubsub/adapter/adapter.go
@@ -183,7 +183,7 @@ func (a *Adapter) receive(ctx context.Context, event cloudevents.Event, resp *cl
 		// a.Sink is likely not exactly what we want...
 		ctx, err = tracing.AddSpanFromTraceparentAttribute(ctx, a.Sink, event)
 		if err != nil {
-			logger.Debugw("Unable to attach tracing to context", zap.Error(err))
+			logger.Warnw("Unable to attach tracing to context", zap.Error(err))
 		}
 	}
 

--- a/pkg/pubsub/adapter/adapter_test.go
+++ b/pkg/pubsub/adapter/adapter_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/google/knative-gcp/pkg/apis/events/v1alpha1"
 	"github.com/google/knative-gcp/pkg/pubsub/adapter/converters"
 
-	"github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go"
 	cepubsub "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/pubsub"
 	pubsubcontext "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/pubsub/context"
 )

--- a/pkg/pubsub/adapter/adapter_test.go
+++ b/pkg/pubsub/adapter/adapter_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/google/knative-gcp/pkg/apis/events/v1alpha1"
 	"github.com/google/knative-gcp/pkg/pubsub/adapter/converters"
 
-	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go"
 	cepubsub "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/pubsub"
 	pubsubcontext "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/pubsub/context"
 )
@@ -213,6 +213,7 @@ func TestReceive(t *testing.T) {
 		wantReportArgs *ReportArgs
 		wantReportCode int
 		wantErr        bool
+		isSource       bool
 	}{{
 		name: "success without responding event",
 		eventFn: func() cloudevents.Event {
@@ -240,8 +241,39 @@ func TestReceive(t *testing.T) {
 		wantBody:    []byte(`{"key":"value"}`),
 		wantEventFn: func() *cloudevents.Event { return nil },
 		wantReportArgs: &ReportArgs{
-			EventSource: "source",
-			EventType:   "unit.testing",
+			EventSource:   "source",
+			EventType:     "unit.testing",
+			ResourceGroup: "channels.messaging.cloud.google.com",
+		},
+		wantReportCode: 200,
+	}, {
+		name: "success without responding event and from source",
+		eventFn: func() cloudevents.Event {
+			e := cloudevents.NewEvent("0.3")
+			e.SetSource("source")
+			e.SetType("unit.testing")
+			e.SetID("abc")
+			e.SetDataContentType("application/json")
+			e.Data = []byte(`{"key":"value"}`)
+			return e
+		},
+		returnStatus: http.StatusOK,
+		isSource:     true,
+		wantHeader: map[string][]string{
+			"Ce-Id":          {"abc"},
+			"Ce-Source":      {"source"},
+			"Ce-Specversion": {"0.3"},
+			"Ce-Type":        {"unit.testing"},
+			"Content-Length": {"15"},
+			"Content-Type":   {"application/json"},
+			"X-B3-Sampled":   {"0"},
+		},
+		wantBody:    []byte(`{"key":"value"}`),
+		wantEventFn: func() *cloudevents.Event { return nil },
+		wantReportArgs: &ReportArgs{
+			EventSource:   "source",
+			EventType:     "unit.testing",
+			ResourceGroup: "pubsub.events.cloud.google.com",
 		},
 		wantReportCode: 200,
 	}, {
@@ -291,8 +323,9 @@ func TestReceive(t *testing.T) {
 		},
 		wantStatus: 200,
 		wantReportArgs: &ReportArgs{
-			EventSource: "source",
-			EventType:   "unit.testing",
+			EventSource:   "source",
+			EventType:     "unit.testing",
+			ResourceGroup: "channels.messaging.cloud.google.com",
 		},
 		wantReportCode: 200,
 	}, {
@@ -322,8 +355,9 @@ func TestReceive(t *testing.T) {
 		wantBody:    []byte(`{"key":"value"}`),
 		wantEventFn: func() *cloudevents.Event { return nil },
 		wantReportArgs: &ReportArgs{
-			EventSource: "source",
-			EventType:   "unit.testing",
+			EventSource:   "source",
+			EventType:     "unit.testing",
+			ResourceGroup: "channels.messaging.cloud.google.com",
 		},
 		wantReportCode: 500,
 		wantErr:        true,
@@ -353,12 +387,19 @@ func TestReceive(t *testing.T) {
 			server := httptest.NewServer(handler)
 
 			r := &mockStatsReporter{}
+			var resourceGroup string
+			if tc.isSource {
+				resourceGroup = "pubsub.events.cloud.google.com"
+			} else {
+				resourceGroup = "channels.messaging.cloud.google.com"
+			}
 			a := Adapter{
-				Project:      "proj",
-				Topic:        "topic",
-				Subscription: "sub",
-				SendMode:     converters.Binary,
-				reporter:     r,
+				Project:       "proj",
+				Topic:         "topic",
+				Subscription:  "sub",
+				SendMode:      converters.Binary,
+				reporter:      r,
+				ResourceGroup: resourceGroup,
 			}
 
 			var err error
@@ -373,11 +414,20 @@ func TestReceive(t *testing.T) {
 				t.Errorf("adapter.receiver got error %v want error %v", err, tc.wantErr)
 			}
 
+			options := make([]cmp.Option, 0)
 			ignoreSpanID := cmpopts.IgnoreMapEntries(func(n string, _ []string) bool {
 				return n == "X-B3-Spanid"
 			})
-			if diff := cmp.Diff(tc.wantHeader, gotHeader, ignoreSpanID); diff != "" {
-				t.Errorf("recevier got unexpected HTTP header (-want +got): %s", diff)
+			options = append(options, ignoreSpanID)
+			// If it's a source, it has no parent trace id, thus we ignore it when diffing.
+			if tc.isSource {
+				ignoreTraceID := cmpopts.IgnoreMapEntries(func(n string, _ []string) bool {
+					return n == "X-B3-Traceid"
+				})
+				options = append(options, ignoreTraceID)
+			}
+			if diff := cmp.Diff(tc.wantHeader, gotHeader, options...); diff != "" {
+				t.Errorf("receiver got unexpected HTTP header (-want +got): %s", diff)
 			}
 			if !bytes.Equal(tc.wantBody, gotBody) {
 				t.Errorf("receiver got HTTP body %v want %v", string(gotBody), string(tc.wantBody))


### PR DESCRIPTION
- Adding the span from trace parent only if it's a channel...
- For sources this is not needed, and we get plenty of info errors because of that.
- Also moved the log to Debug, but I'm OK to move it back to Info if @Harwayne prefers.