### PR TITLE
Fix typo in storage doc

### DIFF
--- a/docs/examples/cloudstoragesource/README.md
+++ b/docs/examples/cloudstoragesource/README.md
@@ -59,7 +59,7 @@ Notifications for when a new object is added to Google Cloud Storage (GCS).
    command:
 
    ```shell
-   sed "s/\BUCKET/$BUCKET/g" cloudstoragesource.yaml | \
+   sed "s/BUCKET/$BUCKET/g" cloudstoragesource.yaml | \
        kubectl apply --filename -
    ```
 
@@ -79,7 +79,7 @@ Notifications for when a new object is added to Google Cloud Storage (GCS).
    and then apply in one command:
 
    ```shell
-   sed "s/\BUCKET/$BUCKET/g" pullsubscription.yaml | \
+   sed "s/BUCKET/$BUCKET/g" pullsubscription.yaml | \
    sed "s/\#project: MY_PROJECT/project: $PROJECT_ID/g" | \
        kubectl apply --filename -
    ```
@@ -102,7 +102,7 @@ Notifications for when a new object is added to Google Cloud Storage (GCS).
 Upload a file to your BUCKET, either using the [Cloud Console](https://cloud.google.com/console) or gsutil:
 
 ```shell
-gsutil cp cloudstoragesource.yaml gs://$BUCKET/testfilehere'
+gsutil cp cloudstoragesource.yaml gs://$BUCKET/testfilehere
 ```
 
 ## Verify


### PR DESCRIPTION
 `sed "s/\BUCKET/$BUCKET/g" cloudstoragesource.yaml | ` will have error in Linux. `sed "s/BUCKET/$BUCKET/g" cloudstoragesource.yaml | ` works for both mac and linux

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🐛 Fix bug
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
