### PR TITLE
Add recordevents as Required Test Image

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1830,6 +1830,7 @@
     "knative.dev/eventing/test/lib/duck",
     "knative.dev/eventing/test/lib/resources",
     "knative.dev/eventing/test/test_images/logevents",
+    "knative.dev/eventing/test/test_images/recordevents",
     "knative.dev/eventing/test/test_images/sendevents",
     "knative.dev/eventing/test/test_images/transformevents",
     "knative.dev/pkg/apis",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -6,6 +6,7 @@ required = [
   "knative.dev/test-infra/tools/dep-collector",
   # for integration tests
   "knative.dev/eventing/test/test_images/logevents",
+  "knative.dev/eventing/test/test_images/recordevents",
   "knative.dev/eventing/test/test_images/sendevents",
   "knative.dev/eventing/test/test_images/transformevents",
 


### PR DESCRIPTION
This will ensure that the image remains vendored after update-deps
