### PR TITLE
Add dummy secret so that the controller pod can at least start

### DIFF
--- a/config/200-dummy-secret.yaml
+++ b/config/200-dummy-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: google-cloud-key
+  namespace: cloud-run-events
+type: Opaque
+data:
+  # Base64 "dummy".
+  key.json: ZHVtbXkK

--- a/config/200-dummy-secret.yaml
+++ b/config/200-dummy-secret.yaml
@@ -1,3 +1,23 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# The dummy secret is a placeholder for the google-cloud-key secret. This
+# secret should be patched with an actual GCP Service Account Key after the
+# installation.
+#
+# The controller mounts the secret as a GCP Service Account Key, which
+# is used to provision GCP resources (e.g. PubSub topic).
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,4 +26,5 @@ metadata:
 type: Opaque
 data:
   # Base64 "dummy".
+  # Shoud be replaced with a real GCP service account key.
   key.json: ZHVtbXkK


### PR DESCRIPTION
Fixes https://github.com/google/knative-gcp/issues/468

## Proposed Changes
Add a dummy secret for the controller pod to mount.
