### PR TITLE
Update docs to add workload identity functionality related in data-plane

### DIFF
--- a/docs/examples/channel/README.md
+++ b/docs/examples/channel/README.md
@@ -17,7 +17,7 @@ intended to provide a durable messaging solution.
 
 1. Create the `Channel` in [channel.yaml](channel.yaml).
    
-     1. If you are using workload identity, update `serviceAccount` with the Pub/Sub enabled Service Account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
+     1. If you are using workload identity, update `serviceAccount` with the Pub/Sub enabled service account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
       
      1. If you are using non-default secret, update `project` and `secret`.
    ```shell

--- a/docs/examples/channel/README.md
+++ b/docs/examples/channel/README.md
@@ -16,9 +16,10 @@ intended to provide a durable messaging solution.
 ## Deployment
 
 1. Create the `Channel` in [channel.yaml](channel.yaml).
-
-   **Note**: _Update `project` and `secret` if you are not using defaults._
-
+   
+     1. If you are using workload identity, update `serviceAccount` with the Pub/Sub enabled Service Account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
+      
+     1. If you are using non-default secret, update `project` and `secret`.
    ```shell
    kubectl apply --filename channel.yaml
    ```

--- a/docs/examples/channel/README.md
+++ b/docs/examples/channel/README.md
@@ -17,9 +17,11 @@ intended to provide a durable messaging solution.
 
 1. Create the `Channel` in [channel.yaml](channel.yaml).
    
-     1. If you are using workload identity, update `serviceAccount` with the Pub/Sub enabled service account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
+     1. If you are in GKE and using [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity),
+      update `serviceAccount` with the Pub/Sub enabled service account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
       
-     1. If you are using non-default secret, update `project` and `secret`.
+     1. If you are using standard Kubernetes secrets, but want to use a non-default one, update `secret` with your own secret.
+
    ```shell
    kubectl apply --filename channel.yaml
    ```

--- a/docs/examples/channel/channel.yaml
+++ b/docs/examples/channel/channel.yaml
@@ -17,6 +17,7 @@ kind: Channel
 metadata:
   name: demo
 spec:
+
 #  # If running in GKE, we will ask the metadata server, change this if required.
 #  project: MY_PROJECT
 #  # If running with workload identity enabled, update serviceAccount.

--- a/docs/examples/channel/channel.yaml
+++ b/docs/examples/channel/channel.yaml
@@ -17,10 +17,11 @@ kind: Channel
 metadata:
   name: demo
 spec:
-
 #  # If running in GKE, we will ask the metadata server, change this if required.
 #  project: MY_PROJECT
-#  # The default secret name and key, change this if required.
+#  # If running with workload identity enabled, update serviceAccount.
+#  serviceAccount: service-account-id@project-id.iam.gserviceaccount.com
+#  # If running with secret, here is the default secret name and key, change this if required.
 #  secret:
 #    name: google-cloud-key
 #    key: key.json

--- a/docs/examples/channel/subscription.yaml
+++ b/docs/examples/channel/subscription.yaml
@@ -23,6 +23,6 @@ spec:
     name: demo
   subscriber:
     ref:
-      apiVersion: serving.knative.dev/v1
+      apiVersion: v1
       kind: Service
       name: event-display

--- a/docs/examples/cloudauditlogssource/README.md
+++ b/docs/examples/cloudauditlogssource/README.md
@@ -32,9 +32,11 @@ directly publish to the underlying transport (Pub/Sub), in CloudEvents format.
    :-------------------: | :--------------------------: | | serviceName |
    protoPayload.serviceName | | methodName | protoPayload.methodName | |
    resourceName | protoPayload.resourceName |
-   1. If you are using workload identity, update `serviceAccount` with the Pub/Sub enabled service account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
-    
-   1. If you are using non-default secret, update `project` and `secret`.
+   
+     1. If you are in GKE and using [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity),
+      update `serviceAccount` with the Pub/Sub enabled service account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
+      
+     1. If you are using standard Kubernetes secrets, but want to use a non-default one, update `secret` with your own secret.
 
    ```shell
    kubectl apply --filename cloudauditlogssource.yaml

