### PR TITLE
CloudPubSubSource to Push mode

### DIFF
--- a/docs/examples/cloudauditlogssource/README.md
+++ b/docs/examples/cloudauditlogssource/README.md
@@ -79,8 +79,8 @@ Context Attributes,
   specversion: 1.0
   type: com.google.cloud.auditlog.event
   source: pubsub.googleapis.com/projects/test
-  subject: pubsub.googleapis.com/projects/test/topics/test-auditlogs-source
-  id: 8c2iznd54odprojects/test/logs/cloudaudit.googleapis.com%2Factivity2020-01-07T20:56:30.516179081Z
+  subject: projects/test/topics/test-auditlogs-source
+  id: efdb9bf7d6fdfc922352530c1ba51242
   time: 2020-01-07T20:56:30.516179081Z
   dataschema: type.googleapis.com/google.logging.v2.LogEntry
   datacontenttype: application/json

--- a/docs/examples/cloudpubsubsource/README.md
+++ b/docs/examples/cloudpubsubsource/README.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-This sample shows how to configure the CloudPubSubSource. CloudPubSubSource fires a new event each time a message is published on a [Google Cloud Platform PubSub topic](https://cloud.google.com/pubsub/).
+This sample shows how to configure `CloudPubSubSources`. 
+The `CloudPubSubSource` fires a new event each time a message is published on a [Cloud Pub/Sub topic](https://cloud.google.com/pubsub/). 
+This source sends events using a Push-compatible format.
 
 ## Prerequisites
 
@@ -68,18 +70,30 @@ Validation: valid
 Context Attributes,
   specversion: 1.0
   type: com.google.cloud.pubsub.topic.publish
-  source: //pubsub.googleapis.com/projects/xiyue-knative-gcp/topics/testing
-  id: 946366448650699
-  time: 2020-01-21T22:12:06.742Z
-  datacontenttype: application/octet-stream
+  source: //pubsub.googleapis.com/projects/PROJECT_ID/topics/TOPIC_NAME
+  id: 951049449503068
+  time: 2020-01-24T18:29:36.874Z
+  datacontenttype: application/json
 Extensions,
-  knativecemode: binary
+  knativearrivaltime: 2020-01-24T18:29:37.212883996Z
+  knativecemode: push
+  traceparent: 00-7e7fb503ae694cc0f1cbf84ea63354be-f8c4848c9c11e073-00
 Data,
-  {"Hello": "world"}
+  {
+    "subscription": "cre-pull-7b35a745-877f-4f1f-9434-74062631a958",
+    "message": {
+      "id": "951049449503068",
+      "data": {
+        "Hello": "world"
+      },
+      "publish_time": "2020-01-24T18:29:36.874Z"
+    }
+  }
 ```
 
 ## What's Next
 
+1. For more details on Cloud Pub/Sub formats refer to the [Subscriber overview guide](https://cloud.google.com/pubsub/docs/subscriber).
 1. For integrating with Cloud Storage see the [Storage example](../../examples/cloudstoragesource/README.md).
 1. For integrating with Cloud Scheduler see the [Scheduler example](../../examples/cloudschedulersource/README.md).
 1. For integrating with Cloud Audit Logs see the [Cloud Audit Logs example](../../examples/cloudauditlogssource/README.md).

--- a/docs/examples/pullsubscription/README.md
+++ b/docs/examples/pullsubscription/README.md
@@ -1,8 +1,9 @@
 # PullSubscription Example
 
 This sample shows how to configure `PullSubscriptions`. This
-can be considered an implementation detail of the [CloudPubSubSource](../../examples/cloudpubsubsource/README.md), and users should rather 
-use the latter if they want to bridge events from other Google Cloud services using Pub/Sub into their clusters.
+can be considered an implementation detail of the [CloudPubSubSource](../../examples/cloudpubsubsource/README.md), 
+and users should rather use the latter if they want to bridge events from Pub/Sub into their clusters. As opposed to the  
+`CloudPubSubSource`, which sends events using the Push-compatible format, this does so using a Pull format.
 
 ## Prerequisites
 
@@ -117,7 +118,8 @@ For more information about the format of the `Data` see the `data` field of
 
 ## What's next
 
-1. For a higher-level construct to interact with Cloud Pub/Sub, see the [PubSub example](../../examples/cloudpubsubsource/README.md).
+1. For more details on Cloud Pub/Sub formats refer to the [Subscriber overview guide](https://cloud.google.com/pubsub/docs/subscriber).
+1. For a higher-level construct to interact with Cloud Pub/Sub that sends Push-compatible format events, see the [PubSub example](../../examples/cloudpubsubsource/README.md).
 1. For integrating with Cloud Storage see the [Storage example](../../examples/cloudstoragesource/README.md).
 1. For integrating with Cloud Scheduler see the [Scheduler example](../../examples/cloudschedulersource/README.md).
 1. For integrating with Cloud Audit Logs see the [Cloud Audit Logs example](../../examples/cloudauditlogssource/README.md).

--- a/hack/boilerplate/boilerplate.go.txt
+++ b/hack/boilerplate/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Google LLC
+Copyright 2020 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.go.txt
+++ b/hack/boilerplate/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Google LLC
+Copyright 2019 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/pubsub/adapter/converters/pubsub.go
+++ b/pkg/pubsub/adapter/converters/pubsub.go
@@ -56,7 +56,7 @@ func convertPubSub(ctx context.Context, msg *cepubsub.Message, sendMode ModeType
 	if sendMode == Push {
 		// Set the content type to something that can be handled by codec.go.
 		event.SetDataContentType(cloudevents.ApplicationJSON)
-		msg := &pubSubMessage{
+		msg := &PubSubMessage{
 			ID:          event.ID(),
 			Attributes:  msg.Attributes,
 			PublishTime: event.Time(),
@@ -72,7 +72,7 @@ func convertPubSub(ctx context.Context, msg *cepubsub.Message, sendMode ModeType
 			msg.Data = raw
 		}
 
-		if err := event.SetData(&pushMessage{
+		if err := event.SetData(&PushMessage{
 			Subscription: tx.Subscription,
 			Message:      msg,
 		}); err != nil {
@@ -99,16 +99,16 @@ func convertPubSub(ctx context.Context, msg *cepubsub.Message, sendMode ModeType
 	return &event, nil
 }
 
-// pushMessage represents the format Pub/Sub uses to push events.
-type pushMessage struct {
+// PushMessage represents the format Pub/Sub uses to push events.
+type PushMessage struct {
 	// Subscription is the subscription ID that received this Message.
 	Subscription string `json:"subscription"`
 	// Message holds the Pub/Sub message contents.
-	Message *pubSubMessage `json:"message,omitempty"`
+	Message *PubSubMessage `json:"message,omitempty"`
 }
 
 // PubSubMessage matches the inner message format used by Push Subscriptions.
-type pubSubMessage struct {
+type PubSubMessage struct {
 	// ID identifies this message. This ID is assigned by the server and is
 	// populated for Messages obtained from a subscription.
 	// This field is read-only.

--- a/pkg/reconciler/events/pubsub/pubsub.go
+++ b/pkg/reconciler/events/pubsub/pubsub.go
@@ -147,7 +147,17 @@ func (r *Reconciler) reconcilePullSubscription(ctx context.Context, source *v1al
 			logging.FromContext(ctx).Desugar().Error("Failed to get PullSubscription", zap.Error(err))
 			return nil, fmt.Errorf("failed to get PullSubscription: %w", err)
 		}
-		newPS := resources.MakePullSubscription(source.Namespace, source.Name, &source.Spec.PubSubSpec, source, source.Spec.Topic, r.receiveAdapterName, "", resourceGroup)
+		args := &resources.PullSubscriptionArgs{
+			Namespace:      source.Namespace,
+			Name:           source.Name,
+			Spec:           &source.Spec.PubSubSpec,
+			Owner:          source,
+			Topic:          source.Spec.Topic,
+			ReceiveAdapter: r.receiveAdapterName,
+			ResourceGroup:  resourceGroup,
+			Mode:           pubsubv1alpha1.ModePushCompatible,
+		}
+		newPS := resources.MakePullSubscription(args)
 		logging.FromContext(ctx).Desugar().Debug("Creating PullSubscription", zap.Any("ps", newPS))
 		ps, err = r.RunClientSet.PubsubV1alpha1().PullSubscriptions(newPS.Namespace).Create(newPS)
 		if err != nil {

--- a/pkg/reconciler/events/pubsub/pubsub_test.go
+++ b/pkg/reconciler/events/pubsub/pubsub_test.go
@@ -156,6 +156,7 @@ func TestAllCases(t *testing.T) {
 					Secret: &secret,
 				}),
 				WithPullSubscriptionSink(sinkGVK, sinkName),
+				WithPullSubscriptionMode(pubsubv1alpha1.ModePushCompatible),
 				WithPullSubscriptionLabels(map[string]string{
 					"receive-adapter": receiveAdapterName,
 				}),

--- a/pkg/reconciler/pubsub/reconciler.go
+++ b/pkg/reconciler/pubsub/reconciler.go
@@ -91,7 +91,17 @@ func (psb *PubSubBase) ReconcilePubSub(ctx context.Context, pubsubable duck.PubS
 			logging.FromContext(ctx).Desugar().Error("Failed to get PullSubscription", zap.Error(err))
 			return t, nil, fmt.Errorf("failed to get Pullsubscription: %w", err)
 		}
-		newPS := resources.MakePullSubscription(namespace, name, spec, pubsubable, topic, psb.receiveAdapterName, psb.adapterType, resourceGroup)
+		args := &resources.PullSubscriptionArgs{
+			Namespace:      namespace,
+			Name:           name,
+			Spec:           spec,
+			Owner:          pubsubable,
+			Topic:          topic,
+			ReceiveAdapter: psb.receiveAdapterName,
+			AdapterType:    psb.adapterType,
+			ResourceGroup:  resourceGroup,
+		}
+		newPS := resources.MakePullSubscription(args)
 		ps, err = pullSubscriptions.Create(newPS)
 		if err != nil {
 			logging.FromContext(ctx).Desugar().Error("Failed to create PullSubscription", zap.Any("ps", newPS), zap.Error(err))

--- a/pkg/reconciler/pubsub/resources/pullsubscription_test.go
+++ b/pkg/reconciler/pubsub/resources/pullsubscription_test.go
@@ -63,7 +63,17 @@ func TestMakePullSubscription(t *testing.T) {
 		},
 	}
 
-	got := MakePullSubscription(source.Namespace, source.Name, &source.Spec.PubSubSpec, source, "topic-abc", "storage.events.cloud.google.com", "google.storage", "storages.events.cloud.google.com")
+	args := &PullSubscriptionArgs{
+		Namespace:      source.Namespace,
+		Name:           source.Name,
+		Spec:           &source.Spec.PubSubSpec,
+		Owner:          source,
+		Topic:          "topic-abc",
+		ReceiveAdapter: "storage.events.cloud.google.com",
+		AdapterType:    "google.storage",
+		ResourceGroup:  "storages.events.cloud.google.com",
+	}
+	got := MakePullSubscription(args)
 
 	yes := true
 	want := &pubsubv1alpha1.PullSubscription{

--- a/pkg/reconciler/testing/pullsubscription.go
+++ b/pkg/reconciler/testing/pullsubscription.go
@@ -273,3 +273,9 @@ func WithPullSubscriptionReadyStatus(status corev1.ConditionStatus, reason, mess
 		}}
 	}
 }
+
+func WithPullSubscriptionMode(mode v1alpha1.ModeType) PullSubscriptionOption {
+	return func(s *v1alpha1.PullSubscription) {
+		s.Spec.Mode = mode
+	}
+}

--- a/test/test_images/target/main.go
+++ b/test/test_images/target/main.go
@@ -39,22 +39,22 @@ type Receiver struct {
 func (r *Receiver) Receive(event cloudevents.Event) {
 	var target string
 
-	// Try Pull first.
+	// Try Pull first used by the PullSubscription.
 	err := event.ExtensionAs("target", &target)
 	if err != nil {
-		// Should be Push format and the target should be in the data payload.
+		// If it fails, try Push format used by the CloudPubSubSource.
 		data, err := event.DataBytes()
 		if err != nil {
 			fmt.Println("failed to get data from event", err)
 			return
 		}
-		msg := converters.PubSubMessage{}
-		if err := json.Unmarshal(data, &msg); err != nil {
-			fmt.Println("failed to unmarshall PubSubMessage", err)
+		push := converters.PushMessage{}
+		if err := json.Unmarshal(data, &push); err != nil {
+			fmt.Println("failed to unmarshall PubMessage", err)
 			return
 		}
 
-		if tt, ok := msg.Attributes["target"]; !ok {
+		if tt, ok := push.Message.Attributes["target"]; !ok {
 			fmt.Println("failed to get target from attributes:", err)
 			return
 		} else {


### PR DESCRIPTION
Follow up from https://github.com/google/knative-gcp/pull/512

## Proposed Changes

- Setting the CloudPubSubSource to always emit Push-compatible format. If users want Pull format, then they should use PullSubscription.
- Adding a PullSubscriptionArgs struct, otherwise the method signature was getting to cumbersome.
- Updating docs


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
CloudPubSubSource now emits Push-based format events. If users want to keep on consuming Pull-based format, they should use PullSubscription. 
```
