### PR TITLE
[release-0.13] Pin test-infra to release branch

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1565,15 +1565,15 @@
   revision = "aa470a6af2da383a5cc81483dfd476d41bbd1830"
 
 [[projects]]
-  branch = "master"
-  digest = "1:2987a1db00b983af9e5d5281639a754fb6449eef01e6a375894829eaec17cb2a"
+  branch = "release-0.13"
+  digest = "1:50482e6fd500cf50c4a29d640cda026206145c6716dff72e4368a5e57fdb7095"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "d878fef854182d0cb2ab2190c66a785b8f05e3e2"
+  revision = "9fa5882b65c5fe7e177bb74874e9a5ac87b84e98"
 
 [[projects]]
   digest = "1:8730e0150dfb2b7e173890c8b9868e7a273082ef8e39f4940e3506a481cf895c"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,6 +40,11 @@ required = [
   name = "knative.dev/serving"
   branch = "release-0.13"
 
+# This is a preemptive override.
+[[override]]
+  name = "knative.dev/test-infra"
+  branch = "release-0.13"
+
 [[override]]
   name = "go.uber.org/zap"
   revision = "67bc79d13d155c02fd008f721863ff8cc5f30659"

--- a/vendor/knative.dev/test-infra/scripts/e2e-tests.sh
+++ b/vendor/knative.dev/test-infra/scripts/e2e-tests.sh
@@ -93,7 +93,7 @@ function dump_cluster_state() {
   echo "***    Start of information dump    ***"
   echo "***************************************"
 
-  local output="${ARTIFACTS}/k8s.dump.txt"
+  local output="${ARTIFACTS}/k8s.dump-$(basename ${E2E_SCRIPT}).txt"
   echo ">>> The dump is located at ${output}"
 
   for crd in $(kubectl api-resources --verbs=list -o name | sort); do

--- a/vendor/knative.dev/test-infra/tools/dep-collector/gobuild.go
+++ b/vendor/knative.dev/test-infra/tools/dep-collector/gobuild.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	gb "go/build"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// https://golang.org/pkg/cmd/go/internal/modinfo/#ModulePublic
+type modInfo struct {
+	Path string
+	Dir  string
+}
+
+type gobuild struct {
+	mod *modInfo
+}
+
+// moduleInfo returns the module path and module root directory for a project
+// using go modules, otherwise returns nil.
+// If there is something wrong in getting the module info, it will return an error.
+//
+// Related: https://github.com/golang/go/issues/26504
+func moduleInfo() (*modInfo, error) {
+	// If `go list -m` returns an error, the project is not using Go modules.
+	c := exec.Command("go", "list", "-m")
+	_, err := c.Output()
+	if err != nil {
+		return nil, nil
+	}
+
+	lc := exec.Command("go", "list", "-mod=readonly", "-m", "-json")
+	output, err := lc.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed getting module info: %v", err)
+	}
+	var info modInfo
+	if err := json.Unmarshal(output, &info); err != nil {
+		return nil, fmt.Errorf("failed parsing module info %q: %v", output, err)
+	}
+	return &info, nil
+}
+
+// importPackage wraps go/build.Import to handle go modules.
+//
+// Note that we will fall back to GOPATH if the project isn't using go modules.
+func (g *gobuild) importPackage(s string) (*gb.Package, error) {
+	if g.mod == nil {
+		return gb.Import(s, WorkingDir, gb.ImportComment)
+	}
+
+	// If we're inside a go modules project, try to use the module's directory
+	// as our source root to import:
+	// * paths that match module path prefix (they should be in this project)
+	// * relative paths (they should also be in this project)
+	gp, err := gb.Import(s, g.mod.Dir, gb.ImportComment)
+	return gp, err
+}
+
+func (g *gobuild) qualifyLocalImport(ip string) (string, error) {
+	if g.mod == nil {
+		gopathsrc := filepath.Join(gb.Default.GOPATH, "src")
+		if !strings.HasPrefix(WorkingDir, gopathsrc) {
+			return "", fmt.Errorf("working directory must be on ${GOPATH}/src = %s", gopathsrc)
+		}
+		return filepath.Join(strings.TrimPrefix(WorkingDir, gopathsrc+string(filepath.Separator)), ip), nil
+	}
+	return filepath.Join(g.mod.Path, ip), nil
+}


### PR DESCRIPTION
https://github.com/knative/test-infra created a release-0.13 branch for dependent release branches to use instead of master. Switching our release branch to this should significantly reduce the frequency of automatic update PRs there.

We will get one more automatic point release from this, but hopefully no more after that.

## Proposed Changes

- Update test-infra dependency to release-0.13 branch in knative-gcp release-0.13 branch