### PR TITLE
Update path to event-display image in examples

### DIFF
--- a/docs/channel/event-display.yaml
+++ b/docs/channel/event-display.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: user-container
-        image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display@sha256:bf45b3eb1e7fc4cb63d6a5a6416cf696295484a7662e0cf9ccdf5c080542c21d
+        image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:070f31589d919779a83adf3cc0f0b0e3f5f063eb57a67d53e5e8d0c5eefb57ba
         ports:
         - containerPort: 8080
 

--- a/docs/pullsubscription/event-display.yaml
+++ b/docs/pullsubscription/event-display.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: user-container
-        image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display@sha256:bf45b3eb1e7fc4cb63d6a5a6416cf696295484a7662e0cf9ccdf5c080542c21d
+        image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:070f31589d919779a83adf3cc0f0b0e3f5f063eb57a67d53e5e8d0c5eefb57ba
         ports:
         - containerPort: 8080
 

--- a/docs/scheduler/event-display.yaml
+++ b/docs/scheduler/event-display.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: user-container
-        image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display@sha256:bf45b3eb1e7fc4cb63d6a5a6416cf696295484a7662e0cf9ccdf5c080542c21d
+        image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:070f31589d919779a83adf3cc0f0b0e3f5f063eb57a67d53e5e8d0c5eefb57ba
         ports:
         - containerPort: 8080
 

--- a/docs/storage/event-display.yaml
+++ b/docs/storage/event-display.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: user-container
-        image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display@sha256:bf45b3eb1e7fc4cb63d6a5a6416cf696295484a7662e0cf9ccdf5c080542c21d
+        image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:070f31589d919779a83adf3cc0f0b0e3f5f063eb57a67d53e5e8d0c5eefb57ba
         ports:
         - containerPort: 8080
 


### PR DESCRIPTION
## Proposed Changes

-The event-display.yaml examples all have stale images that are no longer
compatible with the scheduler event encoding. Adding the url for the new
image for the event-display.yaml.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
/cc @chizhg @grantr @capri-xiyue 