### PR TITLE
Pool volume watcher no longer exits on Remove

### DIFF
--- a/pkg/broker/config/volume/volume_test.go
+++ b/pkg/broker/config/volume/volume_test.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/knative-gcp/pkg/broker/config"
@@ -160,7 +161,11 @@ func TestSyncConfigFromFile(t *testing.T) {
 	b, _ = proto.Marshal(data)
 	atomicWriteFile(t, tmp.Name(), b)
 
-	<-ch
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Timeout waiting for the notification")
+	}
 
 	gotTargets = targets.(*Targets).Load()
 	if !proto.Equal(data, gotTargets) {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Pool volume watcher does not exit when the file is deleted.
  - On my Mac, this change allows TestSyncConfigFromFile to pass. Without it, the first notification received is a Remove, which caused the watcher to return. 
  - There is a chance this will leak go routines and file system watches in the future because essentially nothing shuts the watch down. But the current usage is to only create one of these per process during startup. If we want to add shutdown semantics, we can create an explicit `Close` method.
- Add a timeout to TestSyncConfigFromFile.
  - Without this timeout, the test would never complete on my Mac (before the previous change).