### PR TITLE
add e2e test for AuditLogs>Broker with PubSub Channel

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -209,11 +209,18 @@ func TestCloudPubSubSourceBrokerWithPubSubChannel(t *testing.T) {
 	PubSubSourceBrokerWithPubSubChannelTestImpl(t)
 }
 
-// TestCloudStorageSourceBrokerWithPubSubChannel tests we can knock a Knative Service from a broker with PubSub Channel from a CloudPubSubSource.
+
+// TestCloudStorageSourceBrokerWithPubSubChannel tests we can knock a Knative Service from a broker with PubSub Channel from a CloudStorageSource.
 func TestCloudStorageSourceBrokerWithPubSubChannel(t *testing.T) {
 	cancel := logstream.Start(t)
 	defer cancel()
 	StorageSourceBrokerWithPubSubChannelTestImpl(t)
+
+// TestCloudAuditLogsSourceBrokerWithPubSubChannel tests we can knock a Knative Service from a broker with PubSub Channel from a CloudAuditLogsSource.
+func TestCloudAuditLogsSourceBrokerWithPubSubChannel(t *testing.T) {
+	cancel := logstream.Start(t)
+	defer cancel()
+	AuditLogsSourceBrokerWithPubSubChannelTestImpl(t)
 }
 
 // TestCloudStorageSource tests we can knock down a target from a CloudStorageSource.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -209,12 +209,12 @@ func TestCloudPubSubSourceBrokerWithPubSubChannel(t *testing.T) {
 	PubSubSourceBrokerWithPubSubChannelTestImpl(t)
 }
 
-
 // TestCloudStorageSourceBrokerWithPubSubChannel tests we can knock a Knative Service from a broker with PubSub Channel from a CloudStorageSource.
 func TestCloudStorageSourceBrokerWithPubSubChannel(t *testing.T) {
 	cancel := logstream.Start(t)
 	defer cancel()
 	StorageSourceBrokerWithPubSubChannelTestImpl(t)
+}
 
 // TestCloudAuditLogsSourceBrokerWithPubSubChannel tests we can knock a Knative Service from a broker with PubSub Channel from a CloudAuditLogsSource.
 func TestCloudAuditLogsSourceBrokerWithPubSubChannel(t *testing.T) {

--- a/test/e2e/lib/auditlogs.go
+++ b/test/e2e/lib/auditlogs.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lib
+
+import (
+	"fmt"
+
+	"github.com/google/knative-gcp/pkg/apis/events/v1alpha1"
+	kngcptesting "github.com/google/knative-gcp/pkg/reconciler/testing"
+	"github.com/google/knative-gcp/test/e2e/lib/resources"
+	v1 "k8s.io/api/core/v1"
+)
+
+func MakeAuditLogsOrDie(client *Client,
+	auditlogsName, methodName, project, resourceName, serviceName, targetName string,
+	so ...kngcptesting.CloudAuditLogsSourceOption,
+) {
+	so = append(so, kngcptesting.WithCloudAuditLogsSourceServiceName(serviceName))
+	so = append(so, kngcptesting.WithCloudAuditLogsSourceMethodName(methodName))
+	so = append(so, kngcptesting.WithCloudAuditLogsSourceProject(project))
+	so = append(so, kngcptesting.WithCloudAuditLogsSourceResourceName(resourceName))
+	so = append(so, kngcptesting.WithCloudAuditLogsSourceSink(ServiceGVK, targetName))
+	eventsAuditLogs := kngcptesting.NewCloudAuditLogsSource(auditlogsName, client.Namespace, so...)
+	client.CreateAuditLogsOrFail(eventsAuditLogs)
+
+	client.Core.WaitForResourceReadyOrFail(auditlogsName, CloudAuditLogsSourceTypeMeta)
+}
+
+func MakeAuditLogsJobOrDie(client *Client, methodName, project, resourceName, serviceName, targetName string) {
+	job := resources.AuditLogsTargetJob(targetName, []v1.EnvVar{{
+		Name:  "SERVICENAME",
+		Value: serviceName,
+	}, {
+		Name:  "METHODNAME",
+		Value: methodName,
+	}, {
+		Name:  "RESOURCENAME",
+		Value: resourceName,
+	}, {
+		Name:  "TYPE",
+		Value: v1alpha1.CloudAuditLogsSourceEvent,
+	}, {
+		Name:  "SOURCE",
+		Value: v1alpha1.CloudAuditLogsSourceEventSource(serviceName, fmt.Sprintf("projects/%s", project)),
+	}, {
+		Name:  "SUBJECT",
+		Value: resourceName,
+	}, {
+		Name:  "TIME",
+		Value: "360",
+	}})
+	client.CreateJobOrFail(job, WithServiceForJob(targetName))
+}

--- a/test/e2e/lib/pubsub.go
+++ b/test/e2e/lib/pubsub.go
@@ -29,8 +29,7 @@ import (
 	pkgmetrics "knative.dev/pkg/metrics"
 )
 
-func MakePubSubOrDie(t *testing.T,
-	client *Client,
+func MakePubSubOrDie(client *Client,
 	gvk metav1.GroupVersionKind,
 	psName, targetName, topicName string,
 	so ...kngcptesting.CloudPubSubSourceOption,

--- a/test/e2e/test_pubsub.go
+++ b/test/e2e/test_pubsub.go
@@ -45,7 +45,7 @@ func SmokeCloudPubSubSourceTestImpl(t *testing.T) {
 	defer lib.TearDown(client)
 
 	// Create the PubSub source.
-	lib.MakePubSubOrDie(t, client, metav1.GroupVersionKind{
+	lib.MakePubSubOrDie(client, metav1.GroupVersionKind{
 		Version: "v1",
 		Kind:    "Service"}, psName, svcName, topic)
 
@@ -76,7 +76,7 @@ func CloudPubSubSourceWithTargetTestImpl(t *testing.T, assertMetrics bool) {
 	client.CreateJobOrFail(job, lib.WithServiceForJob(targetName))
 
 	// Create the PubSub source.
-	lib.MakePubSubOrDie(t, client, lib.ServiceGVK, psName, targetName, topicName)
+	lib.MakePubSubOrDie(client, lib.ServiceGVK, psName, targetName, topicName)
 
 	topic := lib.GetTopic(t, topicName)
 


### PR DESCRIPTION
Second part of #511

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add an e2e test that does CloudAuditLogsSource -> Broker backed by PubSub channel
-
-
