### PR TITLE
Add AdapterLifecycle field to Topic and PullSubscription

### DIFF
--- a/pkg/apis/pubsub/v1alpha1/pullsubscription_defaults.go
+++ b/pkg/apis/pubsub/v1alpha1/pullsubscription_defaults.go
@@ -58,4 +58,8 @@ func (ss *PullSubscriptionSpec) SetDefaults(ctx context.Context) {
 		// Default is CloudEvents Binary Mode.
 		ss.Mode = ModeCloudEventsBinary
 	}
+
+	if ss.AdapterLifecycle == "" {
+		ss.AdapterLifecycle = AdapterLifecycleReconcile
+	}
 }

--- a/pkg/apis/pubsub/v1alpha1/pullsubscription_defaults_test.go
+++ b/pkg/apis/pubsub/v1alpha1/pullsubscription_defaults_test.go
@@ -64,6 +64,7 @@ func TestPullSubscriptionDefaults(t *testing.T) {
 					},
 					Key: "test.json",
 				},
+				AdapterLifecycle: AdapterLifecycleReconcile,
 			},
 		},
 	}, {
@@ -79,6 +80,7 @@ func TestPullSubscriptionDefaults(t *testing.T) {
 				RetentionDuration: ptr.String(defaultRetentionDuration.String()),
 				AckDeadline:       ptr.String(defaultAckDeadline.String()),
 				Secret:            duckv1alpha1.DefaultGoogleCloudSecretSelector(),
+				AdapterLifecycle:  AdapterLifecycleReconcile,
 			},
 		},
 	}, {
@@ -94,6 +96,7 @@ func TestPullSubscriptionDefaults(t *testing.T) {
 				RetentionDuration: ptr.String(defaultRetentionDuration.String()),
 				AckDeadline:       ptr.String(defaultAckDeadline.String()),
 				Secret:            duckv1alpha1.DefaultGoogleCloudSecretSelector(),
+				AdapterLifecycle:  AdapterLifecycleReconcile,
 			},
 		},
 	}, {
@@ -108,6 +111,7 @@ func TestPullSubscriptionDefaults(t *testing.T) {
 				RetentionDuration: ptr.String(defaultRetentionDuration.String()),
 				AckDeadline:       ptr.String(defaultAckDeadline.String()),
 				Secret:            duckv1alpha1.DefaultGoogleCloudSecretSelector(),
+				AdapterLifecycle:  AdapterLifecycleReconcile,
 			},
 		},
 	}, {
@@ -122,6 +126,23 @@ func TestPullSubscriptionDefaults(t *testing.T) {
 				RetentionDuration: ptr.String(defaultRetentionDuration.String()),
 				AckDeadline:       ptr.String(defaultAckDeadline.String()),
 				Secret:            duckv1alpha1.DefaultGoogleCloudSecretSelector(),
+				AdapterLifecycle:  AdapterLifecycleReconcile,
+			},
+		},
+	}, {
+		name: "non-nil adapter lifecycle",
+		start: &PullSubscription{
+			Spec: PullSubscriptionSpec{
+				AdapterLifecycle: AdapterLifecycleIgnore,
+			},
+		},
+		want: &PullSubscription{
+			Spec: PullSubscriptionSpec{
+				Mode:              ModeCloudEventsBinary,
+				RetentionDuration: ptr.String(defaultRetentionDuration.String()),
+				AckDeadline:       ptr.String(defaultAckDeadline.String()),
+				Secret:            duckv1alpha1.DefaultGoogleCloudSecretSelector(),
+				AdapterLifecycle:  AdapterLifecycleIgnore,
 			},
 		},
 	}}
@@ -152,6 +173,7 @@ func TestPullSubscriptionDefaults_NoChange(t *testing.T) {
 				},
 				Key: "test.json",
 			},
+			AdapterLifecycle: AdapterLifecycleReconcile,
 		},
 	}
 

--- a/pkg/apis/pubsub/v1alpha1/pullsubscription_types.go
+++ b/pkg/apis/pubsub/v1alpha1/pullsubscription_types.go
@@ -113,6 +113,11 @@ type PullSubscriptionSpec struct {
 	// PullSubscription uses.
 	// +optional
 	AdapterType string `json:"adapterType,omitempty"`
+
+	// AdapterLifecycle determines how the PullSubscription receive adapter
+	// will be created or deleted. Defaults to Reconcile.
+	// +optional
+	AdapterLifecycle AdapterLifecycleType `json:"adapterLifecycle,omitempty"`
 }
 
 // GetAckDeadline parses AckDeadline and returns the default if an error occurs.

--- a/pkg/apis/pubsub/v1alpha1/topic_defaults.go
+++ b/pkg/apis/pubsub/v1alpha1/topic_defaults.go
@@ -35,4 +35,8 @@ func (ts *TopicSpec) SetDefaults(ctx context.Context) {
 	if ts.Secret == nil || equality.Semantic.DeepEqual(ts.Secret, &corev1.SecretKeySelector{}) {
 		ts.Secret = duckv1alpha1.DefaultGoogleCloudSecretSelector()
 	}
+
+	if ts.AdapterLifecycle == "" {
+		ts.AdapterLifecycle = AdapterLifecycleReconcile
+	}
 }

--- a/pkg/apis/pubsub/v1alpha1/topic_defaults_test.go
+++ b/pkg/apis/pubsub/v1alpha1/topic_defaults_test.go
@@ -33,6 +33,7 @@ func TestTopicDefaults(t *testing.T) {
 			},
 			Key: "key.json",
 		},
+		AdapterLifecycle: AdapterLifecycleReconcile,
 	}}
 
 	got := &Topic{Spec: TopicSpec{}}

--- a/pkg/apis/pubsub/v1alpha1/topic_types.go
+++ b/pkg/apis/pubsub/v1alpha1/topic_types.go
@@ -78,6 +78,11 @@ type TopicSpec struct {
 	//PropagationPolicy defines how Topic controls the Cloud Pub/Sub topic for
 	// lifecycle changes. Defaults to TopicPolicyCreateNoDelete if empty.
 	PropagationPolicy PropagationPolicyType `json:"propagationPolicy,omitempty"`
+
+	// AdapterLifecycle determines how the Topic receive adapter will be
+	// created or deleted. Defaults to Reconcile.
+	// +optional
+	AdapterLifecycle AdapterLifecycleType `json:"adapterLifecycle,omitempty"`
 }
 
 // PropagationPolicyType defines enum type for TopicPolicy


### PR DESCRIPTION
This field is intended to control whether the Topic and PullSubscription receive adapters are created/reconciled by the controller. Just the types for now, no controller support yet.

@ericlem @yolocs @liu-cong Creating this PR for early feedback on the approach. I think it might be quickest to use the existing resources to create (and display status on) GCP objects, but skip creating the receive adapters. If you agree this makes sense, I'll go ahead and plumb support for these fields through the controllers.

## Proposed Changes

- Add AdapterLifecycle field to Topic and PullSubscription (type only)

(No user impact yet because it's not hooked up)