### PR TITLE
Updating install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ independently, but is best mixed with [Knative](https://knative.dev).
 
 To get started, [install Knative with GCP](./docs/install/README.md).
 
-Then use one of the implemented `Source` resource,
+Then use one of the implemented Sources:
 
+- [PubSub (events.cloud.google.com)](docs/pubsub/README.md)
 - [Storage (events.cloud.google.com)](docs/storage/README.md)
 - [Scheduler (events.cloud.google.com)](docs/scheduler/README.md)
 
@@ -19,10 +20,10 @@ To use a Knative Eventing Channel backed by Pub/Sub:
 
 - [Channel (messaging.cloud.google.com)](docs/channel/README.md)
 
-To leverage Pub/Sub directly, Pub/Sub resources:
+To leverage Pub/Sub directly, use one of the Pub/Sub resources:
 
 - [PullSubscription (pubsub.cloud.google.com)](docs/pullsubscription/README.md)
 - [Topic (pubsub.cloud.google.com)](docs/topic/README.md)
 
-_Note:_ This repo is still in development apis and resource names are subject to
-change in the future.
+
+_Note:_ This repo is still in development, APIs and resource names are subject to change in the future.

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -1,57 +1,93 @@
-## Installing Knative with GCP
+# Installing Knative with GCP
 
-To install Knative with GCP from master,
+1. Create a
+   [Google Cloud project](https://cloud.google.com/resource-manager/docs/creating-managing-projects)
+   and install the `gcloud` CLI and run `gcloud auth login`. This guide will
+   use a mix of `gcloud` and `kubectl` commands. The rest of the guide assumes
+   that you've set the `PROJECT_ID` environment variable to your Google Cloud
+   project id, and also set your project ID as default using
+   `gcloud config set project $PROJECT_ID`.
 
-### Using [ko](http://github.com/google/ko)
+1. Install [Knative](https://knative.dev/docs/install/). Preferably, set up both [Serving](https://knative.dev/docs/serving/)
+   and [Eventing](https://knative.dev/docs/eventing/). The latter is only required if you want to use the Pub/Sub `Channel`.  
 
-```shell
-ko apply -f ./config
-```
+1. Create the `cloud-run-events` namespace. This is the namespace where our control plane pods run.
 
-Applying the `config` dir will:
+     ```shell
+     kubectl create namespace cloud-run-events
+     ```
 
-- create a new namespace, `cloud-run-events`.
-- install new CRDs,
-  - `channel.messaging.cloud.google.com`
-  - `storages.events.cloud.google.com`
-  - `pullsubscriptions.pubsub.cloud.google.com`
-  - `topics.pubsub.cloud.google.com`
-- install a controller to operate on the new resources,
-  `cloud-run-events/cloud-run-events-controller`.
-- install a new service account, `cloud-run-events/cloud-run-events-controller`.
-- provide RBAC for that service account.
+1.  Create a [Google Cloud Service Account](https://console.cloud.google.com/iam-admin/serviceaccounts/project) with the
+    appropriate permissions needed for the control plane to manage native GCP resources.
+    
+    1. Create a new Service Account named `cloud-run-events` with the following command:
+        
+        ```shell
+        gcloud iam service-accounts create cloud-run-events
+        ```
 
-## Uninstalling Knative with GCP
+    1. Give that Service Account permissions on your project. The actual permissions needed will depend on the resources you 
+       are planning to use. The Table below enumerates such permissions:
+       
+        |     Resource     	|            Roles           	|
+        |:----------------:	|:--------------------------:	|
+        |      PubSub      	|     roles/pubsub.editor    	|
+        |      Storage     	|     roles/storage.admin    	|
+        |     Scheduler    	| roles/cloudscheduler.admin 	|
+        |      Channel     	|     roles/pubsub.editor    	|
+        | PullSubscription 	|     roles/pubsub.editor    	|
+        |       Topic      	|     roles/pubsub.editor    	|
+       
+       In this guide, and for the sake of simplicity, we will just grant `roles/editor` privileges to the Service Account,
+       which encompasses all of the above plus some other permissions. Note that if you prefer finer-grained privileges,
+       you can just grant the ones described in the Table.
+        
+        ```shell
+        gcloud projects add-iam-policy-binding $PROJECT_ID \
+          --member=serviceAccount:cloud-run-events@$PROJECT_ID.iam.gserviceaccount.com \
+          --role roles/editor
+        ```
 
-### Using [ko](http://github.com/google/ko)
+    1.  Download a new JSON private key for that Service Account. **Be sure not to check this key into source control!**
+    
+        ```shell
+        gcloud iam service-accounts keys create cloud-run-events.json \
+        --iam-account=cloud-run-events@$PROJECT_ID.iam.gserviceaccount.com
+        ```
 
-```shell
-ko delete -f ./config
-```
+    1.  Create a Secret on the Kubernetes cluster in the `cloud-run-events` namespace with the downloaded key:
+    
+        ```shell
+        kubectl --namespace cloud-run-events create secret generic google-cloud-key --from-file=key.json=cloud-run-events.json
+        ```
+    
+        Note that `google-cloud-key` and `key.json` are default values expected by our control plane.
 
-### Using [releases](https://github.com/google/knative-gcp/releases)
+1. Finally, install the Knative-GCP constructs. You can either:
 
-```shell
-kubectl apply --filename https://github.com/google/knative-gcp/releases/download/v0.9.0/cloud-run-events.yaml
-```
+    - Install from master using [ko](http://github.com/google/ko)
+        
+        ```shell
+        ko apply -f ./config
+        ```
+    OR
+    - Install a [release](https://github.com/google/knative-gcp/releases). Remember to update `{{< version >}}` in the
+      commands below with the appropriate release version.
 
-Applying the `config` dir will:
-
-- create a new namespace, `cloud-run-events`.
-- install new CRDs,
-  - `channel.messaging.cloud.google.com`
-  - `storages.events.cloud.google.com`
-  - `pullsubscriptions.pubsub.cloud.google.com`
-  - `topics.pubsub.cloud.google.com`
-- install a controller to operate on the new resources,
-  `cloud-run-events/cloud-run-events-controller`.
-- install a new service account, `cloud-run-events/cloud-run-events-controller`.
-- provide RBAC for that service account.
-
-## Uninstalling Knative with GCP
-
-### Using [ko](http://github.com/google/ko)
-
-```shell
-kubectl delete --filename https://github.com/google/knative-gcp/releases/download/v0.9.0/cloud-run-events.yaml
-```
+       1. First install the CRDs by running the `kubectl apply`
+          command with the `--selector` flag. This prevents race conditions during the install, which cause intermittent errors:
+    
+            ```shell
+            kubectl apply --selector pubsub.cloud.google.com/crd-install=true \
+            --filename https://github.com/google/knative-gcp/releases/download/{{< version >}}/cloud-run-events.yaml            
+            kubectl apply --selector messaging.cloud.google.com/crd-install=true \
+            --filename https://github.com/google/knative-gcp/releases/download/{{< version >}}/cloud-run-events.yaml            
+            kubectl apply --selector events.cloud.google.com/crd-install=true \
+            --filename https://github.com/google/knative-gcp/releases/download/{{< version >}}/cloud-run-events.yaml
+            ```
+    
+        1. To complete the install run the `kubectl apply` command again, this time without the `--selector` flags:
+    
+            ```shell
+            kubectl apply --filename https://github.com/google/knative-gcp/releases/download/{{< version >}}/cloud-run-events.yaml            
+            ```


### PR DESCRIPTION
Fixes https://github.com/google/knative-gcp/issues/456

## Proposed Changes

- Updating installation of knative-gcp. Properly documenting about the creation of the control plane secret

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Check out the new installation instructions. You will need a secret in the `cloud-run-events` namespace in order for the controller to start
```
