### PR TITLE
Point test-infra to release-0.14 in prep for 0.14 release

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1712,15 +1712,15 @@
   revision = "f38e9768cb66b2d556b191887769a02abf860336"
 
 [[projects]]
-  branch = "master"
-  digest = "1:dc73d65f40ea05b1d0db96ae5491b6ebc162bb59b3ac5a252cdf87848bc7a4b7"
+  branch = "release-0.14"
+  digest = "1:50482e6fd500cf50c4a29d640cda026206145c6716dff72e4368a5e57fdb7095"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "5e04d955cdb9a460b5d3f2a699bddcab22c8af94"
+  revision = "9fa5882b65c5fe7e177bb74874e9a5ac87b84e98"
 
 [[projects]]
   digest = "1:8730e0150dfb2b7e173890c8b9868e7a273082ef8e39f4940e3506a481cf895c"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,6 +31,11 @@ required = [
   name = "knative.dev/pkg"
   branch = "release-0.14"
 
+# Our master branch tracks knative/test-infra master or a release.
+[[override]]
+  name = "knative.dev/test-infra"
+  branch = "release-0.14"
+
 # This is a preemptive override.
 [[override]]
   name = "knative.dev/eventing"

--- a/vendor/knative.dev/test-infra/scripts/presubmit-tests.sh
+++ b/vendor/knative.dev/test-infra/scripts/presubmit-tests.sh
@@ -129,7 +129,7 @@ function markdown_build_tests() {
   (( DISABLE_MD_LINTING && DISABLE_MD_LINK_CHECK )) && return 0
   # Get changed markdown files (ignore /vendor, github templates, and deleted files)
   local mdfiles=""
-  for file in $(echo "${CHANGED_FILES}" | grep \\.md$ | grep -v ^vendor/ | grep -v ^.github/); do
+  for file in $(echo "${CHANGED_FILES}" | grep \.md$ | grep -v ^vendor/ | grep -v ^.github/); do
     [[ -f "${file}" ]] && mdfiles="${mdfiles} ${file}"
   done
   [[ -z "${mdfiles}" ]] && return 0


### PR DESCRIPTION
Related to https://github.com/knative/test-infra/issues/1900

In future releases, we should coordinate this with the 1-week-early pkg release branch switchover.

## Proposed Changes

- Update test-infra dependency to release-0.14 branch in prep for 0.14 release