--- a/docs/examples/cloudauditlogssource/README.md
+++ b/docs/examples/cloudauditlogssource/README.md
@@ -32,7 +32,7 @@ directly publish to the underlying transport (Pub/Sub), in CloudEvents format.
    :-------------------: | :--------------------------: | | serviceName |
    protoPayload.serviceName | | methodName | protoPayload.methodName | |
    resourceName | protoPayload.resourceName |
-   1. If you are using workload identity, update `serviceAccount` with the Pub/Sub enabled Service Account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
+   1. If you are using workload identity, update `serviceAccount` with the Pub/Sub enabled service account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
     
    1. If you are using non-default secret, update `project` and `secret`.
 

--- a/docs/examples/cloudauditlogssource/README.md
+++ b/docs/examples/cloudauditlogssource/README.md
@@ -32,6 +32,9 @@ directly publish to the underlying transport (Pub/Sub), in CloudEvents format.
    :-------------------: | :--------------------------: | | serviceName |
    protoPayload.serviceName | | methodName | protoPayload.methodName | |
    resourceName | protoPayload.resourceName |
+   1. If you are using workload identity, update `serviceAccount` with the Pub/Sub enabled Service Account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
+    
+   1. If you are using non-default secret, update `project` and `secret`.
 
    ```shell
    kubectl apply --filename cloudauditlogssource.yaml

--- a/docs/examples/cloudauditlogssource/cloudauditlogssource.yaml
+++ b/docs/examples/cloudauditlogssource/cloudauditlogssource.yaml
@@ -11,14 +11,11 @@ spec:
       kind: Service
       name: event-display
 
-  # If running in GKE, we will ask the metadata server, change this if required.
-  #project: MY_PROJECT
-  #  # If running with workload identity enabled, update serviceAccount.
-  #  serviceAccount: service-account-id@project-id.iam.gserviceaccount.com
-  #  # If running with secret, here is the default secret name and key, change this if required.
-  #secret:
-  #  name: google-cloud-key
-  #  key: key.json
-  #pubsubSecret:  # A secret in the default namespace for Pub/Sub operations
-  #name: google-cloud-key
-  #key: key.json
+#    # If running in GKE, we will ask the metadata server, change this if required.
+#  project: MY_PROJECT
+#    # If running with workload identity enabled, update serviceAccount.
+#  serviceAccount: service-account-id@project-id.iam.gserviceaccount.com
+#    # If running with secret, here is the default secret name and key, change this if required.
+#  secret:
+#    name: google-cloud-key
+#    key: key.json

--- a/docs/examples/cloudauditlogssource/cloudauditlogssource.yaml
+++ b/docs/examples/cloudauditlogssource/cloudauditlogssource.yaml
@@ -13,7 +13,9 @@ spec:
 
   # If running in GKE, we will ask the metadata server, change this if required.
   #project: MY_PROJECT
-  # The default secret name and key, change this if required.
+  #  # If running with workload identity enabled, update serviceAccount.
+  #  serviceAccount: service-account-id@project-id.iam.gserviceaccount.com
+  #  # If running with secret, here is the default secret name and key, change this if required.
   #secret:
   #  name: google-cloud-key
   #  key: key.json

--- a/docs/examples/cloudpubsubsource/README.md
+++ b/docs/examples/cloudpubsubsource/README.md
@@ -18,6 +18,9 @@ events using a Push-compatible format.
 1. Create a GCP PubSub Topic. If you change its name (`testing`), you also need
    to update the `topic` in the [`CloudPubSubSource`](cloudpubsubsource.yaml)
    file:
+      1. If you are using workload identity, update `serviceAccount` with the Pub/Sub enabled Service Account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
+       
+      1. If you are using non-default secret, update `project` and `secret`.
 
    ```shell
    gcloud pubsub topics create testing

--- a/docs/examples/cloudpubsubsource/README.md
+++ b/docs/examples/cloudpubsubsource/README.md
@@ -18,7 +18,7 @@ events using a Push-compatible format.
 1. Create a GCP PubSub Topic. If you change its name (`testing`), you also need
    to update the `topic` in the [`CloudPubSubSource`](cloudpubsubsource.yaml)
    file:
