### PR TITLE
Add labels for topics and pullsubscription

### DIFF
--- a/pkg/reconciler/events/auditlogs/auditlogs_test.go
+++ b/pkg/reconciler/events/auditlogs/auditlogs_test.go
@@ -161,7 +161,8 @@ func TestAllCases(t *testing.T) {
 					PropagationPolicy: "CreateDelete",
 				}),
 				WithTopicLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": sourceName,
 				}),
 				WithTopicOwnerReferences([]metav1.OwnerReference{sourceOwnerRef(sourceName, sourceUID)}),
 			),
@@ -371,7 +372,8 @@ func TestAllCases(t *testing.T) {
 				}),
 				WithPullSubscriptionSink(sinkGVK, sinkName),
 				WithPullSubscriptionLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": sourceName,
 				}),
 				WithPullSubscriptionAnnotations(map[string]string{
 					"metrics-resource-group": resourceGroup,

--- a/pkg/reconciler/events/pubsub/pubsub.go
+++ b/pkg/reconciler/events/pubsub/pubsub.go
@@ -157,10 +157,7 @@ func (r *Reconciler) reconcilePullSubscription(ctx context.Context, source *v1al
 			Topic:         source.Spec.Topic,
 			ResourceGroup: resourceGroup,
 			Mode:          pubsubv1alpha1.ModePushCompatible,
-			Labels: map[string]string{
-				"receive-adapter": r.receiveAdapterName,
-				"source":          source.Name,
-			},
+			Labels:        resources.GetLabels(r.receiveAdapterName, source.Name),
 		}
 		newPS := resources.MakePullSubscription(args)
 		logging.FromContext(ctx).Desugar().Debug("Creating PullSubscription", zap.Any("ps", newPS))

--- a/pkg/reconciler/events/pubsub/pubsub.go
+++ b/pkg/reconciler/events/pubsub/pubsub.go
@@ -150,14 +150,17 @@ func (r *Reconciler) reconcilePullSubscription(ctx context.Context, source *v1al
 			return nil, fmt.Errorf("failed to get PullSubscription: %w", err)
 		}
 		args := &resources.PullSubscriptionArgs{
-			Namespace:      source.Namespace,
-			Name:           source.Name,
-			Spec:           &source.Spec.PubSubSpec,
-			Owner:          source,
-			Topic:          source.Spec.Topic,
-			ReceiveAdapter: r.receiveAdapterName,
-			ResourceGroup:  resourceGroup,
-			Mode:           pubsubv1alpha1.ModePushCompatible,
+			Namespace:     source.Namespace,
+			Name:          source.Name,
+			Spec:          &source.Spec.PubSubSpec,
+			Owner:         source,
+			Topic:         source.Spec.Topic,
+			ResourceGroup: resourceGroup,
+			Mode:          pubsubv1alpha1.ModePushCompatible,
+			Labels: map[string]string{
+				"receive-adapter": r.receiveAdapterName,
+				"source":          source.Name,
+			},
 		}
 		newPS := resources.MakePullSubscription(args)
 		logging.FromContext(ctx).Desugar().Debug("Creating PullSubscription", zap.Any("ps", newPS))

--- a/pkg/reconciler/events/pubsub/pubsub_test.go
+++ b/pkg/reconciler/events/pubsub/pubsub_test.go
@@ -161,8 +161,8 @@ func TestAllCases(t *testing.T) {
 				WithPullSubscriptionSink(sinkGVK, sinkName),
 				WithPullSubscriptionMode(pubsubv1alpha1.ModePushCompatible),
 				WithPullSubscriptionLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
-					"source":          pubsubName,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": pubsubName,
 				}),
 				WithPullSubscriptionAnnotations(map[string]string{
 					"metrics-resource-group": resourceGroup,

--- a/pkg/reconciler/events/pubsub/pubsub_test.go
+++ b/pkg/reconciler/events/pubsub/pubsub_test.go
@@ -162,6 +162,7 @@ func TestAllCases(t *testing.T) {
 				WithPullSubscriptionMode(pubsubv1alpha1.ModePushCompatible),
 				WithPullSubscriptionLabels(map[string]string{
 					"receive-adapter": receiveAdapterName,
+					"source":          pubsubName,
 				}),
 				WithPullSubscriptionAnnotations(map[string]string{
 					"metrics-resource-group": resourceGroup,

--- a/pkg/reconciler/events/scheduler/scheduler_test.go
+++ b/pkg/reconciler/events/scheduler/scheduler_test.go
@@ -189,7 +189,8 @@ func TestAllCases(t *testing.T) {
 					PropagationPolicy: "CreateDelete",
 				}),
 				WithTopicLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": schedulerName,
 				}),
 				WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			),
@@ -434,8 +435,8 @@ func TestAllCases(t *testing.T) {
 					}),
 					WithPullSubscriptionSink(sinkGVK, sinkName),
 					WithPullSubscriptionLabels(map[string]string{
-						"receive-adapter": receiveAdapterName,
-					}),
+						"receive-adapter":                     receiveAdapterName,
+						"events.cloud.google.com/source-name": schedulerName}),
 					WithPullSubscriptionAnnotations(map[string]string{
 						"metrics-resource-group": resourceGroup,
 					}),

