### PR TITLE
Add missed secret for performance test setup

### DIFF
--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -29,13 +29,24 @@ source $(dirname $0)/../lib.sh
 readonly TEST_CONFIG_VARIANT="continuous"
 readonly TEST_NAMESPACE="default"
 readonly PUBSUB_SECRET_NAME="google-cloud-key"
+readonly CONTROL_PLANE_NAMESPACE="cloud-run-events"
+readonly CONTROL_PLANE_SECRET_NAME="google-cloud-key"
 
 function update_knative() {
   start_knative_gcp
   # Create the secret for pub-sub if it does not exist.
   kubectl -n ${TEST_NAMESPACE} get secret ${PUBSUB_SECRET_NAME} || \
   kubectl -n ${TEST_NAMESPACE} create secret generic ${PUBSUB_SECRET_NAME} \
-    --from-file=key.json=${GOOGLE_APPLICATION_CREDENTIALS}
+    --from-file=key.json="${GOOGLE_APPLICATION_CREDENTIALS}"
+
+  # Create the control-plane namespace if it does not exist.
+  kubectl get namespace ${CONTROL_PLANE_NAMESPACE} || \
+    kubectl create namespace ${CONTROL_PLANE_NAMESPACE}
+
+  # Create the secret for control-plane if it does not exist.
+  kubectl -n ${CONTROL_PLANE_NAMESPACE} get secret ${CONTROL_PLANE_SECRET_NAME} || \
+  kubectl -n ${CONTROL_PLANE_NAMESPACE} create secret generic ${CONTROL_PLANE_SECRET_NAME} \
+    --from-file=key.json="${GOOGLE_APPLICATION_CREDENTIALS}"
 }
 
 function update_benchmark() {


### PR DESCRIPTION
Fixes #463 

## Proposed Changes
By following the setups in e2e tests, create the control-plane secret in performance tests

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @nachocano 
/cc @grantr 
