### PR TITLE
Structural schemas for all the sources we intend to include in release/1

### DIFF
--- a/config/core/resources/cloudauditlogssource.yaml
+++ b/config/core/resources/cloudauditlogssource.yaml
@@ -27,7 +27,6 @@ metadata:
   name: cloudauditlogssources.events.cloud.google.com
 spec:
   group: events.cloud.google.com
-  version: v1alpha1
   names:
     categories:
     - all
@@ -39,6 +38,7 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+  preserveUnknownFields: false
   additionalPrinterColumns:
     - name: Ready
       type: string
@@ -49,39 +49,89 @@ spec:
     - name: Age
       type: date
       JSONPath: .metadata.creationTimestamp
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
+          required:
+            - sink
+            - serviceName
+            - methodName
           properties:
-            googleServiceAccount:
-              type: string
-              description: "GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service account must be a valid Google service account (see https://cloud.google.com/iam/docs/service-accounts)."
-            secret:
-              type: object
-              description: "Credential used to poll the Cloud Pub/Sub Subscription. It is not used to create or delete the Subscription, only to poll it. The value of the secret entry must be a service account key in the JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys). Defaults to secret.name of 'google-cloud-key' and secret.key of 'key.json'."
-            serviceAccountName:
-              type: string
-              description: "Service Account to run Receive Adapter as. If omitted, uses 'default'."
-            project:
-              type: string
-              description: "Google Cloud Project ID of the project into which the topic should be created. If omitted uses the Project ID from the GKE cluster metadata service."
-            serviceName:
-              type: string
-              description: "The GCP service providing audit logs."
-            methodName:
-              type: string
-              description: "The name of the service method or operation. For API calls, this should be the name of the API method."
-            resourceName:
-              type: string
-              description: "The resource or collection that is the target of the operation. The name is a scheme-less URI, not including the API service name. If omitted, audit log events matching service and method will be pulled for all resources."
             sink:
               type: object