-      1. If you are using workload identity, update `serviceAccount` with the Pub/Sub enabled Service Account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
+      1. If you are using workload identity, update `serviceAccount` with the Pub/Sub enabled service account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
        
       1. If you are using non-default secret, update `project` and `secret`.
 

--- a/docs/examples/cloudpubsubsource/README.md
+++ b/docs/examples/cloudpubsubsource/README.md
@@ -17,10 +17,12 @@ events using a Push-compatible format.
 
 1. Create a GCP PubSub Topic. If you change its name (`testing`), you also need
    to update the `topic` in the [`CloudPubSubSource`](cloudpubsubsource.yaml)
-   file:
-      1. If you are using workload identity, update `serviceAccount` with the Pub/Sub enabled service account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
-       
-      1. If you are using non-default secret, update `project` and `secret`.
+   file.
+   
+     1. If you are in GKE and using [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity),
+      update `serviceAccount` with the Pub/Sub enabled service account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
+      
+     1. If you are using standard Kubernetes secrets, but want to use a non-default one, update `secret` with your own secret.
 
    ```shell
    gcloud pubsub topics create testing

--- a/docs/examples/cloudpubsubsource/cloudpubsubsource.yaml
+++ b/docs/examples/cloudpubsubsource/cloudpubsubsource.yaml
@@ -10,14 +10,11 @@ spec:
       kind: Service
       name: event-display
 
-  # If running in GKE, we will ask the metadata server, change this if required.
-  #project: MY_PROJECT
-  #  # If running with workload identity enabled, update serviceAccount.
-  #  serviceAccount: service-account-id@project-id.iam.gserviceaccount.com
-  #  # If running with secret, here is the default secret name and key, change this if required.
-  #secret:
-  #  name: google-cloud-key
-  #  key: key.json
-  #pubsubSecret:  # A secret in the default namespace for Pub/Sub operations
-  #name: google-cloud-key
-  #key: key.json
+#    # If running in GKE, we will ask the metadata server, change this if required.
+#  project: MY_PROJECT
+#    # If running with workload identity enabled, update serviceAccount.
+#  serviceAccount: service-account-id@project-id.iam.gserviceaccount.com
+#    # If running with secret, here is the default secret name and key, change this if required.
+#  secret:
+#    name: google-cloud-key
+#    key: key.json

--- a/docs/examples/cloudpubsubsource/cloudpubsubsource.yaml
+++ b/docs/examples/cloudpubsubsource/cloudpubsubsource.yaml
@@ -12,7 +12,9 @@ spec:
 
   # If running in GKE, we will ask the metadata server, change this if required.
   #project: MY_PROJECT
-  # The default secret name and key, change this if required.
+  #  # If running with workload identity enabled, update serviceAccount.
+  #  serviceAccount: service-account-id@project-id.iam.gserviceaccount.com
+  #  # If running with secret, here is the default secret name and key, change this if required.
   #secret:
   #  name: google-cloud-key
   #  key: key.json

--- a/docs/examples/cloudschedulersource/README.md
+++ b/docs/examples/cloudschedulersource/README.md
@@ -25,6 +25,9 @@ scheduled events from
 
 1. Create a [`CloudSchedulerSource`](cloudschedulersource.yaml)
 
+   1. If you are using workload identity, update `serviceAccount` with the Pub/Sub enabled Service Account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
+    
+   1. If you are using non-default secret, update `project` and `secret`.
    ```shell
    kubectl apply --filename cloudschedulersource.yaml
    ```

--- a/docs/examples/cloudschedulersource/README.md
+++ b/docs/examples/cloudschedulersource/README.md
@@ -25,9 +25,11 @@ scheduled events from
 
 1. Create a [`CloudSchedulerSource`](cloudschedulersource.yaml)
 
-   1. If you are using workload identity, update `serviceAccount` with the Pub/Sub enabled service account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
-    
-   1. If you are using non-default secret, update `project` and `secret`.
+     1. If you are in GKE and using [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity),
+      update `serviceAccount` with the Pub/Sub enabled service account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
+      
+     1. If you are using standard Kubernetes secrets, but want to use a non-default one, update `secret` with your own secret.
+
    ```shell
    kubectl apply --filename cloudschedulersource.yaml
    ```

--- a/docs/examples/cloudschedulersource/README.md
+++ b/docs/examples/cloudschedulersource/README.md
@@ -25,7 +25,7 @@ scheduled events from
 
 1. Create a [`CloudSchedulerSource`](cloudschedulersource.yaml)
 
-   1. If you are using workload identity, update `serviceAccount` with the Pub/Sub enabled Service Account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
+   1. If you are using workload identity, update `serviceAccount` with the Pub/Sub enabled service account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
     
    1. If you are using non-default secret, update `project` and `secret`.
    ```shell

