### PR TITLE
Fix performance tests

### DIFF
--- a/test/performance/benchmarks/broker-pubsub/continuous/200-broker-pubsub.yaml
+++ b/test/performance/benchmarks/broker-pubsub/continuous/200-broker-pubsub.yaml
@@ -39,29 +39,29 @@ spec:
           serviceAccountName: perf-pubsub
           restartPolicy: Never
           containers:
-            - name: sender-receiver
-              image: knative.dev/eventing/test/test_images/performance
-              args:
-                - "--roles=sender,receiver"
-                - "--sink=http://pubsub-broker"
-                - "--aggregator=broker-pubsub-aggregator:10000"
-                - "--pace=100:10,200:20,400:30,500:60,600:60"
-              env:
-                - name: POD_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.name
-                - name: POD_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-              resources:
-                requests:
-                  cpu: 1000m
-                  memory: 2Gi
-              ports:
-                - name: cloudevents
-                  containerPort: 8080
+          - name: sender-receiver
+            image: knative.dev/eventing/test/test_images/performance
+            args:
+              - "--roles=sender,receiver"
+              - "--sink=http://pubsub-broker"
+              - "--aggregator=broker-pubsub-aggregator:10000"
+              - "--pace=100:10,200:20,400:30,500:60,600:60"
+            env:
+              - name: POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: POD_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+            resources:
+              requests:
+                cpu: 1000m
+                memory: 2Gi
+            ports:
+              - name: cloudevents
+                containerPort: 8080
 
 ---
 
@@ -92,38 +92,38 @@ spec:
           serviceAccountName: perf-pubsub
           restartPolicy: Never
           containers:
-            - name: aggregator
-              image: knative.dev/eventing/test/test_images/performance
-              args:
-                - "--roles=aggregator"
-                # set to the number of sender + receiver (same image that does both counts 2)
-                - "--expect-records=2"
-                - "--mako-tags=channel=pubsub"
-                - "--benchmark-key=6592390798245888"
-                - "--benchmark-name=Development - PubSub Broker Latency & Throughput"
-              ports:
-                - name: grpc
-                  containerPort: 10000
-              resources:
-                requests:
-                  cpu: 1000m
-                  memory: 2Gi
-              volumeMounts:
-                - name: config-mako
-                  mountPath: /etc/config-mako
-              terminationMessagePolicy: FallbackToLogsOnError
-            - name: mako
-              image: gcr.io/knative-performance/mako-microservice:latest
-              env:
-                - name: GOOGLE_APPLICATION_CREDENTIALS
-                  value: /var/secret/robot.json
-              volumeMounts:
-                - name: mako-secrets
-                  mountPath: /var/secret
-              ports:
-                - name: quickstore
-                  containerPort: 9813
-              terminationMessagePolicy: FallbackToLogsOnError
+          - name: aggregator
+            image: knative.dev/eventing/test/test_images/performance
+            args:
+              - "--roles=aggregator"
+              # set to the number of sender + receiver (same image that does both counts 2)
+              - "--expect-records=2"
+              - "--mako-tags=channel=pubsub"
+              - "--benchmark-key=6592390798245888"
+              - "--benchmark-name=Development - PubSub Broker Latency & Throughput"
+            ports:
+              - name: grpc
+                containerPort: 10000
+            resources:
+              requests:
+                cpu: 1000m
+                memory: 2Gi
+            volumeMounts:
+              - name: config-mako
+                mountPath: /etc/config-mako
+            terminationMessagePolicy: FallbackToLogsOnError
+          - name: mako
+            image: gcr.io/knative-performance/mako-microservice:latest
+            env:
+              - name: GOOGLE_APPLICATION_CREDENTIALS
+                value: /var/secret/robot.json
+            volumeMounts:
+              - name: mako-secrets
+                mountPath: /var/secret
+            ports:
+              - name: quickstore
+                containerPort: 9813
+            terminationMessagePolicy: FallbackToLogsOnError
           volumes:
             - name: config-mako
               configMap:

--- a/test/performance/benchmarks/channel-pubsub/continuous/200-channel-perf.yaml
+++ b/test/performance/benchmarks/channel-pubsub/continuous/200-channel-perf.yaml
@@ -39,29 +39,29 @@ spec:
           serviceAccountName: perf-pubsub
           restartPolicy: Never
           containers:
-            - name: sender-receiver
-              image: knative.dev/eventing/test/test_images/performance
-              args:
-                - "--roles=sender,receiver"
-                - "--sink=http://cre-pubsub-test-channel-chan-publish.default.svc.cluster.local"
-                - "--aggregator=channel-perf-aggregator:10000"
-                - "--pace=100:10,200:20,400:30,500:60,600:60,700:60"
-              env:
-                - name: POD_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.name
-                - name: POD_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-              resources:
-                requests:
-                  cpu: 1000m
-                  memory: 2Gi
-              ports:
-                - name: cloudevents
-                  containerPort: 8080
+          - name: sender-receiver
+            image: knative.dev/eventing/test/test_images/performance
+            args:
+              - "--roles=sender,receiver"
+              - "--sink=http://cre-pubsub-test-channel-chan-publish.default.svc.cluster.local"
+              - "--aggregator=channel-perf-aggregator:10000"
+              - "--pace=100:10,200:20,400:30,500:60,600:60,700:60"
+            env:
+              - name: POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: POD_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+            resources:
+              requests:
+                cpu: 1000m
+                memory: 2Gi
+            ports:
+              - name: cloudevents
+                containerPort: 8080
 
 ---
 
@@ -92,38 +92,38 @@ spec:
           serviceAccountName: perf-pubsub
           restartPolicy: Never
           containers:
-            - name: aggregator
-              image: knative.dev/eventing/test/test_images/performance
-              args:
-                - "--roles=aggregator"
-                # set to the number of sender + receiver (same image that does both counts 2)
-                - "--expect-records=2"
-                - "--mako-tags=channel=pubsub"
-                - "--benchmark-key=6246352530964480"
-                - "--benchmark-name=Development - PubSub Channel Latency & Throughput"
-              ports:
-                - name: grpc
-                  containerPort: 10000
-              resources:
-                requests:
-                  cpu: 1000m
-                  memory: 2Gi
-              volumeMounts:
-                - name: config-mako
-                  mountPath: /etc/config-mako
-              terminationMessagePolicy: FallbackToLogsOnError
-            - name: mako
-              image: gcr.io/knative-performance/mako-microservice:latest
-              env:
-                - name: GOOGLE_APPLICATION_CREDENTIALS
-                  value: /var/secret/robot.json
-              volumeMounts:
-                - name: mako-secrets
-                  mountPath: /var/secret
-              ports:
-                - name: quickstore
-                  containerPort: 9813
-              terminationMessagePolicy: FallbackToLogsOnError
+          - name: aggregator
+            image: knative.dev/eventing/test/test_images/performance
+            args:
+              - "--roles=aggregator"
+              # set to the number of sender + receiver (same image that does both counts 2)
+              - "--expect-records=2"
+              - "--mako-tags=channel=pubsub"
+              - "--benchmark-key=6246352530964480"
+              - "--benchmark-name=Development - PubSub Channel Latency & Throughput"
+            ports:
+              - name: grpc
+                containerPort: 10000
+            resources:
+              requests:
+                cpu: 1000m
+                memory: 2Gi
+            volumeMounts:
+              - name: config-mako
+                mountPath: /etc/config-mako
+            terminationMessagePolicy: FallbackToLogsOnError
+          - name: mako
+            image: gcr.io/knative-performance/mako-microservice:latest
+            env:
+              - name: GOOGLE_APPLICATION_CREDENTIALS
+                value: /var/secret/robot.json
+            volumeMounts:
+              - name: mako-secrets
+                mountPath: /var/secret
+            ports:
+              - name: quickstore
+                containerPort: 9813
+            terminationMessagePolicy: FallbackToLogsOnError
           volumes:
             - name: config-mako
               configMap:

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -43,6 +43,10 @@ function install_knative_gcp_resources() {
 }
 
 function update_knative() {
+  pushd .
+  cd ${GOPATH} && mkdir -p src/knative.dev && cd src/knative.dev
+  git clone https://github.com/knative/eventing
+  popd
   start_latest_knative_eventing
   # Create the secret for pub-sub.
   kubectl -n ${TEST_NAMESPACE} create secret generic ${PUBSUB_SECRET_NAME} \

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -43,10 +43,6 @@ function install_knative_gcp_resources() {
 }
 
 function update_knative() {
-  pushd .
-  cd ${GOPATH} && mkdir -p src/knative.dev && cd src/knative.dev
-  git clone https://github.com/knative/eventing
-  popd
   start_latest_knative_eventing
   # Create the secret for pub-sub.
   kubectl -n ${TEST_NAMESPACE} create secret generic ${PUBSUB_SECRET_NAME} \
@@ -56,6 +52,10 @@ function update_knative() {
 
 function update_benchmark() {
   echo ">> Updating benchmark $1"
+  pushd .
+  cd ${GOPATH} && mkdir -p src/knative.dev && cd src/knative.dev
+  git clone https://github.com/knative/eventing
+  popd
   ko delete -f ${BENCHMARK_ROOT_PATH}/$1/${TEST_CONFIG_VARIANT} --ignore-not-found=true
   ko apply -f ${BENCHMARK_ROOT_PATH}/$1/${TEST_CONFIG_VARIANT} || abort "failed to apply benchmark $1"
 }


### PR DESCRIPTION
Since the image path in the benchmark cronjobs is a GOPATH, it needs to be existed on local when we `ko apply` the yaml.

Fix by `git clone` eventing before installing the benchmark.

/cc @nachocano 
/cc @capri-xiyue 