### PR TITLE
Update to conform with the latest performance test infra

### DIFF
--- a/test/lib.sh
+++ b/test/lib.sh
@@ -31,6 +31,11 @@ function cloud_run_events_setup() {
   # Install the latest Cloud Run Events in the current cluster.
   header "Starting Cloud Run Events"
   subheader "Installing Cloud Run Events"
+  pushd .
+  cd ${GOPATH} && mkdir -p src/github.com/google && cd src/github.com/google
+  git clone https://github.com/google/knative-gcp
+  popd
+
   ko apply -f ${CLOUD_RUN_EVENTS_CONFIG} || return 1
   wait_until_pods_running cloud-run-events || return 1
 }

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -31,11 +31,6 @@ function cloud_run_events_setup() {
   # Install the latest Cloud Run Events in the current cluster.
   header "Starting Cloud Run Events"
   subheader "Installing Cloud Run Events"
-  pushd .
-  cd ${GOPATH} && mkdir -p src/github.com/google && cd src/github.com/google
-  git clone https://github.com/google/knative-gcp
-  popd
-
   ko apply -f ${CLOUD_RUN_EVENTS_CONFIG} || return 1
   wait_until_pods_running cloud-run-events || return 1
 }

--- a/test/performance/benchmarks/broker-pubsub/continuous/100-broker-pubsub-setup.yaml
+++ b/test/performance/benchmarks/broker-pubsub/continuous/100-broker-pubsub-setup.yaml
@@ -12,43 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-mako
-  namespace: default
-
-data:
-  _example: |
-    ################################
-    #                              #
-    #    EXAMPLE CONFIGURATION     #
-    #                              #
-    ################################
-
-    # This block is not actually functional configuration,
-    # but serves to illustrate the available configuration
-    # options and document them in a way that is accessible
-    # to users that `kubectl edit` this config map.
-    #
-    # These sample configuration options may be copied out of
-    # this example block and unindented to be in the data block
-    # to actually change the configuration.
-
-    # The Mako environment in which we are running.
-    # Only our performance automation should run in "prod", but
-    # there should be a "dev" environment with a fairly broad
-    # write ACL.  Users can also develop against custom configurations
-    # by adding `foo.config` under their benchmark's kodata directory.
-    environment: dev
-
-    # Additional tags to tag the runs. These tags are added
-    # to the list that the binary itself publishes (Kubernetes version, etc).
-    # It is a comma separated list of tags.
-    additionalTags: "key=value,absolute"
-
----
-
 apiVersion: eventing.knative.dev/v1alpha1
 kind: Broker
 metadata:

--- a/test/performance/benchmarks/broker-pubsub/continuous/200-broker-pubsub.yaml
+++ b/test/performance/benchmarks/broker-pubsub/continuous/200-broker-pubsub.yaml
@@ -99,8 +99,6 @@ spec:
               # set to the number of sender + receiver (same image that does both counts 2)
               - "--expect-records=2"
               - "--mako-tags=channel=pubsub"
-              - "--benchmark-key=6592390798245888"
-              - "--benchmark-name=Development - PubSub Broker Latency & Throughput"
             ports:
               - name: grpc
                 containerPort: 10000

--- a/test/performance/benchmarks/broker-pubsub/dev.config
+++ b/test/performance/benchmarks/broker-pubsub/dev.config
@@ -1,12 +1,12 @@
-### Creating this benchmark:
-# mako create_benchmark test/performance/broker-pubsub/continuous/dev.config
-### Updating this benchmark:
-# mako update_benchmark test/performance/broker-pubsub/continuous/dev.config
+# Create this benchmark with the mako tool: mako create_benchmark dev.config
+# Update this benchmark with the mako tool: mako update_benchmark dev.config
+# Learn more about the mako tool at
+# https://github.com/google/mako/blob/master/docs/CLI.md.
 
 project_name: "Knative"
 benchmark_name: "Development - PubSub Broker Latency & Throughput"
 description: "Measure latency and throughput of the broker using various channels."
-benchmark_key: '6592390798245888'
+benchmark_key: '5613587219349504'
 
 # Human owners for manual benchmark adjustments.
 owner_list: "grantrodgers@google.com"
@@ -58,6 +58,10 @@ metric_info_list: {
   label: "deliver-throughput"
 }
 metric_info_list: {
-  value_key: "ft"
-  label: "failure-throughput"
+  value_key: "pet"
+  label: "publish-failure-throughput"
+}
+metric_info_list: {
+  value_key: "det"
+  label: "deliver-failure-throughput"
 }

--- a/test/performance/benchmarks/broker-pubsub/prod.config
+++ b/test/performance/benchmarks/broker-pubsub/prod.config
@@ -1,12 +1,12 @@
-# Create this benchmark with the mako tool: mako create_benchmark dev.config
-# Update this benchmark with the mako tool: mako update_benchmark dev.config
+# Create this benchmark with the mako tool: mako create_benchmark prod.config
+# Update this benchmark with the mako tool: mako update_benchmark prod.config
 # Learn more about the mako tool at
 # https://github.com/google/mako/blob/master/docs/CLI.md.
 
 project_name: "Knative"
-benchmark_name: "Development - PubSub Channel Latency & Throughput"
-description: "Measure latency and throughput of channels."
-benchmark_key: '6736782773190656'
+benchmark_name: "PubSub Broker Latency & Throughput"
+description: "Measure latency and throughput of the broker using various channels."
+benchmark_key: '6592390798245888'
 
 # Human owners for manual benchmark adjustments.
 owner_list: "grantrodgers@google.com"