--- a/docs/examples/cloudschedulersource/cloudschedulersource.yaml
+++ b/docs/examples/cloudschedulersource/cloudschedulersource.yaml
@@ -12,14 +12,11 @@ spec:
       kind: Service
       name: event-display
 
-  # If running in GKE, we will ask the metadata server, change this if required.
-  #project: MY_PROJECT
-  #  # If running with workload identity enabled, update serviceAccount.
-  #  serviceAccount: service-account-id@project-id.iam.gserviceaccount.com
-  #  # If running with secret, here is the default secret name and key, change this if required.
-  #secret:
-  #  name: google-cloud-key
-  #  key: key.json
-  #pubsubSecret:  # A secret in the default namespace for Pub/Sub operations
-  #name: google-cloud-key
-  #key: key.json
+#    # If running in GKE, we will ask the metadata server, change this if required.
+#  project: MY_PROJECT
+#    # If running with workload identity enabled, update serviceAccount.
+#  serviceAccount: service-account-id@project-id.iam.gserviceaccount.com
+#    # If running with secret, here is the default secret name and key, change this if required.
+#  secret:
+#    name: google-cloud-key
+#    key: key.json

--- a/docs/examples/cloudschedulersource/cloudschedulersource.yaml
+++ b/docs/examples/cloudschedulersource/cloudschedulersource.yaml
@@ -14,7 +14,9 @@ spec:
 
   # If running in GKE, we will ask the metadata server, change this if required.
   #project: MY_PROJECT
-  # The default secret name and key, change this if required.
+  #  # If running with workload identity enabled, update serviceAccount.
+  #  serviceAccount: service-account-id@project-id.iam.gserviceaccount.com
+  #  # If running with secret, here is the default secret name and key, change this if required.
   #secret:
   #  name: google-cloud-key
   #  key: key.json

