### PR TITLE
Update the release script to use ARTIFACTS_TO_PUBLISH

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -58,7 +58,7 @@ function build_release() {
     done
     all_yamls+=(${yaml})
   done
-  YAMLS_TO_PUBLISH="${all_yamls[@]}"
+  ARTIFACTS_TO_PUBLISH="${all_yamls[@]}"
 }
 
 main $@


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- This project has not updated test-infra for a while, and the update in https://github.com/google/knative-gcp/pull/579 contains a breaking change that removes an environment variable in base release script. This cause knative-gcp release jobs to fail. Update the release.sh to use the new variable.

/cc @nachocano 