### PR TITLE
Start knative gcp after creating secrets for perf tests

### DIFF
--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -33,7 +33,6 @@ readonly CONTROL_PLANE_NAMESPACE="cloud-run-events"
 readonly CONTROL_PLANE_SECRET_NAME="google-cloud-key"
 
 function update_knative() {
-  start_knative_gcp || return 1
   # Create the secret for pub-sub if it does not exist.
   kubectl -n ${TEST_NAMESPACE} get secret ${PUBSUB_SECRET_NAME} || \
   kubectl -n ${TEST_NAMESPACE} create secret generic ${PUBSUB_SECRET_NAME} \
@@ -47,6 +46,9 @@ function update_knative() {
   kubectl -n ${CONTROL_PLANE_NAMESPACE} get secret ${CONTROL_PLANE_SECRET_NAME} || \
   kubectl -n ${CONTROL_PLANE_NAMESPACE} create secret generic ${CONTROL_PLANE_SECRET_NAME} \
     --from-file=key.json="${GOOGLE_APPLICATION_CREDENTIALS}"
+
+  # Start Knative GCP. Fail the update process if there is any error.
+  start_knative_gcp || return 1
 }
 
 function update_benchmark() {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- The change in https://github.com/google/knative-gcp/pull/573 broke the performance tests setup - the controller was unable to start due to missing google-cloud-key secret. We should create the secrets first, then start Knative GCP.

/cc @nachocano 
/cc @grac3gao 