### PR TITLE
Update test-infra to latest

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1531,14 +1531,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e4a2fd481bd2d6dcac5ae03c55d6104a0953d0a78cb45fdd4d20a116ed2a5218"
+  digest = "1:4ba0f80b3feed917d2c9a1aa79ea95836c3aef84589431cff77ffd01615a1150"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "e381f11dc722330fe082158e2f22cd39f8fe8375"
+  revision = "d5990f0e5a05d5819a40ad3b4de6227406850b48"
 
 [[projects]]
   digest = "1:8730e0150dfb2b7e173890c8b9868e7a273082ef8e39f4940e3506a481cf895c"

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -41,26 +41,3 @@ function istio_patch() {
   header "Patching Istio"
   kubectl apply -f test/e2e/config/istio-patch/istio-knative-extras.yaml
 }
-
-# Install Knative Eventing in the current cluster.
-# Parameters: $1 - Knative Eventing manifest.
-function start_knative_eventing() {
-  header "Starting Knative Eventing"
-  subheader "Installing Knative Eventing"
-  echo "Installing Eventing CRDs from $1"
-  kubectl apply --selector knative.dev/crd-install=true -f "$1"
-  echo "Installing the rest of eventing components from $1"
-  kubectl apply -f "$1"
-  wait_until_pods_running knative-eventing || return 1
-}
-
-# Install the stable release Knative/eventing in the current cluster.
-# Parameters: $1 - Knative Eventing version number, e.g. 0.6.0.
-function start_release_knative_eventing() {
-  start_knative_eventing "https://storage.googleapis.com/knative-releases/eventing/previous/v$1/eventing.yaml"
-}
-
-# Install the latest stable Knative Eventing in the current cluster.
-function start_latest_knative_eventing() {
-  start_knative_eventing "${KNATIVE_EVENTING_RELEASE}"
-}

--- a/vendor/knative.dev/test-infra/scripts/README.md
+++ b/vendor/knative.dev/test-infra/scripts/README.md
@@ -68,9 +68,7 @@ tests to be executed, in the right order (i.e., build, then unit, then
 integration tests).
 
 Use the flags `--build-tests`, `--unit-tests` and `--integration-tests` to run a
-specific set of tests. The flag `--emit-metrics` is used to emit metrics when
-running the tests, and is automatically handled by the default action for
-integration tests (see above).
+specific set of tests.
 
 To run a specific program as a test, use the `--run-test` flag, and provide the
 program as the argument. If arguments are required for the program, pass
@@ -167,12 +165,7 @@ This is a helper script for Knative E2E test scripts. To use it:
    (or `report_go_test()` if you need a more fine-grained control) and call
    `fail_test()` or `success()` if any of them failed. The environment variable
    `KO_DOCKER_REPO` and `E2E_PROJECT_ID` will be set according to the test
-   cluster. You can also use the following boolean (0 is false, 1 is true)
-   environment variables for the logic:
-
-   - `EMIT_METRICS`: true if `--emit-metrics` was passed.
-
-   All environment variables above are marked read-only.
+   cluster.
 
 **Notes:**
 

--- a/vendor/knative.dev/test-infra/scripts/e2e-tests.sh
+++ b/vendor/knative.dev/test-infra/scripts/e2e-tests.sh
@@ -81,7 +81,6 @@ function teardown_test_resources() {
 function go_test_e2e() {
   local test_options=""
   local go_options=""
-  (( EMIT_METRICS )) && test_options="-emitmetrics"
   [[ ! " $@" == *" -tags="* ]] && go_options="-tags=e2e"
   report_go_test -v -race -count=1 ${go_options} $@ ${test_options}
 }
@@ -228,7 +227,6 @@ function create_test_cluster() {
   echo "Test script is ${E2E_SCRIPT}"
   # Set arguments for this script again
   local test_cmd_args="--run-tests"
-  (( EMIT_METRICS )) && test_cmd_args+=" --emit-metrics"
   (( SKIP_KNATIVE_SETUP )) && test_cmd_args+=" --skip-knative-setup"
   [[ -n "${GCP_PROJECT}" ]] && test_cmd_args+=" --gcp-project ${GCP_PROJECT}"
   [[ -n "${E2E_SCRIPT_CUSTOM_FLAGS[@]}" ]] && test_cmd_args+=" ${E2E_SCRIPT_CUSTOM_FLAGS[@]}"
@@ -419,7 +417,6 @@ function fail_test() {
 }
 
 RUN_TESTS=0
-EMIT_METRICS=0
 SKIP_KNATIVE_SETUP=0
 SKIP_ISTIO_ADDON=0
 GCP_PROJECT=""
@@ -455,7 +452,6 @@ function initialize() {
     # Try parsing flag as a standard one.
     case ${parameter} in
       --run-tests) RUN_TESTS=1 ;;
-      --emit-metrics) EMIT_METRICS=1 ;;
       --skip-knative-setup) SKIP_KNATIVE_SETUP=1 ;;
       --skip-istio-addon) SKIP_ISTIO_ADDON=1 ;;
       *)
