### PR TITLE
Use e2 VMs instead of n1 for performance test clusters

### DIFF
--- a/test/performance/benchmarks/broker-pubsub/cluster.yaml
+++ b/test/performance/benchmarks/broker-pubsub/cluster.yaml
@@ -17,5 +17,5 @@
 GKECluster:
   location: "us-west1"
   nodeCount: 2
-  nodeType: "n1-standard-4"
+  nodeType: "e2-standard-4"
   addons: "HorizontalPodAutoscaling,HttpLoadBalancing,Istio"

--- a/test/performance/benchmarks/channel-pubsub/cluster.yaml
+++ b/test/performance/benchmarks/channel-pubsub/cluster.yaml
@@ -17,5 +17,5 @@
 GKECluster:
   location: "us-west1"
   nodeCount: 2
-  nodeType: "n1-standard-4"
+  nodeType: "e2-standard-4"
   addons: "HorizontalPodAutoscaling,HttpLoadBalancing,Istio"


### PR DESCRIPTION
It's more efficient on Google Cloud.

This follows the upstream changes:
- https://github.com/knative/test-infra/pull/1649
- https://github.com/knative/pkg/pull/1024