### PR TITLE
Small improvement on broker memory config for easier testing.

### DIFF
--- a/pkg/broker/config/memory/memory.go
+++ b/pkg/broker/config/memory/memory.go
@@ -17,7 +17,6 @@ limitations under the License.
 package memory
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/golang/protobuf/proto"
@@ -81,22 +80,14 @@ var _ config.Targets = (*memoryTargets)(nil)
 
 // NewEmptyTargets returns an empty mutable Targets in memory.
 func NewEmptyTargets() config.Targets {
-	t := &memoryTargets{
-		mux: sync.Mutex{},
-	}
-	t.Store(&config.TargetsConfig{Brokers: make(map[string]*config.Broker)})
-	return t
+	return NewTargets(&config.TargetsConfig{Brokers: make(map[string]*config.Broker)})
 }
 
-// NewTargetsFromBytes creates a mutable Targets in memory.
-func NewTargetsFromBytes(b []byte) (config.Targets, error) {
-	pb := config.TargetsConfig{}
-	if err := proto.Unmarshal(b, &pb); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal bytes to TargetsConfig: %w", err)
-	}
+// NewTargets returns a new mutable Targets in memory.
+func NewTargets(pb *config.TargetsConfig) config.Targets {
 	m := &memoryTargets{mux: sync.Mutex{}}
-	m.Store(&pb)
-	return m, nil
+	m.Store(pb)
+	return m
 }
 
 // MutateBroker mutates a broker by namespace and name.

--- a/pkg/broker/config/memory/memory_test.go
+++ b/pkg/broker/config/memory/memory_test.go
@@ -62,14 +62,7 @@ func TestUpsertTargetsWithNamespaceBrokerEnforced(t *testing.T) {
 
 func TestMutateBroker(t *testing.T) {
 	val := &config.TargetsConfig{}
-	b, err := proto.Marshal(val)
-	if err != nil {
-		t.Fatalf("unexpected error from proto.Marshal: %v", err)
-	}
-	targets, err := NewTargetsFromBytes(b)
-	if err != nil {
-		t.Fatalf("unexpected error from NewTargetsFromBytes: %v", err)
-	}
+	targets := NewTargets(val)
 
 	wantBroker := &config.Broker{
 		Id:        "b-uid",
@@ -197,8 +190,7 @@ func assertBroker(t *testing.T, want *config.Broker, namespace, name string, tar
 
 func ExampleMutateBroker() {
 	val := &config.TargetsConfig{}
-	b, _ := proto.Marshal(val)
-	targets, _ := NewTargetsFromBytes(b)
+	targets := NewTargets(val)
 
 	// Create a new broker with targets.
 	targets.MutateBroker("ns", "broker", func(m config.BrokerMutation) {


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- Replace `NewTargetsFromBytes` with `NewTargets` that takes in a proto struct. It seems we will never need NewTargetsFromBytes for the in memory config.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