-              description: "Sink which receives the notifications."
-          required:
-          - sink
-          - serviceName
-          - methodName
+              description: >
+                Sink which receives the notifications.
+              properties:
+                uri:
+                  type: string
+                  minLength: 1
+                ref:
+                  type: object
+                  required:
+                    - apiVersion
+                    - kind
+                    - name
+                  properties:
+                    apiVersion:
+                      type: string
+                      minLength: 1
+                    kind:
+                      type: string
+                      minLength: 1
+                    namespace:
+                      type: string
+                    name:
+                      type: string
+                      minLength: 1
+            ceOverrides:
+              type: object
+              description: >
+                Defines overrides to control modifications of the event sent to the sink.
+              properties:
+                extensions:
+                  type: object
+                  description: >
+                    Extensions specify what attribute are added or overridden on the outbound event. Each
+                    `Extensions` key-value pair are set on the event as an attribute extension independently.
+                  x-kubernetes-preserve-unknown-fields: true
+            googleServiceAccount:
+              type: string
+              description: >
+                GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service
+                account must be a valid Google service account (see
+                https://cloud.google.com/iam/docs/service-accounts).
+            secret:
+              type: object
+              description: >
+                Credential used to poll the Cloud Pub/Sub Subscription. It is not used to create or delete the
+                Subscription, only to poll it. The value of the secret entry must be a service account key in
+                the JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
+                Defaults to secret.name of 'google-cloud-key' and secret.key of 'key.json'.
+              properties:
+                name:
+                  type: string
+                key:
+                  type: string
+                optional:
+                  type: boolean
+            project:
+              type: string
+              description: >
+                Google Cloud Project ID of the project into which the topic should be created. If omitted uses
+                the Project ID from the GKE cluster metadata service.
+            serviceName:
+              type: string
+            methodName:
+              type: string
+            resourceName:
+              type: string
         status:
           type: object
           properties:
@@ -94,8 +144,7 @@ spec:
                 type: object
                 properties:
                   lastTransitionTime:
-                    # we use a string in the stored object but a wrapper object
-                    # at runtime.
+                    # We use a string in the stored object but a wrapper object at runtime.
                     type: string
                   message:
                     type: string
@@ -108,15 +157,28 @@ spec:
                   type:
                     type: string
                 required:
-                - type
-                - status
+                  - type
+                  - status
+            serviceAccountName:
+              type: string
             sinkUri:
               type: string
+            ceAttributes:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  source:
+                    type: string
             projectId:
               type: string
             topicId:
               type: string
-            stackdriverSink:
-              type: string
             subscriptionId:
               type: string
+            stackdriverSink:
+              type: string
+              description: >
+                ID of the Stackdriver sink used to publish audit log messages.

--- a/config/core/resources/cloudpubsubsource.yaml
+++ b/config/core/resources/cloudpubsubsource.yaml
@@ -27,7 +27,6 @@ metadata:
   name: cloudpubsubsources.events.cloud.google.com
 spec:
   group: events.cloud.google.com
-  version: v1alpha1
   names:
     categories:
     - all
@@ -39,6 +38,7 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+  preserveUnknownFields: false
   additionalPrinterColumns:
     - name: Ready
       type: string
@@ -49,81 +49,121 @@ spec:
     - name: Age
       type: date
       JSONPath: .metadata.creationTimestamp
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           required:
             - sink
             - topic
           properties:
-            googleServiceAccount:
-              type: string
-              description: "GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service account must be a valid Google service account (see https://cloud.google.com/iam/docs/service-accounts)."
-            secret:
-              type: object
-              description: "Credential used to poll the Cloud Pub/Sub Subscription. It is not used to create or delete the Subscription, only to poll it. The value of the secret entry must be a service account key in the JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys). Defaults to secret.name of 'google-cloud-key' and secret.key of 'key.json'."
-            project:
-              type: string
-              description: "ID of the Google Cloud Project that the Pub/Sub Topic exists in. E.g. 'my-project-1234' rather than its display name, 'My Project' or its number '1234567890'. If omitted uses the Project ID from the GKE cluster metadata service."
             sink:
               type: object
-              description: "Reference to an object that will resolve to a domain name to use as the sink."
-              anyOf:
-                - type: object
+              description: >
+                Sink which receives the notifications.
+              properties:
+                uri:
+                  type: string
+                  minLength: 1
+                ref:
+                  type: object
+                  required:
+                    - apiVersion
+                    - kind
+                    - name
                   properties:
-                    uri:
+                    apiVersion:
                       type: string
                       minLength: 1
-                - type: object
-                  properties:
-                    ref:
-                      type: object
-                      required:
-                        - apiVersion
-                        - kind
-                        - name
-                      properties:
-                        apiVersion:
-                          type: string
-                          minLength: 1
-                        kind:
-                          type: string
-                          minLength: 1
-                        name:
-                          type: string
-                          minLength: 1
+                    kind:
+                      type: string
+                      minLength: 1
+                    namespace:
+                      type: string
+                    name:
+                      type: string
+                      minLength: 1
             ceOverrides:
               type: object
-              description: "Defines overrides to control modifications of the event sent to the sink."
+              description: >
+                Defines overrides to control modifications of the event sent to the sink.
               properties:
                 extensions:
                   type: object
-                  description: "Extensions specify what attribute are added or overridden on the outbound event. Each `Extensions` key-value pair are set on the event as an attribute extension independently."
+                  description: >
+                    Extensions specify what attribute are added or overridden on the outbound event. Each
+                    `Extensions` key-value pair are set on the event as an attribute extension independently.
+                  x-kubernetes-preserve-unknown-fields: true
+            googleServiceAccount:
+              type: string
+              description: >
+                GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service
+                account must be a valid Google service account (see
+                https://cloud.google.com/iam/docs/service-accounts).
+            secret:
+              type: object
+              description: >
+                Credential used to poll the Cloud Pub/Sub Subscription. It is not used to create or delete the
+                Subscription, only to poll it. The value of the secret entry must be a service account key in
+                the JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
+                Defaults to secret.name of 'google-cloud-key' and secret.key of 'key.json'.
+              properties:
+                name:
+                  type: string
+                key:
+                  type: string
+                optional:
+                  type: boolean
+            project:
+              type: string
+              description: >
+                Google Cloud Project ID of the project into which the topic should be created. If omitted uses
+                the Project ID from the GKE cluster metadata service.
             topic:
               type: string
-              description: "ID of the Cloud Pub/Sub Topic to Subscribe to. It must be in the form of the unique identifier within the project, not the entire name. E.g. it must be 'laconia', not 'projects/my-gcp-project/topics/laconia'."
+              description: >
+                ID of the Cloud Pub/Sub Topic to Subscribe to. It must be in the form of the unique
+                identifier within the project, not the entire name. E.g. it must be 'laconia', not
+                'projects/my-gcp-project/topics/laconia'.
             ackDeadline:
               type: string
-              description:  "The default maximum time after a subscriber receives a message before the subscriber should acknowledge the message. Defaults to `30s`. Valid time units are `s`, `m`, `h`. The minimum deadline you can specify is 0 seconds. The maximum deadline you can specify is 600 seconds (10 minutes)."
+              description: >
+                The default maximum time after a subscriber receives a message before the subscriber
+                should acknowledge the message. Defaults to `30s`. Valid time units are `s`, `m`,
+                `h`. The minimum deadline you can specify is 0 seconds. The maximum deadline you can
+                specify is 600 seconds (10 minutes).
             retainAckedMessages:
               type: boolean
-              description: "Whether to retain acknowledged messages. If true, acknowledged messages will not be expunged until they fall out of the RetentionDuration window."
+              description: >
+                Whether to retain acknowledged messages. If true, acknowledged messages will not be
+                expunged until they fall out of the RetentionDuration window.
             retentionDuration:
               type: string
-              description: "How long to retain messages in backlog, from the time of publish. If retainAckedMessages is true, this duration affects the retention of acknowledged messages, otherwise only unacknowledged messages are retained. Defaults to 7 days (`168h`). Cannot be longer than 7 days or shorter than 10 minutes. Valid time units are `s`, `m`, `h`."
-          type: object
+              description: >
+                How long to retain messages in backlog, from the time of publish. If
+                retainAckedMessages is true, this duration affects the retention of acknowledged
+                messages, otherwise only unacknowledged messages are retained. Defaults to 7 days
+                (`168h`). Cannot be longer than 7 days or shorter than 10 minutes. Valid time units
+                are `s`, `m`, `h`.
         status:
+          type: object
           properties:
             observedGeneration:
               type: integer
               format: int64
             conditions:
+              type: array
               items:
+                type: object
                 properties:
                   lastTransitionTime:
-                    # we use a string in the stored object but a wrapper object
-                    # at runtime.
+                    # We use a string in the stored object but a wrapper object at runtime.
                     type: string
                   message:
                     type: string
@@ -136,10 +176,24 @@ spec:
                   type:
                     type: string
                 required:
-                - type
-                - status
-                type: object
-              type: array
+                  - type
+                  - status
+            serviceAccountName:
+              type: string
             sinkUri:
               type: string
-          type: object
+            ceAttributes:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  source:
+                    type: string
+            projectId:
+              type: string
+            topicId:
+              type: string
+            subscriptionId:
+              type: string

--- a/config/core/resources/cloudschedulersource.yaml
+++ b/config/core/resources/cloudschedulersource.yaml
@@ -27,7 +27,6 @@ metadata:
   name: cloudschedulersources.events.cloud.google.com
 spec:
   group: events.cloud.google.com
-  version: v1alpha1
   names:
     categories:
     - all
@@ -39,6 +38,7 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+  preserveUnknownFields: false
   additionalPrinterColumns:
     - name: Ready
       type: string
@@ -49,76 +49,109 @@ spec:
     - name: Age
       type: date
       JSONPath: .metadata.creationTimestamp
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
+          required:
+            - location
+            - schedule
+            - sink
+            - data
           properties:
-            googleServiceAccount:
-              type: string
-              description: "GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service account must be a valid Google service account (see https://cloud.google.com/iam/docs/service-accounts)."
-            secret:
-              type: object
-              description: "Credential used to poll the Cloud Pub/Sub Subscription. It is not used to create or delete the Subscription, only to poll it. The value of the secret entry must be a service account key in the JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys). Defaults to secret.name of 'google-cloud-key' and secret.key of 'key.json'."
-            project:
-              type: string
-              description: "Google Cloud Project ID of the project into which the Scheduler job should be created. If omitted uses the Project ID from the GKE cluster metadata service."
-            location:
-              type: string
-              description: "Location to create the Scheduler job in."
-            schedule:
-              type: string
-              description: "Frequency using the unix-cron format. Or App Engine Cron format."
-            data:
-              type: string
-              description: "Data to send in the payload of the Event."
             sink:
               type: object
-              description: "Sink which receives the notifications."
-              anyOf:
-                - type: object
+              description: >
+                Sink which receives the notifications.
+              properties:
+                uri:
+                  type: string
+                  minLength: 1
+                ref:
+                  type: object
+                  required:
+                    - apiVersion
+                    - kind
+                    - name
                   properties:
-                    uri:
+                    apiVersion:
                       type: string
                       minLength: 1
-                - type: object
-                  properties:
-                    ref:
-                      type: object
-                      required:
-                        - apiVersion
-                        - kind
-                        - name
-                      properties:
-                        apiVersion:
-                          type: string
-                          minLength: 1
-                        kind:
-                          type: string
-                          minLength: 1
-                        name:
-                          type: string
-                          minLength: 1
+                    kind:
+                      type: string
+                      minLength: 1
+                    namespace:
+                      type: string
+                    name:
+                      type: string
+                      minLength: 1
             ceOverrides:
               type: object
-              description: "Defines overrides to control modifications of the event sent to the sink."
+              description: >
+                Defines overrides to control modifications of the event sent to the sink.
               properties:
                 extensions:
                   type: object
-                  description: "Extensions specify what attribute are added or overridden on the outbound event. Each `Extensions` key-value pair are set on the event as an attribute extension independently."
-          required:
-          - location
-          - schedule
-          - sink
-          - data
+                  description: >
+                    Extensions specify what attribute are added or overridden on the outbound event. Each
+                    `Extensions` key-value pair are set on the event as an attribute extension independently.
+                  x-kubernetes-preserve-unknown-fields: true
+            googleServiceAccount:
+              type: string
+              description: >
+                GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service
+                account must be a valid Google service account (see
+                https://cloud.google.com/iam/docs/service-accounts).
+            secret:
+              type: object
+              description: >
+                Credential used to poll the Cloud Pub/Sub Subscription. It is not used to create or delete the
+                Subscription, only to poll it. The value of the secret entry must be a service account key in
+                the JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
+                Defaults to secret.name of 'google-cloud-key' and secret.key of 'key.json'.
+              properties:
+                name:
+                  type: string
+                key:
+                  type: string
+                optional:
+                  type: boolean
+            project:
+              type: string
+              description: >
+                Google Cloud Project ID of the project into which the topic should be created. If omitted uses
+                the Project ID from the GKE cluster metadata service.
+            location:
+              type: string
+              description: >
+                Location to create the Scheduler job in.
+            schedule:
+              type: string
+              description: >
+                Frequency using the unix-cron format. Or App Engine Cron format.
+            data:
+              type: string
+              description: >
+                Data to send in the payload of the Event.
         status:
+          type: object
           properties:
+            observedGeneration:
+              type: integer
+              format: int64
             conditions:
+              type: array
               items:
+                type: object
                 properties:
                   lastTransitionTime:
-                    # we use a string in the stored object but a wrapper object
-                    # at runtime.
+                    # We use a string in the stored object but a wrapper object at runtime.
                     type: string
                   message:
                     type: string
@@ -131,18 +164,26 @@ spec:
                   type:
                     type: string
                 required:
-                - type
-                - status
-                type: object
-              type: array
+                  - type
+                  - status
+            serviceAccountName:
+              type: string
             sinkUri:
               type: string
+            ceAttributes:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  source:
+                    type: string
             projectId:
               type: string
             topicId:
               type: string
-            notificationId:
-              type: string
             subscriptionId:
               type: string
-          type: object
+            jobName:
+              type: string

--- a/config/core/resources/cloudstoragesource.yaml
+++ b/config/core/resources/cloudstoragesource.yaml
@@ -30,7 +30,6 @@ metadata:
   name: cloudstoragesources.events.cloud.google.com
 spec:
   group: events.cloud.google.com
-  version: v1alpha1
   names:
     categories:
     - all
@@ -42,6 +41,7 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+  preserveUnknownFields: false
   additionalPrinterColumns:
     - name: Ready
       type: string
@@ -52,66 +52,98 @@ spec:
     - name: Age
       type: date
       JSONPath: .metadata.creationTimestamp
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
+          required:
+            - bucket
+            - sink
           properties:
-            googleServiceAccount:
-              type: string
-              description: "GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service account must be a valid Google service account (see https://cloud.google.com/iam/docs/service-accounts)."
-            secret:
-              type: object
-              description: "Credential used to poll the Cloud Pub/Sub Subscription. It is not used to create or delete the Subscription, only to poll it. The value of the secret entry must be a service account key in the JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys). Defaults to secret.name of 'google-cloud-key' and secret.key of 'key.json'."
-            serviceAccountName:
-              type: string
-              description: "Service Account to run Receive Adapter as. If omitted, uses 'default'."
-            project:
-              type: string
-              description: "Google Cloud Project ID of the project into which the topic should be created. If omitted uses the Project ID from the GKE cluster metadata service."
-            bucket:
-              type: string
-              description: "GCS bucket to subscribe to. For example my-test-bucket"
-            objectNamePrefix:
-              type: string
-              description: "Optional prefix to only notify when objects match this prefix."
-            payloadFormat:
-              type: string
-              description: "Optional payload format. Either NONE or JSON_API_V1. If omitted, uses JSON_API_V1."
             sink:
               type: object
-              description: "Sink which receives the notifications."
-              anyOf:
-                - type: object
+              description: >
+                Sink which receives the notifications.
+              properties:
+                uri:
+                  type: string
+                  minLength: 1
+                ref:
+                  type: object
+                  required:
+                    - apiVersion
+                    - kind
+                    - name
                   properties:
-                    uri:
+                    apiVersion:
                       type: string
                       minLength: 1
-                - type: object
-                  properties:
-                    ref:
-                      type: object
-                      required:
-                        - apiVersion
-                        - kind
-                        - name
-                      properties:
-                        apiVersion:
-                          type: string
-                          minLength: 1
-                        kind:
-                          type: string
-                          minLength: 1
-                        name:
-                          type: string
-                          minLength: 1
+                    kind:
+                      type: string
+                      minLength: 1
+                    namespace:
+                      type: string
+                    name:
+                      type: string
+                      minLength: 1
             ceOverrides:
               type: object
-              description: "Defines overrides to control modifications of the event sent to the sink."
+              description: >
+                Defines overrides to control modifications of the event sent to the sink.
               properties:
                 extensions:
                   type: object
-                  description: "Extensions specify what attribute are added or overridden on the outbound event. Each `Extensions` key-value pair are set on the event as an attribute extension independently."
+                  description: >
+                    Extensions specify what attribute are added or overridden on the outbound event. Each
+                    `Extensions` key-value pair are set on the event as an attribute extension independently.
+                  x-kubernetes-preserve-unknown-fields: true
+            googleServiceAccount:
+              type: string
+              description: >
+                GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service
+                account must be a valid Google service account (see
+                https://cloud.google.com/iam/docs/service-accounts).
+            secret:
+              type: object
+              description: >
+                Credential used to poll the Cloud Pub/Sub Subscription. It is not used to create or delete the
+                Subscription, only to poll it. The value of the secret entry must be a service account key in
+                the JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
+                Defaults to secret.name of 'google-cloud-key' and secret.key of 'key.json'.
+              properties:
+                name:
+                  type: string
+                key:
+                  type: string
+                optional:
+                  type: boolean
+            project:
+              type: string
+              description: >
+                Google Cloud Project ID of the project into which the topic should be created. If omitted uses
+                the Project ID from the GKE cluster metadata service.
+            serviceAccountName:
+              type: string
+              description: >
+                Service Account to run Receive Adapter as. If omitted, uses 'default'.
+            bucket:
+              type: string
+              description: >
+                GCS bucket to subscribe to. For example 'my-test-bucket'.
+            objectNamePrefix:
+              type: string
+              description: >
+                Optional prefix to only notify when objects match this prefix.
+            payloadFormat:
+              type: string
+              description: >
+                Optional payload format. Either NONE or JSON_API_V1. If omitted, uses JSON_API_V1.
             eventTypes:
               type: array
               items:
@@ -121,9 +153,6 @@ spec:
                   - com.google.cloud.storage.object.delete
                   - com.google.cloud.storage.object.archive
                   - com.google.cloud.storage.object.metadataUpdate
-          required:
-          - bucket
-          - sink
         status:
           type: object
           properties:
@@ -136,8 +165,7 @@ spec:
                 type: object
                 properties:
                   lastTransitionTime:
-                    # we use a string in the stored object but a wrapper object
-                    # at runtime.
+                    # We use a string in the stored object but a wrapper object at runtime.
                     type: string
                   message:
                     type: string
@@ -150,15 +178,26 @@ spec:
                   type:
                     type: string
                 required:
-                - type
-                - status
+                  - type
+                  - status
+            serviceAccountName:
+              type: string
             sinkUri:
               type: string
+            ceAttributes:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  source:
+                    type: string
             projectId:
               type: string
             topicId:
               type: string
-            notificationId:
-              type: string
             subscriptionId:
+              type: string
+            notificationId:
               type: string


### PR DESCRIPTION
Helps with #614.

## Proposed Changes

- Create structural schemas for the sources that we intend to include in release/1.
  - This is a prerequisite for serving multiple versions of the same CRD.

**Release Note**

```release-note
`CloudAuditLogsSource`, `CloudPubSubSource`, `CloudSchedulerSource`, 
and `CloudStorageSource` will aggressively remove unknown fields.
```