--- a/docs/examples/cloudstoragesource/README.md
+++ b/docs/examples/cloudstoragesource/README.md
@@ -72,9 +72,11 @@ Object Notifications for when a new object is added to Google Cloud Storage
    kubectl apply --filename cloudstoragesource.yaml
    ```
    **Note**:
-      1. If you are using workload identity, update `serviceAccount` with the Pub/Sub enabled Service Account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
-       
-      1. If you are using non-default secret, update `project` and `secret`.
+     1. If you are in GKE and using [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity),
+      update `serviceAccount` with the Pub/Sub enabled service account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
+      
+     1. If you are using standard Kubernetes secrets, but want to use a non-default one, update `secret` with your own secret.
+
 1. [Optional] If not using GKE, or want to use a Pub/Sub topic from another
    project, uncomment and replace the `MY_PROJECT` placeholder in
    [`cloudstoragesource.yaml`](cloudstoragesource.yaml) and apply it. Note that

--- a/docs/examples/cloudstoragesource/README.md
+++ b/docs/examples/cloudstoragesource/README.md
@@ -71,7 +71,10 @@ Object Notifications for when a new object is added to Google Cloud Storage
    ```shell
    kubectl apply --filename cloudstoragesource.yaml
    ```
-
+   **Note**:
+      1. If you are using workload identity, update `serviceAccount` with the Pub/Sub enabled Service Account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
+       
+      1. If you are using non-default secret, update `project` and `secret`.
 1. [Optional] If not using GKE, or want to use a Pub/Sub topic from another
    project, uncomment and replace the `MY_PROJECT` placeholder in
    [`cloudstoragesource.yaml`](cloudstoragesource.yaml) and apply it. Note that

--- a/docs/examples/cloudstoragesource/README.md
+++ b/docs/examples/cloudstoragesource/README.md
@@ -54,6 +54,13 @@ Object Notifications for when a new object is added to Google Cloud Storage
 
 ## Deployment
 
+1. Update `serviceAccount` / `secret` in the [`cloudstoragesource.yaml`](cloudstoragesource.yaml)
+
+     1. If you are in GKE and using [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity),
+      update `serviceAccount` with the Pub/Sub enabled service account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
+      
+     1. If you are using standard Kubernetes secrets, but want to use a non-default one, update `secret` with your own secret.
+
 1. Update `BUCKET` in the [`cloudstoragesource.yaml`](cloudstoragesource.yaml)
    and apply it.
 
@@ -71,11 +78,6 @@ Object Notifications for when a new object is added to Google Cloud Storage
    ```shell
    kubectl apply --filename cloudstoragesource.yaml
    ```
-   **Note**:
-     1. If you are in GKE and using [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity),
-      update `serviceAccount` with the Pub/Sub enabled service account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
-      
-     1. If you are using standard Kubernetes secrets, but want to use a non-default one, update `secret` with your own secret.
 
 1. [Optional] If not using GKE, or want to use a Pub/Sub topic from another
    project, uncomment and replace the `MY_PROJECT` placeholder in

--- a/docs/examples/cloudstoragesource/cloudstoragesource.yaml
+++ b/docs/examples/cloudstoragesource/cloudstoragesource.yaml
@@ -30,7 +30,9 @@ spec:
 
   # If running in GKE, we will ask the metadata server, change this if required.
   #project: MY_PROJECT
-  # The default secret name and key, change this if required.
+  #  # If running with workload identity enabled, update serviceAccount.
+  #  serviceAccount: service-account-id@project-id.iam.gserviceaccount.com
+  #  # If running with secret, here is the default secret name and key, change this if required.
   #secret:
   #  name: google-cloud-key
   #  key: key.json

--- a/docs/examples/cloudstoragesource/cloudstoragesource.yaml
+++ b/docs/examples/cloudstoragesource/cloudstoragesource.yaml
@@ -28,19 +28,14 @@ spec:
       kind: Service
       name: event-display
 
-  # If running in GKE, we will ask the metadata server, change this if required.
-  #project: MY_PROJECT
-  #  # If running with workload identity enabled, update serviceAccount.
-  #  serviceAccount: service-account-id@project-id.iam.gserviceaccount.com
-  #  # If running with secret, here is the default secret name and key, change this if required.
-  #secret:
-  #  name: google-cloud-key
-  #  key: key.json
-  # The default secret name and key for managing Pub/Sub resources,
-  # change this if required.
-  #pubSubSecret:
-  #  name: google-cloud-key
-  #  key: key.json
+#    # If running in GKE, we will ask the metadata server, change this if required.
+#  project: MY_PROJECT
+#    # If running with workload identity enabled, update serviceAccount.
+#  serviceAccount: service-account-id@project-id.iam.gserviceaccount.com
+#    # If running with secret, here is the default secret name and key, change this if required.
+#  secret:
+#    name: google-cloud-key
+#    key: key.json
 
 ---
 

--- a/docs/examples/pullsubscription/README.md
+++ b/docs/examples/pullsubscription/README.md
@@ -23,6 +23,13 @@ does so using a Pull format.
    export TOPIC_NAME=testing
    gcloud pubsub topics create $TOPIC_NAME
    ```
+   
+1. Update `serviceAccount` / `secret` in the [`pullsubscription.yaml`](pullsubscription.yaml)
+
+     1. If you are in GKE and using [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity),
+      update `serviceAccount` with the Pub/Sub enabled service account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
+      
+     1. If you are using standard Kubernetes secrets, but want to use a non-default one, update `secret` with your own secret.
 
 1. Update `TOPIC_NAME` in the [`pullsubscription.yaml`](pullsubscription.yaml)
    and apply it.