--- a/pkg/reconciler/events/storage/storage_test.go
+++ b/pkg/reconciler/events/storage/storage_test.go
@@ -185,7 +185,8 @@ func TestAllCases(t *testing.T) {
 					PropagationPolicy: "CreateDelete",
 				}),
 				WithTopicLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": storageName,
 				}),
 				WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			),
@@ -416,7 +417,8 @@ func TestAllCases(t *testing.T) {
 				}),
 				WithPullSubscriptionSink(sinkGVK, sinkName),
 				WithPullSubscriptionLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": storageName,
 				}),
 				WithPullSubscriptionAnnotations(map[string]string{
 					"metrics-resource-group": resourceGroup,

--- a/pkg/reconciler/pubsub/reconciler.go
+++ b/pkg/reconciler/pubsub/reconciler.go
@@ -29,7 +29,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 )
@@ -69,7 +69,18 @@ func (psb *PubSubBase) ReconcilePubSub(ctx context.Context, pubsubable duck.PubS
 			logging.FromContext(ctx).Desugar().Error("Failed to get Topics", zap.Error(err))
 			return nil, nil, fmt.Errorf("failed to get Topics: %w", err)
 		}
-		newTopic := resources.MakeTopic(namespace, name, spec, pubsubable, topic, psb.receiveAdapterName)
+		args := &resources.TopicArgs{
+			Namespace: namespace,
+			Name:      name,
+			Spec:      spec,
+			Owner:     pubsubable,
+			Topic:     topic,
+			Labels: map[string]string{
+				"receive-adapter": psb.receiveAdapterName,
+				"source":          name,
+			},
+		}
+		newTopic := resources.MakeTopic(args)
 		t, err = topics.Create(newTopic)
 		if err != nil {
 			logging.FromContext(ctx).Desugar().Error("Failed to create Topic", zap.Any("topic", newTopic), zap.Error(err))
@@ -92,14 +103,17 @@ func (psb *PubSubBase) ReconcilePubSub(ctx context.Context, pubsubable duck.PubS
 			return t, nil, fmt.Errorf("failed to get Pullsubscription: %w", err)
 		}
 		args := &resources.PullSubscriptionArgs{
-			Namespace:      namespace,
-			Name:           name,
-			Spec:           spec,
-			Owner:          pubsubable,
-			Topic:          topic,
-			ReceiveAdapter: psb.receiveAdapterName,
-			AdapterType:    psb.adapterType,
-			ResourceGroup:  resourceGroup,
+			Namespace:     namespace,
+			Name:          name,
+			Spec:          spec,
+			Owner:         pubsubable,
+			Topic:         topic,
+			AdapterType:   psb.adapterType,
+			ResourceGroup: resourceGroup,
+			Labels: map[string]string{
+				"receive-adapter": psb.receiveAdapterName,
+				"source":          name,
+			},
 		}
 		newPS := resources.MakePullSubscription(args)
 		ps, err = pullSubscriptions.Create(newPS)

--- a/pkg/reconciler/pubsub/reconciler.go
+++ b/pkg/reconciler/pubsub/reconciler.go
@@ -75,10 +75,7 @@ func (psb *PubSubBase) ReconcilePubSub(ctx context.Context, pubsubable duck.PubS
 			Spec:      spec,
 			Owner:     pubsubable,
 			Topic:     topic,
-			Labels: map[string]string{
-				"receive-adapter": psb.receiveAdapterName,
-				"source":          name,
-			},
+			Labels:    resources.GetLabels(psb.receiveAdapterName, name),
 		}
 		newTopic := resources.MakeTopic(args)
 		t, err = topics.Create(newTopic)
@@ -110,10 +107,7 @@ func (psb *PubSubBase) ReconcilePubSub(ctx context.Context, pubsubable duck.PubS
 			Topic:         topic,
 			AdapterType:   psb.adapterType,
 			ResourceGroup: resourceGroup,
-			Labels: map[string]string{
-				"receive-adapter": psb.receiveAdapterName,
-				"source":          name,
-			},
+			Labels:        resources.GetLabels(psb.receiveAdapterName, name),
 		}
 		newPS := resources.MakePullSubscription(args)
 		ps, err = pullSubscriptions.Create(newPS)

--- a/pkg/reconciler/pubsub/reconciler_test.go
+++ b/pkg/reconciler/pubsub/reconciler_test.go
@@ -95,8 +95,8 @@ func TestCreates(t *testing.T) {
 				PropagationPolicy: "CreateDelete",
 			}),
 			rectesting.WithTopicLabels(map[string]string{
-				"receive-adapter": receiveAdapterName,
-				"source":          name,
+				"receive-adapter":                     receiveAdapterName,
+				"events.cloud.google.com/source-name": name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 		),
@@ -109,8 +109,8 @@ func TestCreates(t *testing.T) {
 					PropagationPolicy: "CreateDelete",
 				}),
 				rectesting.WithTopicLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
-					"source":          name,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			),
@@ -124,8 +124,8 @@ func TestCreates(t *testing.T) {
 					PropagationPolicy: "CreateDelete",
 				}),
 				rectesting.WithTopicLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
-					"source":          name,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			),
@@ -137,8 +137,8 @@ func TestCreates(t *testing.T) {
 				PropagationPolicy: "CreateDelete",
 			}),
 			rectesting.WithTopicLabels(map[string]string{
-				"receive-adapter": receiveAdapterName,
-				"source":          name,
+				"receive-adapter":                     receiveAdapterName,
+				"events.cloud.google.com/source-name": name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 		),
@@ -153,8 +153,8 @@ func TestCreates(t *testing.T) {
 					PropagationPolicy: "CreateDelete",
 				}),
 				rectesting.WithTopicLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
