### PR TITLE
Update PR template with more instructions

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,17 +1,43 @@
 Fixes #
 
+<!-- Please include the 'why' behind your changes if no issue exists -->
+
 ## Proposed Changes
 
 -
 -
 -
 
+<!--
+If this change has user-visible impact, follow the instructions below.
+Examples include:
+
+- 🎁 Add new feature
+- 🐛 Fix bug
+- 🧽 Update or clean up current behavior
+- 🗑️ Remove feature or internal logic
+
+Otherwise delete the rest of this template.
+-->
+
 **Release Note**
 
-<!-- Enter your extended release note in the below block. If the PR requires
-additional action from users switching to the new release, include the string
-"action required". If no release note is required, write "NONE". -->
+<!--
+🗒️ If this change has user-visible impact, write a release note in the block
+below. Include the string "action required" if additional action is required of
+users switching to the new release, for example in case of a breaking change.
+
+Write as if you are speaking to users, not other Knative contributors. If this
+change has no user-visible impact, no release-note is needed.
+-->
 
 ```release-note
 
 ```
+
+**Docs**
+
+<!--
+📖 If this change has user-visible impact, link to an issue or PR in
+https://github.com/knative/docs.
+-->


### PR DESCRIPTION
Copied from https://github.com/knative/eventing/pull/2601.

Call to action to add release notes and docs issues when the change has user-visible impact.