### PR TITLE
Update policy binding validation and immutable fields check

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1757,6 +1757,7 @@
     "knative.dev/pkg/injection/clients/dynamicclient/fake",
     "knative.dev/pkg/injection/sharedmain",
     "knative.dev/pkg/kmeta",
+    "knative.dev/pkg/kmp",
     "knative.dev/pkg/leaderelection",
     "knative.dev/pkg/logging",
     "knative.dev/pkg/logging/testing",

--- a/pkg/apis/security/v1alpha1/common_validation.go
+++ b/pkg/apis/security/v1alpha1/common_validation.go
@@ -120,10 +120,9 @@ func (pbs *PolicyBindingSpec) Validate(ctx context.Context, parentNamespace stri
 	}
 	// Specify subject either by an object reference or by label selector.
 	// Cannot be both.
-	if pbs.Subject.APIVersion != "" || pbs.Subject.Kind != "" || pbs.Subject.Name != "" {
-		if pbs.Subject.APIVersion == "" || pbs.Subject.Kind == "" || pbs.Subject.Name == "" {
-			errs = errs.Also(subjectRefErr.ViaField("subject"))
-		}
+	if !allEmpty(pbs.Subject.APIVersion, pbs.Subject.Kind, pbs.Subject.Name) &&
+		!allPresent(pbs.Subject.APIVersion, pbs.Subject.Kind, pbs.Subject.Name) {
+		errs = errs.Also(subjectRefErr.ViaField("subject"))
 	}
 	if pbs.Subject.Name == "" && pbs.Subject.Selector == nil {
 		errs = errs.Also(apis.ErrMissingOneOf("name", "selector").ViaField("subject"))
@@ -142,6 +141,24 @@ func (pbs *PolicyBindingSpec) Validate(ctx context.Context, parentNamespace stri
 		errs = errs.Also(apis.ErrInvalidValue(pbs.Policy.Namespace, "namespace").ViaField("policy"))
 	}
 	return errs
+}
+
+func allEmpty(ss ...string) bool {
+	for _, s := range ss {
+		if s != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func allPresent(ss ...string) bool {
+	for _, s := range ss {
+		if s == "" {
+			return false
+		}
+	}
+	return true
 }
 
 // CheckImmutableFields checks if any immutable fields are changed in a PolicyBindingSpec.

--- a/pkg/apis/security/v1alpha1/eventpolicybinding_validation.go
+++ b/pkg/apis/security/v1alpha1/eventpolicybinding_validation.go
@@ -30,3 +30,11 @@ func (pb *EventPolicyBinding) Validate(ctx context.Context) *apis.FieldError {
 	}
 	return errs
 }
+
+// CheckImmutableFields checks if any immutable fields are changed in an EventPolicyBinding.
+func (pb *EventPolicyBinding) CheckImmutableFields(ctx context.Context, original *EventPolicyBinding) *apis.FieldError {
+	if original == nil {
+		return nil
+	}
+	return pb.Spec.CheckImmutableFields(ctx, &original.Spec)
+}

--- a/pkg/apis/security/v1alpha1/httppolicybinding_validation.go
+++ b/pkg/apis/security/v1alpha1/httppolicybinding_validation.go
@@ -30,3 +30,11 @@ func (pb *HTTPPolicyBinding) Validate(ctx context.Context) *apis.FieldError {
 	}
 	return errs
 }
+
+// CheckImmutableFields checks if any immutable fields are changed in a HTTPPolicyBinding.
+func (pb *HTTPPolicyBinding) CheckImmutableFields(ctx context.Context, original *HTTPPolicyBinding) *apis.FieldError {
+	if original == nil {
+		return nil
+	}
+	return pb.Spec.CheckImmutableFields(ctx, &original.Spec)
+}

--- a/pkg/apis/security/v1alpha1/httppolicybinding_validation_test.go
+++ b/pkg/apis/security/v1alpha1/httppolicybinding_validation_test.go
@@ -43,8 +43,10 @@ func TestHTTPPolicyBindingValidation(t *testing.T) {
 			Spec: PolicyBindingSpec{
 				BindingSpec: duckv1alpha1.BindingSpec{
 					Subject: tracker.Reference{
-						Name:      "subject",
-						Namespace: "foo",
+						APIVersion: "example.com/v1",
+						Kind:       "Foo",
+						Name:       "subject",
+						Namespace:  "foo",
 					},
 				},
 				Policy: duckv1.KReference{
@@ -63,8 +65,10 @@ func TestHTTPPolicyBindingValidation(t *testing.T) {
 			Spec: PolicyBindingSpec{
 				BindingSpec: duckv1alpha1.BindingSpec{
 					Subject: tracker.Reference{
-						Name:      "subject",
-						Namespace: "bar",
+						APIVersion: "example.com/v1",
+						Kind:       "Foo",
+						Name:       "subject",
+						Namespace:  "bar",
 					},
 				},
 				Policy: duckv1.KReference{
@@ -104,8 +108,10 @@ func TestHTTPPolicyBindingValidation(t *testing.T) {
 			Spec: PolicyBindingSpec{
 				BindingSpec: duckv1alpha1.BindingSpec{
 					Subject: tracker.Reference{
-						Name:      "subject",
-						Namespace: "foo",
+						APIVersion: "example.com/v1",
+						Kind:       "Foo",
+						Name:       "subject",
+						Namespace:  "foo",
 					},
 				},
 				Policy: duckv1.KReference{
@@ -125,8 +131,10 @@ func TestHTTPPolicyBindingValidation(t *testing.T) {
 			Spec: PolicyBindingSpec{
 				BindingSpec: duckv1alpha1.BindingSpec{
 					Subject: tracker.Reference{
-						Name:      "subject",
-						Namespace: "foo",
+						APIVersion: "example.com/v1",
+						Kind:       "Foo",
+						Name:       "subject",
+						Namespace:  "foo",
 					},
 				},
 				Policy: duckv1.KReference{
@@ -147,8 +155,10 @@ func TestHTTPPolicyBindingValidation(t *testing.T) {
 			Spec: PolicyBindingSpec{
 				BindingSpec: duckv1alpha1.BindingSpec{
 					Subject: tracker.Reference{
-						Name:      "subject",
-						Namespace: "foo",
+						APIVersion: "example.com/v1",
+						Kind:       "Foo",
+						Name:       "subject",
+						Namespace:  "foo",
 					},
 				},
 				Policy: duckv1.KReference{
@@ -166,6 +176,112 @@ func TestHTTPPolicyBindingValidation(t *testing.T) {
 			gotErr := tc.pb.Validate(context.Background())
 			if diff := cmp.Diff(tc.wantErr.Error(), gotErr.Error()); diff != "" {
 				t.Errorf("HTTPPolicyBinding.Validate (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
+func TestHTTPPolicyBindingCheckImmutableFields(t *testing.T) {
+	cases := []struct {
+		name    string
+		orignal *HTTPPolicyBinding
+		updated *HTTPPolicyBinding
+		wantErr *apis.FieldError
+	}{{
+		name: "subject changed",
+		orignal: &HTTPPolicyBinding{Spec: PolicyBindingSpec{
+			BindingSpec: duckv1alpha1.BindingSpec{
+				Subject: tracker.Reference{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+				},
+			},
+			Policy: duckv1.KReference{
+				Name: "policy",
+			},
+		}},
+		updated: &HTTPPolicyBinding{Spec: PolicyBindingSpec{
+			BindingSpec: duckv1alpha1.BindingSpec{
+				Subject: tracker.Reference{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "foo"},
+					},
+				},
+			},
+			Policy: duckv1.KReference{
+				Name: "policy",
+			},
+		}},
+		wantErr: &apis.FieldError{
+			Message: "Immutable fields changed (-old +new)",
+			Paths:   []string{"spec"},
+			Details: "{*v1alpha1.PolicyBindingSpec}.BindingSpec.Subject.Selector.MatchLabels[\"app\"]:\n\t-: \"test\"\n\t+: \"foo\"\n",
+		},
+	}, {
+		name: "policy changed",
+		orignal: &HTTPPolicyBinding{Spec: PolicyBindingSpec{
+			BindingSpec: duckv1alpha1.BindingSpec{
+				Subject: tracker.Reference{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+				},
+			},
+			Policy: duckv1.KReference{
+				Name: "policy",
+			},
+		}},
+		updated: &HTTPPolicyBinding{Spec: PolicyBindingSpec{
+			BindingSpec: duckv1alpha1.BindingSpec{
+				Subject: tracker.Reference{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+				},
+			},
+			Policy: duckv1.KReference{
+				Name: "new-policy",
+			},
+		}},
+		wantErr: &apis.FieldError{
+			Message: "Immutable fields changed (-old +new)",
+			Paths:   []string{"spec"},
+			Details: "{*v1alpha1.PolicyBindingSpec}.Policy.Name:\n\t-: \"policy\"\n\t+: \"new-policy\"\n",
+		},
+	}, {
+		name: "not changed",
+		orignal: &HTTPPolicyBinding{Spec: PolicyBindingSpec{
+			BindingSpec: duckv1alpha1.BindingSpec{
+				Subject: tracker.Reference{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+				},
+			},
+			Policy: duckv1.KReference{
+				Name: "policy",
+			},
+		}},
+		updated: &HTTPPolicyBinding{Spec: PolicyBindingSpec{
+			BindingSpec: duckv1alpha1.BindingSpec{
+				Subject: tracker.Reference{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+				},
+			},
+			Policy: duckv1.KReference{
+				Name: "policy",
+			},
+		}},
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotErr := tc.updated.CheckImmutableFields(context.Background(), tc.orignal)
+			if diff := cmp.Diff(tc.wantErr.Error(), gotErr.Error()); diff != "" {
+				t.Errorf("PolicyBindingSpec.CheckImmutableFields (-want, +got) = %v", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes https://github.com/google/knative-gcp/issues/575

## Changes

- Make policy binding spec immutable. This is needed because otherwise the controller cannot properly cleanup resources from previous subject/policy.
- Better subject validation. A policy binding subject can either be a concrete object reference or label selector. If specified with label selector, then the label selector will directly be used to select workload to bind the policy.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