-					"source":          name,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 				rectesting.WithTopicReady(testTopicID),
@@ -168,8 +168,8 @@ func TestCreates(t *testing.T) {
 				PropagationPolicy: "CreateDelete",
 			}),
 			rectesting.WithTopicLabels(map[string]string{
-				"receive-adapter": receiveAdapterName,
-				"source":          name,
+				"receive-adapter":                     receiveAdapterName,
+				"events.cloud.google.com/source-name": name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			rectesting.WithTopicReady(testTopicID),
@@ -187,8 +187,8 @@ func TestCreates(t *testing.T) {
 					PropagationPolicy: "CreateDelete",
 				}),
 				rectesting.WithTopicLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
-					"source":          name,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 				rectesting.WithTopicProjectID(testProjectID),
@@ -202,8 +202,8 @@ func TestCreates(t *testing.T) {
 				PropagationPolicy: "CreateDelete",
 			}),
 			rectesting.WithTopicLabels(map[string]string{
-				"receive-adapter": receiveAdapterName,
-				"source":          name,
+				"receive-adapter":                     receiveAdapterName,
+				"events.cloud.google.com/source-name": name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			rectesting.WithTopicFailed(),
@@ -221,8 +221,8 @@ func TestCreates(t *testing.T) {
 					PropagationPolicy: "CreateDelete",
 				}),
 				rectesting.WithTopicLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
-					"source":          name,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 				rectesting.WithTopicProjectID(testProjectID),
@@ -236,8 +236,8 @@ func TestCreates(t *testing.T) {
 				PropagationPolicy: "CreateDelete",
 			}),
 			rectesting.WithTopicLabels(map[string]string{
-				"receive-adapter": receiveAdapterName,
-				"source":          name,
+				"receive-adapter":                     receiveAdapterName,
+				"events.cloud.google.com/source-name": name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			rectesting.WithTopicUnknown(),
@@ -255,8 +255,8 @@ func TestCreates(t *testing.T) {
 					PropagationPolicy: "CreateDelete",
 				}),
 				rectesting.WithTopicLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
-					"source":          name,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 				rectesting.WithTopicProjectID(testProjectID),
@@ -271,8 +271,8 @@ func TestCreates(t *testing.T) {
 				PropagationPolicy: "CreateDelete",
 			}),
 			rectesting.WithTopicLabels(map[string]string{
-				"receive-adapter": receiveAdapterName,
-				"source":          name,
+				"receive-adapter":                     receiveAdapterName,
+				"events.cloud.google.com/source-name": name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			rectesting.WithTopicReady(""),
@@ -291,8 +291,8 @@ func TestCreates(t *testing.T) {
 					PropagationPolicy: "CreateDelete",
 				}),
 				rectesting.WithTopicLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
-					"source":          name,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 				rectesting.WithTopicProjectID(testProjectID),
@@ -307,8 +307,8 @@ func TestCreates(t *testing.T) {
 				PropagationPolicy: "CreateDelete",
 			}),
 			rectesting.WithTopicLabels(map[string]string{
-				"receive-adapter": receiveAdapterName,
-				"source":          name,
+				"receive-adapter":                     receiveAdapterName,
+				"events.cloud.google.com/source-name": name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			rectesting.WithTopicReady(testTopicID),
@@ -322,8 +322,8 @@ func TestCreates(t *testing.T) {
 				Secret: &secret,
 			}),
 			rectesting.WithPullSubscriptionLabels(map[string]string{
-				"receive-adapter": receiveAdapterName,
-				"source":          name,
+				"receive-adapter":                     receiveAdapterName,
+				"events.cloud.google.com/source-name": name,
 			}),
 			rectesting.WithPullSubscriptionAnnotations(map[string]string{
 				"metrics-resource-group": resourceGroup,
@@ -338,8 +338,8 @@ func TestCreates(t *testing.T) {
 					Secret: &secret,
 				}),
 				rectesting.WithPullSubscriptionLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
-					"source":          name,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": name,
 				}),
 				rectesting.WithPullSubscriptionAnnotations(map[string]string{
 					"metrics-resource-group": resourceGroup,
@@ -356,8 +356,8 @@ func TestCreates(t *testing.T) {
 					PropagationPolicy: "CreateDelete",
 				}),
 				rectesting.WithTopicLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
-					"source":          name,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 				rectesting.WithTopicProjectID(testProjectID),
@@ -370,8 +370,8 @@ func TestCreates(t *testing.T) {
 					Secret: &secret,
 				}),
 				rectesting.WithPullSubscriptionLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
