### PR TITLE
Use base64 encoding to encode broker config bytes

### DIFF
--- a/pkg/broker/config/cache_test.go
+++ b/pkg/broker/config/cache_test.go
@@ -158,7 +158,7 @@ func TestCachedTargetsRange(t *testing.T) {
 	})
 }
 
-func TestCachedTargetsBytes(t *testing.T) {
+func TestCachedTargetsEncodedString(t *testing.T) {
 	t1 := &Target{
 		Id:               "uid-1",
 		Name:             "name1",
@@ -243,31 +243,18 @@ func TestCachedTargetsBytes(t *testing.T) {
 	targets := &CachedTargets{}
 	targets.Store(val)
 
-	wantBytes, err := proto.Marshal(val)
+	gotEncoded, err := targets.EncodedString()
 	if err != nil {
-		t.Fatalf("unexpected error from proto.Marshal: %v", err)
-	}
-
-	gotBytes, err := targets.Bytes()
-	if err != nil {
-		t.Errorf("unexpected error from targets.Byte(): %v", err)
-	}
-
-	var gotVal TargetsConfig
-	if err := proto.Unmarshal(gotBytes, &gotVal); err != nil {
-		t.Errorf("unexpected error from proto.Unmarshal: %v", err)
-	}
-	if !proto.Equal(&gotVal, val) {
-		t.Errorf("got unmarshaled targets=%+v, want=%+v", gotVal, val)
+		t.Errorf("unexpected error from targets.EncodedString(): %v", err)
 	}
 
 	// Test EqualsBytes
-	if !targets.EqualsBytes(wantBytes) {
-		t.Error("CachedTargets.EqualsBytes() got=false, want=true")
+	if !targets.EqualsEncodedString(gotEncoded) {
+		t.Error("CachedTargets.EqualsEncodedString() got=false, want=true")
 	}
 
-	if targets.EqualsBytes([]byte("random")) {
-		t.Error("CachedTargets.EqualBytes() with random bytes got=true, want=false")
+	if targets.EqualsEncodedString("random") {
+		t.Error("CachedTargets.EqualsEncodedString() with random string got=true, want=false")
 	}
 }
 

--- a/pkg/broker/config/config.go
+++ b/pkg/broker/config/config.go
@@ -29,13 +29,13 @@ type ReadonlyTargets interface {
 	// RangeBrokers ranges over all brokers.
 	// Do not modify the given Broker copy.
 	RangeBrokers(func(*Broker) bool)
-	// Bytes serializes all the targets.
-	Bytes() ([]byte, error)
-	// String returns the text format of all the targets.
+	// EncodedString encodes all the targets as a string.
+	EncodedString() (string, error)
+	// String returns the human-readable text format of all the targets.
 	String() string
-	// EqualsBytes checks if the current targets config equals the given
-	// targets config in bytes.
-	EqualsBytes([]byte) bool
+	// EqualsEncodedString checks if the current targets config equals the given
+	// targets config in encoded string.
+	EqualsEncodedString(string) bool
 	// EqualsString checks if the current targets config equals the given
 	// targets config in string.
 	EqualsString(string) bool

--- a/pkg/broker/config/volume/volume.go
+++ b/pkg/broker/config/volume/volume.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/golang/protobuf/proto"
 	"github.com/google/knative-gcp/pkg/broker/config"
 )
 
@@ -118,13 +117,7 @@ func (t *Targets) sync() error {
 		return fmt.Errorf("failed to read config file: %w", err)
 	}
 
-	var val config.TargetsConfig
-	if err := proto.Unmarshal(b, &val); err != nil {
-		return fmt.Errorf("failed to unmarshal config file: %w", err)
-	}
-
-	t.Store(&val)
-	return nil
+	return t.StoreWithEncodedString(string(b))
 }
 
 func (t *Targets) readFile() ([]byte, error) {

--- a/pkg/broker/config/volume/volume_test.go
+++ b/pkg/broker/config/volume/volume_test.go
@@ -101,7 +101,12 @@ func TestSyncConfigFromFile(t *testing.T) {
 		},
 	}
 
-	b, _ := proto.Marshal(data)
+	ct := &config.CachedTargets{}
+	ct.Store(data)
+	encoded, err := ct.EncodedString()
+	if err != nil {
+		t.Fatalf("failed to get encoded string for test targets: %v", err)
+	}
 	dir, err := ioutil.TempDir("", "configtest-*")
 	if err != nil {
 		t.Fatalf("unexpected error from creating temp dir: %v", err)
@@ -114,7 +119,7 @@ func TestSyncConfigFromFile(t *testing.T) {
 		tmp.Close()
 		os.RemoveAll(dir)
 	}()
-	if _, err := tmp.Write(b); err != nil {
+	if _, err := tmp.Write([]byte(encoded)); err != nil {
 		t.Fatalf("unexpected error from writing config file: %v", err)
 	}
 	if err := tmp.Close(); err != nil {
@@ -157,8 +162,11 @@ func TestSyncConfigFromFile(t *testing.T) {
 	}
 
 	delete(data.Brokers["ns2/broker2"].Targets, "name4")
-	b, _ = proto.Marshal(data)
-	atomicWriteFile(t, tmp.Name(), b)
+	encoded, err = ct.EncodedString()
+	if err != nil {
+		t.Fatalf("failed to get encoded string for test targets: %v", err)
+	}
+	atomicWriteFile(t, tmp.Name(), []byte(encoded))
 
 	<-ch
 


### PR DESCRIPTION
Fixes https://github.com/google/knative-gcp/issues/804

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- drop `Bytes()` since it probably won't be used (when putting into configmap, we use string)
- use base64 encoding to encode raw proto bytes to avoid encoding problem in configmap

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Use base64 encoding to encode broker config bytes
```


<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
