### PR TITLE
Stop decoding json from pubsub

### DIFF
--- a/pkg/pubsub/adapter/converters/pubsub.go
+++ b/pkg/pubsub/adapter/converters/pubsub.go
@@ -18,7 +18,6 @@ package converters
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go"
@@ -60,16 +59,7 @@ func convertPubSub(ctx context.Context, msg *cepubsub.Message, sendMode ModeType
 			ID:          event.ID(),
 			Attributes:  msg.Attributes,
 			PublishTime: event.Time(),
-		}
-
-		var raw json.RawMessage
-		if err := event.DataAs(&raw); err != nil {
-			logger.Desugar().Debug("Failed to get data as raw json, using as is.", zap.Error(err))
-			// Use data as a byte slice.
-			msg.Data = event.Data
-		} else {
-			// Use data as a raw message.
-			msg.Data = raw
+			Data:        event.Data,
 		}
 
 		if err := event.SetData(&PushMessage{

--- a/pkg/pubsub/adapter/converters/pubsub_test.go
+++ b/pkg/pubsub/adapter/converters/pubsub_test.go
@@ -116,7 +116,7 @@ func TestConvertCloudPubSub(t *testing.T) {
 			return pubSubPushCloudEvent(map[string]string{
 				"attribute1":        "value1",
 				"Invalid-Attrib#$^": "value2",
-			}, "\"test data\"")
+			}, "\"InRlc3QgZGF0YSI=\"")
 		},
 	}, {
 		name: "Push mode with no attributes",
@@ -126,7 +126,7 @@ func TestConvertCloudPubSub(t *testing.T) {
 		},
 		sendMode: Push,
 		wantEventFn: func() *cloudevents.Event {
-			return pubSubPushCloudEvent(nil, "\"test data\"")
+			return pubSubPushCloudEvent(nil, "\"InRlc3QgZGF0YSI=\"")
 		},
 	}}
 


### PR DESCRIPTION
Always leave pubsub message data as b64-encoded, regardless of what the decoded data looks like.

Fixes #546

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
All data in pubsub messages is returned as a base-64 encoded strings. Previously, JSON data was decoded as a special case.
```
