### PR TITLE
Rename clusterrole in 201-channelable-manipulator-clusterrole.yaml(cherry-pick)

### DIFF
--- a/config/201-channelable-manipulator-clusterrole.yaml
+++ b/config/201-channelable-manipulator-clusterrole.yaml
@@ -17,7 +17,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: events-channel-addressable-resolver
+  name: events-channel-channelable-manipulator
   labels:
     events.cloud.google.com/release: devel
     duck.knative.dev/channelable: "true"
@@ -27,6 +27,7 @@ rules:
       - messaging.cloud.google.com
     resources:
       - channels
+      - channels/status
     verbs:
       - create
       - get


### PR DESCRIPTION
## Proposed Changes

* Rename clusterrole in 201-channelable-manipulator-clusterrole.yaml

* renamed to keep it consistency with knative eventing

* fixed typo