### PR TITLE
Update Installing Pub/Sub Enabled Service Account doc

### DIFF
--- a/docs/install/pubsub-service-account.md
+++ b/docs/install/pubsub-service-account.md
@@ -85,13 +85,13 @@ Service Account.
            for each resource. 
            
            Generally, updating `spec.serviceAccount` will trigger 
-           the controller to enable Workload Identity for sources in the data plane 
-           with the following steps (all handled by the controller):
+           the controller to enable Workload Identity for sources in the data plane. 
+           The following steps are handled by the controller:
            
            1. Create a Kubernetes Service Account and add an `OwnerReference` to it. The `OwnerReference` is referencing to the source.
            
            1. Bind the Kubernetes Service Account with Google Cloud Service Account, this will add `role/iam.workloadIdentityUser` to the Google Cloud Service Account. 
-           The scope of this role is only for this specific Google Cloud Service Account. It is equal to this command:
+           The scope of this role is only for this specific Google Cloud Service Account. It equals to this command:
            
               ```shell
                 gcloud iam service-accounts add-iam-policy-binding \

--- a/docs/install/pubsub-service-account.md
+++ b/docs/install/pubsub-service-account.md
@@ -82,7 +82,31 @@ Service Account.
            [Google Cloud Service Account](https://console.cloud.google.com/iam-admin/serviceaccounts/project)
            when creating resources. Check docs to see
            [examples](https://github.com/google/knative-gcp/tree/master/docs/examples)
-           for each resource.
+           for each resource. 
+           
+           Generally, updating `spec.serviceAccount` will trigger 
+           the controller to enable Workload Identity for sources in the data plane 
+           with the following steps (all handled by the controller):
+           
+           1. Create a Kubernetes Service Account and add an `OwnerReference` to it. The `OwnerReference` is referencing to the source.
+           
+           1. Bind the Kubernetes Service Account with Google Cloud Service Account, this will add `role/iam.workloadIdentityUser` to the Google Cloud Service Account. 
+           The scope of this role is only for this specific Google Cloud Service Account. It is equal to this command:
+           
+              ```shell
+                gcloud iam service-accounts add-iam-policy-binding \
+                --role roles/iam.workloadIdentityUser \
+                --member serviceAccount:$PROJECT_ID.svc.id.goog[namespace/Kubernetes-service-account] \
+                GCP-service-account@$PROJECT_ID.iam.gserviceaccount.com
+              ```
+           
+           1. Annotate the Kubernetes Service Account with `iam.gke.io/gcp-service-account=GCP-service-account@PROJECT_ID.iam.gserviceaccount.com`
+           
+           For every namespace, the Kubernetes Service Account and the Google Cloud Service Account will have one to one mapping relation. 
+           If multiple source instances use the same Google Cloud Service Account, they will use the same Kubernetes Service Account as well, 
+           and the kubernetes Service Account will have multiple `OwnerReference`s.
+           If there is no source instance using a Kubernetes Service Account, this Kubernetes Service Account will be deleted, 
+           and its binding to the Google Cloud Service Account will be deleted as well.
 
     1.  Export service account keys and store them as Kubernetes Secrets.
 


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Update Installing Pub/Sub Enabled Service Account doc to explicitly explain what will be done in the data plane, when we enable Workload Identity and put value in `spec.serviceAccount`.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
