### PR TITLE
Rename clusterrole in 201-channelable-manipulator-clusterrole.yaml

### DIFF
--- a/config/201-channelable-manipulator-clusterrole.yaml
+++ b/config/201-channelable-manipulator-clusterrole.yaml
@@ -17,7 +17,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: events-channel-channelable-manipulator-resolver
+  name: events-channel-channelable-manipulator
   labels:
     events.cloud.google.com/release: devel
     duck.knative.dev/channelable: "true"

--- a/config/201-channelable-manipulator-clusterrole.yaml
+++ b/config/201-channelable-manipulator-clusterrole.yaml
@@ -17,7 +17,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: events-channel-manipulator-resolver
+  name: events-channel-channelable-manipulator-resolver
   labels:
     events.cloud.google.com/release: devel
     duck.knative.dev/channelable: "true"
@@ -27,6 +27,7 @@ rules:
       - messaging.cloud.google.com
     resources:
       - channels
+      - channels/status
     verbs:
       - create
       - get

--- a/config/201-channelable-manipulator-clusterrole.yaml
+++ b/config/201-channelable-manipulator-clusterrole.yaml
@@ -17,7 +17,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: events-channel-addressable-resolver
+  name: events-channel-manipulator-resolver
   labels:
     events.cloud.google.com/release: devel
     duck.knative.dev/channelable: "true"


### PR DESCRIPTION
Fixes #406 
## Proposed Changes

- Rename clusterrole in 201-channelable-manipulator-clusterrole.yaml

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```