@@ -486,7 +482,6 @@ function initialize() {
   (( SKIP_ISTIO_ADDON )) || GKE_ADDONS="--addons=Istio"
 
   readonly RUN_TESTS
-  readonly EMIT_METRICS
   readonly GCP_PROJECT
   readonly IS_BOSKOS
   readonly EXTRA_CLUSTER_CREATION_FLAGS

--- a/vendor/knative.dev/test-infra/scripts/library.sh
+++ b/vendor/knative.dev/test-infra/scripts/library.sh
@@ -426,9 +426,7 @@ function start_knative_monitoring() {
   # mentioned in
   # https://github.com/knative/serving/blob/4202efc0dc12052edc0630515b101cbf8068a609/config/monitoring/tracing/zipkin/100-zipkin.yaml#L21
   kubectl create namespace istio-system 2>/dev/null
-  echo "Installing Monitoring CRDs from $1"
-  kubectl apply --selector knative.dev/crd-install=true -f "$1" || return 1
-  echo "Installing the rest of monitoring components from $1"
+  echo "Installing Monitoring from $1"
   kubectl apply -f "$1" || return 1
   wait_until_pods_running knative-monitoring || return 1
   wait_until_pods_running istio-system || return 1
@@ -443,6 +441,29 @@ function start_release_knative_serving() {
 # Install the latest stable Knative Serving in the current cluster.
 function start_latest_knative_serving() {
   start_knative_serving "${KNATIVE_SERVING_RELEASE}"
+}
+
+# Install Knative Eventing in the current cluster.
+# Parameters: $1 - Knative Eventing manifest.
+function start_knative_eventing() {
+  header "Starting Knative Eventing"
+  subheader "Installing Knative Eventing"
+  echo "Installing Eventing CRDs from $1"
+  kubectl apply --selector knative.dev/crd-install=true -f "$1"
+  echo "Installing the rest of eventing components from $1"
+  kubectl apply -f "$1"
+  wait_until_pods_running knative-eventing || return 1
+}
+
+# Install the stable release Knative/eventing in the current cluster.
+# Parameters: $1 - Knative Eventing version number, e.g. 0.6.0.
+function start_release_knative_eventing() {
+  start_knative_eventing "https://storage.googleapis.com/knative-releases/eventing/previous/v$1/release.yaml"
+}
+
+# Install the latest stable Knative Eventing in the current cluster.
+function start_latest_knative_eventing() {
+  start_knative_eventing "${KNATIVE_EVENTING_RELEASE}"
 }
 
 # Run a go tool, installing it first if necessary.
@@ -617,5 +638,5 @@ readonly REPO_NAME_FORMATTED="Knative $(capitalize ${REPO_NAME//-/ })"
 
 # Public latest nightly or release yaml files.
 readonly KNATIVE_SERVING_RELEASE="$(get_latest_knative_yaml_source "serving" "serving")"
-readonly KNATIVE_EVENTING_RELEASE="$(get_latest_knative_yaml_source "eventing" "release")"
+readonly KNATIVE_EVENTING_RELEASE="$(get_latest_knative_yaml_source "eventing" "eventing")"
 readonly KNATIVE_MONITORING_RELEASE="$(get_latest_knative_yaml_source "serving" "monitoring")"

--- a/vendor/knative.dev/test-infra/scripts/presubmit-tests.sh
+++ b/vendor/knative.dev/test-infra/scripts/presubmit-tests.sh
@@ -156,8 +156,10 @@ function default_build_test_runner() {
   markdown_build_tests || failed=1
   # For documentation PRs, just check the md files
   (( IS_DOCUMENTATION_PR )) && return ${failed}
+  # Don't merge these two lines, or return code will always be 0.
+  local go_pkg_dirs
+  go_pkg_dirs="$(go list ./...)" || return 1
   # Skip build test if there is no go code
-  local go_pkg_dirs="$(go list ./...)"
   [[ -z "${go_pkg_dirs}" ]] && return ${failed}
   # Ensure all the code builds
   subheader "Checking that go code builds"
@@ -267,7 +269,6 @@ function run_integration_tests() {
 function default_integration_test_runner() {
   local options=""
   local failed=0
-  (( EMIT_METRICS )) && options="--emit-metrics"
   for e2e_test in $(find test/ -name e2e-*tests.sh); do
     echo "Running integration test ${e2e_test}"
     if ! ${e2e_test} ${options}; then
@@ -281,7 +282,6 @@ function default_integration_test_runner() {
 RUN_BUILD_TESTS=0
 RUN_UNIT_TESTS=0
 RUN_INTEGRATION_TESTS=0
-EMIT_METRICS=0
 
 # Process flags and run tests accordingly.
 function main() {
@@ -333,7 +333,6 @@ function main() {
       --build-tests) RUN_BUILD_TESTS=1 ;;
       --unit-tests) RUN_UNIT_TESTS=1 ;;
       --integration-tests) RUN_INTEGRATION_TESTS=1 ;;
-      --emit-metrics) EMIT_METRICS=1 ;;
       --all-tests)
         RUN_BUILD_TESTS=1
         RUN_UNIT_TESTS=1
@@ -352,7 +351,6 @@ function main() {
   readonly RUN_BUILD_TESTS
   readonly RUN_UNIT_TESTS
   readonly RUN_INTEGRATION_TESTS
-  readonly EMIT_METRICS
   readonly TEST_TO_RUN
 
   cd ${REPO_ROOT_DIR}


### PR DESCRIPTION
## Proposed Changes
- The release file of eventing has been changed from `release.yaml` to `eventing.yaml`. Update test-infra to latest to pick up that change when install eventing.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @nachocano 
/cc @capri-xiyue 