--- a/docs/examples/pullsubscription/pullsubscription.yaml
+++ b/docs/examples/pullsubscription/pullsubscription.yaml
@@ -28,12 +28,14 @@ spec:
       kind: Service
       name: event-display
 
-  # If running in GKE, we will ask the metadata server, change this if required.
-  #project: MY_PROJECT
-  # The default secret name and key, change this if required.
-  #secret:
-  #  name: google-cloud-key
-  #  key: key.json
+#    # If running in GKE, we will ask the metadata server, change this if required.
+#  project: MY_PROJECT
+#    # If running with workload identity enabled, update serviceAccount.
+#  serviceAccount: service-account-id@project-id.iam.gserviceaccount.com
+#    # If running with secret, here is the default secret name and key, change this if required.
+#  secret:
+#    name: google-cloud-key
+#    key: key.json
 
 ---
 

--- a/docs/examples/topic/README.md
+++ b/docs/examples/topic/README.md
@@ -20,7 +20,14 @@ construct used by higher-level objects, such as `Channel`.
    export TOPIC_NAME=testing
    gcloud pubsub topics create $TOPIC_NAME
    ```
+   
+1. Update `serviceAccount` / `secret` in the [`topic.yaml`](topic.yaml)
 
+     1. If you are in GKE and using [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity),
+      update `serviceAccount` with the Pub/Sub enabled service account you created in [Create a Pub/Sub enabled Service Account](../../install/pubsub-service-account.md).
+      
+     1. If you are using standard Kubernetes secrets, but want to use a non-default one, update `secret` with your own secret.
+     
 1. Update `TOPIC_NAME` in the [`topic.yaml`](topic.yaml) and apply it.
 
    If you're in the topic directory, you can replace `TOPIC_NAME` and apply in

--- a/docs/examples/topic/topic.yaml
+++ b/docs/examples/topic/topic.yaml
@@ -22,9 +22,11 @@ metadata:
   name: TOPIC_NAME-sample
 spec:
   topic: TOPIC_NAME
-  # If running in GKE, we will ask the metadata server, change this if required.
-  #project: MY_PROJECT
-  # The default secret name and key, change this if required.
-  #secret:
-  #  name: google-cloud-key
-  #  key: key.json
+#    # If running in GKE, we will ask the metadata server, change this if required.
+#  project: MY_PROJECT
+#    # If running with workload identity enabled, update serviceAccount.
+#  serviceAccount: service-account-id@project-id.iam.gserviceaccount.com
+#    # If running with secret, here is the default secret name and key, change this if required.
+#  secret:
+#    name: google-cloud-key
+#    key: key.json

--- a/docs/install/pubsub-service-account.md
+++ b/docs/install/pubsub-service-account.md
@@ -47,21 +47,20 @@ Service Account.
           --member=serviceAccount:cre-pubsub@$PROJECT_ID.iam.gserviceaccount.com \
           --role roles/pubsub.editor
         ```