@@ -18,11 +18,6 @@ owner_list: "cshou@google.com"
 
 # Anyone can add their IAM robot here to publish to this benchmark.
 owner_list: "mako-job@knative-performance.iam.gserviceaccount.com"
-# This is grantrodgers' robot:
-owner_list: "mako-upload@grantrodgers-crd.iam.gserviceaccount.com"
-owner_list: "mako-upload@xiyue-knative-project.iam.gserviceaccount.com"
-owner_list: "mako-upload@gracegao-knative-gcp-testing.iam.gserviceaccount.com"
-owner_list: "mako-upload@cshou-playground.iam.gserviceaccount.com"
 
 # Define the name and type for x-axis of run charts
 input_value_info: {

--- a/test/performance/benchmarks/channel-pubsub/continuous/100-channel-perf-setup.yaml
+++ b/test/performance/benchmarks/channel-pubsub/continuous/100-channel-perf-setup.yaml
@@ -13,39 +13,6 @@
 # limitations under the License.
 
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-mako
-  namespace: default
-
-data:
-  _example: |
-    ################################
-    #                              #
-    #    EXAMPLE CONFIGURATION     #
-    #                              #
-    ################################
-    # This block is not actually functional configuration,
-    # but serves to illustrate the available configuration
-    # options and document them in a way that is accessible
-    # to users that `kubectl edit` this config map.
-    #
-    # These sample configuration options may be copied out of
-    # this example block and unindented to be in the data block
-    # to actually change the configuration.
-    # The Mako environment in which we are running.
-    # Only our performance automation should run in "prod", but
-    # there should be a "dev" environment with a fairly broad
-    # write ACL.  Users can also develop against custom configurations
-    # by adding `foo.config` under their benchmark's kodata directory.
-    environment: dev
-    # Additional tags to tag the runs. These tags are added
-    # to the list that the binary itself publishes (Kubernetes version, etc).
-    # It is a comma separated list of tags.
-    additionalTags: "key=value,absolute"
----
-
-apiVersion: v1
 kind: Service
 metadata:
   name: channel-perf-consumer

--- a/test/performance/benchmarks/channel-pubsub/continuous/200-channel-perf.yaml
+++ b/test/performance/benchmarks/channel-pubsub/continuous/200-channel-perf.yaml
@@ -99,8 +99,6 @@ spec:
               # set to the number of sender + receiver (same image that does both counts 2)
               - "--expect-records=2"
               - "--mako-tags=channel=pubsub"
-              - "--benchmark-key=6246352530964480"
-              - "--benchmark-name=Development - PubSub Channel Latency & Throughput"
             ports:
               - name: grpc
                 containerPort: 10000

--- a/test/performance/benchmarks/channel-pubsub/prod.config
+++ b/test/performance/benchmarks/channel-pubsub/prod.config
@@ -1,12 +1,12 @@
-# Create this benchmark with the mako tool: mako create_benchmark dev.config
-# Update this benchmark with the mako tool: mako update_benchmark dev.config
+# Create this benchmark with the mako tool: mako create_benchmark prod.config
+# Update this benchmark with the mako tool: mako update_benchmark prod.config
 # Learn more about the mako tool at
 # https://github.com/google/mako/blob/master/docs/CLI.md.
 
 project_name: "Knative"
-benchmark_name: "Development - PubSub Channel Latency & Throughput"
+benchmark_name: "PubSub Channel Latency & Throughput"
 description: "Measure latency and throughput of channels."
-benchmark_key: '6736782773190656'
+benchmark_key: '6246352530964480'
 
 # Human owners for manual benchmark adjustments.
 owner_list: "grantrodgers@google.com"
@@ -18,11 +18,6 @@ owner_list: "cshou@google.com"
 
 # Anyone can add their IAM robot here to publish to this benchmark.
 owner_list: "mako-job@knative-performance.iam.gserviceaccount.com"
-# This is grantrodgers' robot:
-owner_list: "mako-upload@grantrodgers-crd.iam.gserviceaccount.com"
-owner_list: "mako-upload@xiyue-knative-project.iam.gserviceaccount.com"
-owner_list: "mako-upload@gracegao-knative-gcp-testing.iam.gserviceaccount.com"
-owner_list: "mako-upload@cshou-playground.iam.gserviceaccount.com"
 
 # Define the name and type for x-axis of run charts
 input_value_info: {

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -20,8 +20,7 @@
 
 # Setup env vars to override the default settings
 export PROJECT_NAME="knative-eventing-performance"
-#export BENCHMARK_ROOT_PATH="$GOPATH/src/github.com/google/knative-gcp/test/performance/benchmarks"
-export BENCHMARK_ROOT_PATH="$GOPATH/src/github.com/chizhg/knative-gcp/test/performance/benchmarks"
+export BENCHMARK_ROOT_PATH="$GOPATH/src/github.com/google/knative-gcp/test/performance/benchmarks"
 
 source vendor/knative.dev/test-infra/scripts/performance-tests.sh
 source $(dirname $0)/../lib.sh


### PR DESCRIPTION
Update to conform with the latest performance test infra, basically the same as what we changed in eventing in https://github.com/knative/eventing/pull/2213 and https://github.com/knative/eventing/pull/2215

I have tested these changes:
PubSub Channel - https://mako.dev/run?run_key=4985480196128768&~pl=1&~pe=1&~st=1&~dl=1&~de=1&~dt=1&~pet=1&~det=1
PubSub Broker - https://mako.dev/run?run_key=6300670921539584&~pl=1&~pe=1&~st=1&~dl=1&~de=1&~dt=1&~pet=1&~det=1

/cc @grantr 
/cc @nachocano 