-					"source":          name,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": name,
 				}),
 				rectesting.WithPullSubscriptionAnnotations(map[string]string{
 					"metrics-resource-group": resourceGroup,
@@ -386,8 +386,8 @@ func TestCreates(t *testing.T) {
 				PropagationPolicy: "CreateDelete",
 			}),
 			rectesting.WithTopicLabels(map[string]string{
-				"receive-adapter": receiveAdapterName,
-				"source":          name,
+				"receive-adapter":                     receiveAdapterName,
+				"events.cloud.google.com/source-name": name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			rectesting.WithTopicReady(testTopicID),
@@ -401,8 +401,8 @@ func TestCreates(t *testing.T) {
 				Secret: &secret,
 			}),
 			rectesting.WithPullSubscriptionLabels(map[string]string{
-				"receive-adapter": receiveAdapterName,
-				"source":          name,
+				"receive-adapter":                     receiveAdapterName,
+				"events.cloud.google.com/source-name": name,
 			}),
 			rectesting.WithPullSubscriptionAnnotations(map[string]string{
 				"metrics-resource-group": resourceGroup,
@@ -419,8 +419,8 @@ func TestCreates(t *testing.T) {
 					PropagationPolicy: "CreateDelete",
 				}),
 				rectesting.WithTopicLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
-					"source":          name,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 				rectesting.WithTopicProjectID(testProjectID),
@@ -433,8 +433,8 @@ func TestCreates(t *testing.T) {
 					Secret: &secret,
 				}),
 				rectesting.WithPullSubscriptionLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
-					"source":          name,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": name,
 				}),
 				rectesting.WithPullSubscriptionAnnotations(map[string]string{
 					"metrics-resource-group": resourceGroup,
@@ -450,8 +450,8 @@ func TestCreates(t *testing.T) {
 				PropagationPolicy: "CreateDelete",
 			}),
 			rectesting.WithTopicLabels(map[string]string{
-				"receive-adapter": receiveAdapterName,
-				"source":          name,
+				"receive-adapter":                     receiveAdapterName,
+				"events.cloud.google.com/source-name": name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			rectesting.WithTopicReady(testTopicID),
@@ -465,8 +465,8 @@ func TestCreates(t *testing.T) {
 				Secret: &secret,
 			}),
 			rectesting.WithPullSubscriptionLabels(map[string]string{
-				"receive-adapter": receiveAdapterName,
-				"source":          name,
+				"receive-adapter":                     receiveAdapterName,
+				"events.cloud.google.com/source-name": name,
 			}),
 			rectesting.WithPullSubscriptionAnnotations(map[string]string{
 				"metrics-resource-group": resourceGroup,
@@ -484,8 +484,8 @@ func TestCreates(t *testing.T) {
 					PropagationPolicy: "CreateDelete",
 				}),
 				rectesting.WithTopicLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
-					"source":          name,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 				rectesting.WithTopicProjectID(testProjectID),
@@ -498,8 +498,8 @@ func TestCreates(t *testing.T) {
 					Secret: &secret,
 				}),
 				rectesting.WithPullSubscriptionLabels(map[string]string{
-					"receive-adapter": receiveAdapterName,
-					"source":          name,
+					"receive-adapter":                     receiveAdapterName,
+					"events.cloud.google.com/source-name": name,
 				}),
 				rectesting.WithPullSubscriptionAnnotations(map[string]string{
 					"metrics-resource-group": resourceGroup,
@@ -515,8 +515,8 @@ func TestCreates(t *testing.T) {
 				PropagationPolicy: "CreateDelete",
 			}),
 			rectesting.WithTopicLabels(map[string]string{
-				"receive-adapter": receiveAdapterName,
-				"source":          name,
+				"receive-adapter":                     receiveAdapterName,
+				"events.cloud.google.com/source-name": name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			rectesting.WithTopicReady(testTopicID),
@@ -530,8 +530,8 @@ func TestCreates(t *testing.T) {
 				Secret: &secret,
 			}),
 			rectesting.WithPullSubscriptionLabels(map[string]string{
-				"receive-adapter": receiveAdapterName,
-				"source":          name,
+				"receive-adapter":                     receiveAdapterName,
+				"events.cloud.google.com/source-name": name,
 			}),
 			rectesting.WithPullSubscriptionAnnotations(map[string]string{
 				"metrics-resource-group": resourceGroup,

--- a/pkg/reconciler/pubsub/reconciler_test.go
+++ b/pkg/reconciler/pubsub/reconciler_test.go
@@ -96,6 +96,7 @@ func TestCreates(t *testing.T) {
 			}),
 			rectesting.WithTopicLabels(map[string]string{
 				"receive-adapter": receiveAdapterName,
+				"source":          name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 		),
@@ -109,6 +110,7 @@ func TestCreates(t *testing.T) {
 				}),
 				rectesting.WithTopicLabels(map[string]string{
 					"receive-adapter": receiveAdapterName,
+					"source":          name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			),
@@ -123,6 +125,7 @@ func TestCreates(t *testing.T) {
 				}),
 				rectesting.WithTopicLabels(map[string]string{
 					"receive-adapter": receiveAdapterName,
+					"source":          name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			),
@@ -135,6 +138,7 @@ func TestCreates(t *testing.T) {
 			}),
 			rectesting.WithTopicLabels(map[string]string{
 				"receive-adapter": receiveAdapterName,
+				"source":          name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 		),
@@ -150,6 +154,7 @@ func TestCreates(t *testing.T) {
 				}),
 				rectesting.WithTopicLabels(map[string]string{
 					"receive-adapter": receiveAdapterName,
+					"source":          name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 				rectesting.WithTopicReady(testTopicID),
@@ -164,6 +169,7 @@ func TestCreates(t *testing.T) {
 			}),
 			rectesting.WithTopicLabels(map[string]string{
 				"receive-adapter": receiveAdapterName,
+				"source":          name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			rectesting.WithTopicReady(testTopicID),
@@ -182,6 +188,7 @@ func TestCreates(t *testing.T) {
 				}),
 				rectesting.WithTopicLabels(map[string]string{
 					"receive-adapter": receiveAdapterName,
+					"source":          name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 				rectesting.WithTopicProjectID(testProjectID),
@@ -196,6 +203,7 @@ func TestCreates(t *testing.T) {
 			}),
 			rectesting.WithTopicLabels(map[string]string{
 				"receive-adapter": receiveAdapterName,
+				"source":          name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			rectesting.WithTopicFailed(),
@@ -214,6 +222,7 @@ func TestCreates(t *testing.T) {
 				}),
 				rectesting.WithTopicLabels(map[string]string{
 					"receive-adapter": receiveAdapterName,
+					"source":          name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 				rectesting.WithTopicProjectID(testProjectID),
@@ -228,6 +237,7 @@ func TestCreates(t *testing.T) {
 			}),
 			rectesting.WithTopicLabels(map[string]string{
 				"receive-adapter": receiveAdapterName,
+				"source":          name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			rectesting.WithTopicUnknown(),
@@ -246,6 +256,7 @@ func TestCreates(t *testing.T) {
 				}),
 				rectesting.WithTopicLabels(map[string]string{
 					"receive-adapter": receiveAdapterName,
+					"source":          name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 				rectesting.WithTopicProjectID(testProjectID),
@@ -261,6 +272,7 @@ func TestCreates(t *testing.T) {
 			}),
 			rectesting.WithTopicLabels(map[string]string{
 				"receive-adapter": receiveAdapterName,
+				"source":          name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			rectesting.WithTopicReady(""),
@@ -280,6 +292,7 @@ func TestCreates(t *testing.T) {
 				}),
 				rectesting.WithTopicLabels(map[string]string{
 					"receive-adapter": receiveAdapterName,
+					"source":          name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 				rectesting.WithTopicProjectID(testProjectID),
@@ -295,6 +308,7 @@ func TestCreates(t *testing.T) {
 			}),
 			rectesting.WithTopicLabels(map[string]string{
 				"receive-adapter": receiveAdapterName,
+				"source":          name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			rectesting.WithTopicReady(testTopicID),
@@ -309,6 +323,7 @@ func TestCreates(t *testing.T) {
 			}),
 			rectesting.WithPullSubscriptionLabels(map[string]string{
 				"receive-adapter": receiveAdapterName,
+				"source":          name,
 			}),
 			rectesting.WithPullSubscriptionAnnotations(map[string]string{
 				"metrics-resource-group": resourceGroup,
@@ -324,6 +339,7 @@ func TestCreates(t *testing.T) {
 				}),
 				rectesting.WithPullSubscriptionLabels(map[string]string{
 					"receive-adapter": receiveAdapterName,
+					"source":          name,
 				}),
 				rectesting.WithPullSubscriptionAnnotations(map[string]string{
 					"metrics-resource-group": resourceGroup,
@@ -341,6 +357,7 @@ func TestCreates(t *testing.T) {
 				}),
 				rectesting.WithTopicLabels(map[string]string{
 					"receive-adapter": receiveAdapterName,
+					"source":          name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 				rectesting.WithTopicProjectID(testProjectID),
@@ -354,6 +371,7 @@ func TestCreates(t *testing.T) {
 				}),
 				rectesting.WithPullSubscriptionLabels(map[string]string{
 					"receive-adapter": receiveAdapterName,
+					"source":          name,
 				}),
 				rectesting.WithPullSubscriptionAnnotations(map[string]string{
 					"metrics-resource-group": resourceGroup,
@@ -369,6 +387,7 @@ func TestCreates(t *testing.T) {
 			}),
 			rectesting.WithTopicLabels(map[string]string{
 				"receive-adapter": receiveAdapterName,
+				"source":          name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			rectesting.WithTopicReady(testTopicID),
@@ -383,6 +402,7 @@ func TestCreates(t *testing.T) {
 			}),
 			rectesting.WithPullSubscriptionLabels(map[string]string{
 				"receive-adapter": receiveAdapterName,
+				"source":          name,
 			}),
 			rectesting.WithPullSubscriptionAnnotations(map[string]string{
 				"metrics-resource-group": resourceGroup,
@@ -400,6 +420,7 @@ func TestCreates(t *testing.T) {
 				}),
 				rectesting.WithTopicLabels(map[string]string{
 					"receive-adapter": receiveAdapterName,
+					"source":          name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 				rectesting.WithTopicProjectID(testProjectID),
@@ -413,6 +434,7 @@ func TestCreates(t *testing.T) {
 				}),
 				rectesting.WithPullSubscriptionLabels(map[string]string{
 					"receive-adapter": receiveAdapterName,
+					"source":          name,
 				}),
 				rectesting.WithPullSubscriptionAnnotations(map[string]string{
 					"metrics-resource-group": resourceGroup,
@@ -429,6 +451,7 @@ func TestCreates(t *testing.T) {
 			}),
 			rectesting.WithTopicLabels(map[string]string{
 				"receive-adapter": receiveAdapterName,
+				"source":          name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			rectesting.WithTopicReady(testTopicID),
@@ -443,6 +466,7 @@ func TestCreates(t *testing.T) {
 			}),
 			rectesting.WithPullSubscriptionLabels(map[string]string{
 				"receive-adapter": receiveAdapterName,
+				"source":          name,
 			}),
 			rectesting.WithPullSubscriptionAnnotations(map[string]string{
 				"metrics-resource-group": resourceGroup,
@@ -461,6 +485,7 @@ func TestCreates(t *testing.T) {
 				}),
 				rectesting.WithTopicLabels(map[string]string{
 					"receive-adapter": receiveAdapterName,
+					"source":          name,
 				}),
 				rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 				rectesting.WithTopicProjectID(testProjectID),
@@ -474,6 +499,7 @@ func TestCreates(t *testing.T) {
 				}),
 				rectesting.WithPullSubscriptionLabels(map[string]string{
 					"receive-adapter": receiveAdapterName,
+					"source":          name,
 				}),
 				rectesting.WithPullSubscriptionAnnotations(map[string]string{
 					"metrics-resource-group": resourceGroup,
@@ -490,6 +516,7 @@ func TestCreates(t *testing.T) {
 			}),
 			rectesting.WithTopicLabels(map[string]string{
 				"receive-adapter": receiveAdapterName,
+				"source":          name,
 			}),
 			rectesting.WithTopicOwnerReferences([]metav1.OwnerReference{ownerRef()}),
 			rectesting.WithTopicReady(testTopicID),
@@ -504,6 +531,7 @@ func TestCreates(t *testing.T) {
 			}),
 			rectesting.WithPullSubscriptionLabels(map[string]string{
 				"receive-adapter": receiveAdapterName,
+				"source":          name,
 			}),
 			rectesting.WithPullSubscriptionAnnotations(map[string]string{
 				"metrics-resource-group": resourceGroup,

--- a/pkg/reconciler/pubsub/resources/labels.go
+++ b/pkg/reconciler/pubsub/resources/labels.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Google LLC
+Copyright 2020 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/reconciler/pubsub/resources/labels.go
+++ b/pkg/reconciler/pubsub/resources/labels.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+func GetLabels(receiveAdapterName, source string) map[string]string {
+	return map[string]string{
+		"receive-adapter":                     receiveAdapterName,
+		"events.cloud.google.com/source-name": source,
+	}
+}

--- a/pkg/reconciler/pubsub/resources/labels_test.go
+++ b/pkg/reconciler/pubsub/resources/labels_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Google LLC
+Copyright 2020 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/reconciler/pubsub/resources/labesl_test.go
+++ b/pkg/reconciler/pubsub/resources/labesl_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetLabels(t *testing.T) {
+	want := map[string]string{
+		"receive-adapter":                     "receive-adapter-name",
+		"events.cloud.google.com/source-name": "source",
+	}
+	got := GetLabels("receive-adapter-name", "source")
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected (-want, +got) = %v", diff)
+	}
+}

--- a/pkg/reconciler/pubsub/resources/pullsubscription.go
+++ b/pkg/reconciler/pubsub/resources/pullsubscription.go
@@ -26,24 +26,20 @@ import (
 )
 
 type PullSubscriptionArgs struct {
-	Namespace      string
-	Name           string
-	Spec           *duckv1alpha1.PubSubSpec
-	Owner          kmeta.OwnerRefable
-	Topic          string
-	ReceiveAdapter string
-	AdapterType    string
-	ResourceGroup  string
-	Mode           pubsubv1alpha1.ModeType
+	Namespace     string
+	Name          string
+	Spec          *duckv1alpha1.PubSubSpec
+	Owner         kmeta.OwnerRefable
+	Topic         string
+	AdapterType   string
+	ResourceGroup string
+	Mode          pubsubv1alpha1.ModeType
+	Labels        map[string]string
 }
 
 // MakePullSubscription creates the spec for, but does not create, a GCP PullSubscription
 // for a given GCS.
 func MakePullSubscription(args *PullSubscriptionArgs) *pubsubv1alpha1.PullSubscription {
-	labels := map[string]string{
-		"receive-adapter": args.ReceiveAdapter,
-	}
-
 	annotations := map[string]string{
 		"metrics-resource-group": args.ResourceGroup,
 	}
@@ -57,7 +53,7 @@ func MakePullSubscription(args *PullSubscriptionArgs) *pubsubv1alpha1.PullSubscr
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            args.Name,
 			Namespace:       args.Namespace,
-			Labels:          labels,
+			Labels:          args.Labels,
 			Annotations:     annotations,
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(args.Owner)},
 		},
@@ -68,13 +64,13 @@ func MakePullSubscription(args *PullSubscriptionArgs) *pubsubv1alpha1.PullSubscr
 			AdapterType: args.AdapterType,
 			Mode:        args.Mode,
 			SourceSpec: duckv1.SourceSpec{
-				Sink: args.Spec.Sink,
+				Sink: args.Spec.SourceSpec.Sink,
 			},
 		},
 	}
-	if args.Spec.CloudEventOverrides != nil && args.Spec.CloudEventOverrides.Extensions != nil {
+	if args.Spec.SourceSpec.CloudEventOverrides != nil && args.Spec.SourceSpec.CloudEventOverrides.Extensions != nil {
 		ps.Spec.SourceSpec.CloudEventOverrides = &duckv1.CloudEventOverrides{
-			Extensions: args.Spec.CloudEventOverrides.Extensions,
+			Extensions: args.Spec.SourceSpec.CloudEventOverrides.Extensions,
 		}
 	}
 	return ps

--- a/pkg/reconciler/pubsub/resources/pullsubscription.go
+++ b/pkg/reconciler/pubsub/resources/pullsubscription.go
@@ -68,9 +68,9 @@ func MakePullSubscription(args *PullSubscriptionArgs) *pubsubv1alpha1.PullSubscr
 			},
 		},
 	}
-	if args.Spec.SourceSpec.CloudEventOverrides != nil && args.Spec.SourceSpec.CloudEventOverrides.Extensions != nil {
+	if args.Spec.CloudEventOverrides != nil && args.Spec.CloudEventOverrides.Extensions != nil {
 		ps.Spec.SourceSpec.CloudEventOverrides = &duckv1.CloudEventOverrides{
-			Extensions: args.Spec.SourceSpec.CloudEventOverrides.Extensions,
+			Extensions: args.Spec.CloudEventOverrides.Extensions,
 		}
 	}
 	return ps

--- a/pkg/reconciler/pubsub/resources/pullsubscription_test.go
+++ b/pkg/reconciler/pubsub/resources/pullsubscription_test.go
@@ -62,16 +62,18 @@ func TestMakePullSubscription(t *testing.T) {
 			},
 		},
 	}
-
 	args := &PullSubscriptionArgs{
-		Namespace:      source.Namespace,
-		Name:           source.Name,
-		Spec:           &source.Spec.PubSubSpec,
-		Owner:          source,
-		Topic:          "topic-abc",
-		ReceiveAdapter: "storage.events.cloud.google.com",
-		AdapterType:    "google.storage",
-		ResourceGroup:  "storages.events.cloud.google.com",
+		Namespace:     source.Namespace,
+		Name:          source.Name,
+		Spec:          &source.Spec.PubSubSpec,
+		Owner:         source,
+		Topic:         "topic-abc",
+		AdapterType:   "google.storage",
+		ResourceGroup: "storages.events.cloud.google.com",
+		Labels: map[string]string{
+			"receive-adapter": "storage.events.cloud.google.com",
+			"source":          source.Name,
+		},
 	}
 	got := MakePullSubscription(args)
 
@@ -82,6 +84,7 @@ func TestMakePullSubscription(t *testing.T) {
 			Name:      "bucket-name",
 			Labels: map[string]string{
 				"receive-adapter": "storage.events.cloud.google.com",
+				"source":          "bucket-name",
 			},
 			Annotations: map[string]string{
 				"metrics-resource-group": "storages.events.cloud.google.com",

--- a/pkg/reconciler/pubsub/resources/pullsubscription_test.go
+++ b/pkg/reconciler/pubsub/resources/pullsubscription_test.go
@@ -72,7 +72,7 @@ func TestMakePullSubscription(t *testing.T) {
 		ResourceGroup: "storages.events.cloud.google.com",
 		Labels: map[string]string{
 			"receive-adapter": "storage.events.cloud.google.com",
-			"source":          source.Name,
+			"events.cloud.google.com/source-name":          source.Name,
 		},
 	}
 	got := MakePullSubscription(args)
@@ -84,7 +84,7 @@ func TestMakePullSubscription(t *testing.T) {
 			Name:      "bucket-name",
 			Labels: map[string]string{
 				"receive-adapter": "storage.events.cloud.google.com",
-				"source":          "bucket-name",
+				"events.cloud.google.com/source-name":          "bucket-name",
 			},
 			Annotations: map[string]string{
 				"metrics-resource-group": "storages.events.cloud.google.com",

--- a/pkg/reconciler/pubsub/resources/topic.go
+++ b/pkg/reconciler/pubsub/resources/topic.go
@@ -24,29 +24,35 @@ import (
 	pubsubv1alpha1 "github.com/google/knative-gcp/pkg/apis/pubsub/v1alpha1"
 )
 
+type TopicArgs struct {
+	Namespace string
+	Name      string
+	Spec      *duckv1alpha1.PubSubSpec
+	Owner     kmeta.OwnerRefable
+	Topic     string
+	Labels    map[string]string
+}
+
 // MakeTopic creates the spec for, but does not create, a GCP Topic
 // for a given GCS.
-func MakeTopic(namespace, name string, spec *duckv1alpha1.PubSubSpec, owner kmeta.OwnerRefable, topic, receiveAdapterName string) *pubsubv1alpha1.Topic {
-	labels := map[string]string{
-		"receive-adapter": receiveAdapterName,
-	}
+func MakeTopic(args *TopicArgs) *pubsubv1alpha1.Topic {
 
-	pubsubSecret := spec.Secret
-	if spec.PubSubSecret != nil {
-		pubsubSecret = spec.PubSubSecret
+	pubsubSecret := args.Spec.Secret
+	if args.Spec.PubSubSecret != nil {
+		pubsubSecret = args.Spec.PubSubSecret
 	}
 
 	return &pubsubv1alpha1.Topic{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            name,
-			Namespace:       namespace,
-			Labels:          labels,
-			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(owner)},
+			Name:            args.Name,
+			Namespace:       args.Namespace,
+			Labels:          args.Labels,
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(args.Owner)},
 		},
 		Spec: pubsubv1alpha1.TopicSpec{
 			Secret:            pubsubSecret,
-			Project:           spec.Project,
-			Topic:             topic,
+			Project:           args.Spec.Project,
+			Topic:             args.Topic,
 			PropagationPolicy: pubsubv1alpha1.TopicPolicyCreateDelete,
 		},
 	}

--- a/pkg/reconciler/pubsub/resources/topic_test.go
+++ b/pkg/reconciler/pubsub/resources/topic_test.go
@@ -58,8 +58,18 @@ func TestMakeTopicWithCloudStorageSource(t *testing.T) {
 			Bucket: "this-bucket",
 		},
 	}
-
-	got := MakeTopic(source.Namespace, source.Name, &source.Spec.PubSubSpec, source, "topic-abc", "storage.events.cloud.google.com")
+	args := &TopicArgs{
+		Namespace: source.Namespace,
+		Name:      source.Name,
+		Spec:      &source.Spec.PubSubSpec,
+		Owner:     source,
+		Topic:     "topic-abc",
+		Labels: map[string]string{
+			"receive-adapter": "storage.events.cloud.google.com",
+			"source":          source.Name,
+		},
+	}
+	got := MakeTopic(args)
 
 	yes := true
 	want := &pubsubv1alpha1.Topic{
@@ -68,6 +78,7 @@ func TestMakeTopicWithCloudStorageSource(t *testing.T) {
 			Name:      "storage-name",
 			Labels: map[string]string{
 				"receive-adapter": "storage.events.cloud.google.com",
+				"source":          "storage-name",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion:         "events.cloud.google.com/v1alpha1",
@@ -124,8 +135,18 @@ func TestMakeTopicWithCloudSchedulerSource(t *testing.T) {
 			},
 		},
 	}
-
-	got := MakeTopic(source.Namespace, source.Name, &source.Spec.PubSubSpec, source, "topic-abc", "storage.events.cloud.google.com")
+	args := &TopicArgs{
+		Namespace: source.Namespace,
+		Name:      source.Name,
+		Spec:      &source.Spec.PubSubSpec,
+		Owner:     source,
+		Topic:     "topic-abc",
+		Labels: map[string]string{
+			"receive-adapter": "storage.events.cloud.google.com",
+			"source":          source.Name,
+		},
+	}
+	got := MakeTopic(args)
 
 	yes := true
 	want := &pubsubv1alpha1.Topic{
@@ -134,6 +155,7 @@ func TestMakeTopicWithCloudSchedulerSource(t *testing.T) {
 			Name:      "scheduler-name",
 			Labels: map[string]string{
 				"receive-adapter": "storage.events.cloud.google.com",
+				"source":          "scheduler-name",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion:         "events.cloud.google.com/v1alpha1",
@@ -196,8 +218,18 @@ func TestMakeTopicWithCloudSchedulerSourceWithPubSubSecret(t *testing.T) {
 			},
 		},
 	}
-
-	got := MakeTopic(source.Namespace, source.Name, &source.Spec.PubSubSpec, source, "topic-abc", "scheduler.events.cloud.google.com")
+	args := &TopicArgs{
+		Namespace: source.Namespace,
+		Name:      source.Name,
+		Spec:      &source.Spec.PubSubSpec,
+		Owner:     source,
+		Topic:     "topic-abc",
+		Labels: map[string]string{
+			"receive-adapter": "scheduler.events.cloud.google.com",
+			"source":          source.Name,
+		},
+	}
+	got := MakeTopic(args)
 
 	yes := true
 	want := &pubsubv1alpha1.Topic{
@@ -206,6 +238,7 @@ func TestMakeTopicWithCloudSchedulerSourceWithPubSubSecret(t *testing.T) {
 			Name:      "scheduler-name",
 			Labels: map[string]string{
 				"receive-adapter": "scheduler.events.cloud.google.com",
+				"source":          "scheduler-name",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion:         "events.cloud.google.com/v1alpha1",

--- a/pkg/reconciler/pubsub/resources/topic_test.go
+++ b/pkg/reconciler/pubsub/resources/topic_test.go
@@ -142,7 +142,7 @@ func TestMakeTopicWithCloudSchedulerSource(t *testing.T) {
 		Owner:     source,
 		Topic:     "topic-abc",
 		Labels: map[string]string{
-			"receive-adapter": "storage.events.cloud.google.com",
+			"receive-adapter": "scheduler.events.cloud.google.com",
 			"source":          source.Name,
 		},
 	}
@@ -154,7 +154,7 @@ func TestMakeTopicWithCloudSchedulerSource(t *testing.T) {
 			Namespace: "scheduler-namespace",
 			Name:      "scheduler-name",
 			Labels: map[string]string{
-				"receive-adapter": "storage.events.cloud.google.com",
+				"receive-adapter": "scheduler.events.cloud.google.com",
 				"source":          "scheduler-name",
 			},
 			OwnerReferences: []metav1.OwnerReference{{


### PR DESCRIPTION
Fixes #509

## Proposed Changes

- Add labels as part of args for MakeTopic / MakePullSubscription
- Pass the name of the source as one of the labels
- refactor labels to include receive-adapter
- refactor MakeTopic to receive a TopicArgs as in https://github.com/google/knative-gcp/pull/521 for MakePullSubscription

Still have some questions about where the info for channel, if necessary at all, comes from.

**Release Note**

```release-note
Improved observability of which source or channel or broker a resource belongs to.
```