-1. Access Google Cloud service. There are two methods provided to access 
-    Google Cloud service with [Google Cloud Service Account](https://console.cloud.google.com/iam-admin/serviceaccounts/project),
-    you can either:
-    1. Use workload identity.
+1. Configure the authentication mechanism used for accessing the Google Cloud services. 
+   Currently, we support two methods:
+    1. Use Workload Identity.
      
         It is the recommended way to access Google Cloud services from within GKE due to its improved security properties and 
-        manageability. More information about [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity). 
+        manageability. For more information about Workload Identity see [here](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity). 
         
-        1. Enable workload identity. Skip this step if it is already enabled in control plane.
+        1. Enable Workload Identity. Skip this step if you already enable it in the control plane setup: [Install Knative-GCP](install-knative-gcp.md).
             ```shell
            gcloud beta container clusters update ${CLUSTER_NAME} \
             --identity-namespace=${PROJECT_ID}.svc.id.goog
            ``` 
-        1. Update `spec.serviceAccount` with [Google Cloud Service Account](https://console.cloud.google.com/iam-admin/serviceaccounts/project)
-         when creating resources. Check docs to see [example](https://github.com/google/knative-gcp/tree/master/docs/examples) for each resource.
+        1. Update `spec.serviceAccount` with a [Google Cloud Service Account](https://console.cloud.google.com/iam-admin/serviceaccounts/project)
+         when creating resources. Check docs to see [examples](https://github.com/google/knative-gcp/tree/master/docs/examples) for each resource.
     1. Export service account keys and store them as Kubernetes Secrets.
     
         1.  Download a new JSON private key for that Service Account. **Be sure not

--- a/docs/install/pubsub-service-account.md
+++ b/docs/install/pubsub-service-account.md
@@ -47,25 +47,40 @@ Service Account.
           --member=serviceAccount:cre-pubsub@$PROJECT_ID.iam.gserviceaccount.com \
           --role roles/pubsub.editor
         ```
-
-    1.  Download a new JSON private key for that Service Account. **Be sure not
+1. Access Google Cloud service. There are two methods provided to access 
+    Google Cloud service with [Google Cloud Service Account](https://console.cloud.google.com/iam-admin/serviceaccounts/project),
+    you can either:
+    1. Use workload identity.
+     
+        It is the recommended way to access Google Cloud services from within GKE due to its improved security properties and 
+        manageability. More information about [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity). 
+        
+        1. Enable workload identity. Skip this step if it is already enabled in control plane.
+            ```shell
+           gcloud beta container clusters update ${CLUSTER_NAME} \
+            --identity-namespace=${PROJECT_ID}.svc.id.goog
+           ``` 
+        1. Update `spec.serviceAccount` with [Google Cloud Service Account](https://console.cloud.google.com/iam-admin/serviceaccounts/project)
+         when creating resources. Check docs to see [examples](https://github.com/google/knative-gcp/tree/master/docs/examples) per resources.
+    1. Export service account keys and store them as Kubernetes Secrets.
+    
+        1.  Download a new JSON private key for that Service Account. **Be sure not
         to check this key into source control!**
 
-        ```shell
-        gcloud iam service-accounts keys create cre-pubsub.json \
-        --iam-account=cre-pubsub@$PROJECT_ID.iam.gserviceaccount.com
-        ```
-
-    1.  Create a secret on the Kubernetes cluster with the downloaded key.
+            ```shell
+            gcloud iam service-accounts keys create cre-pubsub.json \
+            --iam-account=cre-pubsub@$PROJECT_ID.iam.gserviceaccount.com
+            ```
+        1.  Create a secret on the Kubernetes cluster with the downloaded key.
         Remember to create the secret in the namespace your resources will
         reside. The example below does so in the `default` namespace.
 
-        ```shell
-        kubectl --namespace default create secret generic google-cloud-key --from-file=key.json=cre-pubsub.json
-        ```
-
-        `google-cloud-key` and `key.json` are default values expected by our
-        resources.
+            ```shell
+            kubectl --namespace default create secret generic google-cloud-key --from-file=key.json=cre-pubsub.json
+            ```
+    
+            `google-cloud-key` and `key.json` are default values expected by our
+            resources.
 
 ## Cleaning Up
 

--- a/docs/install/pubsub-service-account.md
+++ b/docs/install/pubsub-service-account.md
@@ -61,7 +61,7 @@ Service Account.
             --identity-namespace=${PROJECT_ID}.svc.id.goog
            ``` 
         1. Update `spec.serviceAccount` with [Google Cloud Service Account](https://console.cloud.google.com/iam-admin/serviceaccounts/project)
-         when creating resources. Check docs to see [examples](https://github.com/google/knative-gcp/tree/master/docs/examples) per resources.
+         when creating resources. Check docs to see [example](https://github.com/google/knative-gcp/tree/master/docs/examples) for each resource.
     1. Export service account keys and store them as Kubernetes Secrets.
     
         1.  Download a new JSON private key for that Service Account. **Be sure not


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
related on #540 
related on #671
- Update Installing Pub/Sub Enabled Service Account doc to include "how to enable workload identity in data-plane"
- Update channel, sources example docs to include "how to leverage workload identity when it is enabled"
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
