### PR TITLE
Get default project ID from metadata

### DIFF
--- a/cmd/broker/fanout/main.go
+++ b/cmd/broker/fanout/main.go
@@ -57,7 +57,7 @@ var (
 type envConfig struct {
 	PodName                string        `envconfig:"POD_NAME" required:"true"`
 	ProjectID              string        `envconfig:"PROJECT_ID"`
-	TargetsConfigPath      string        `envconfig:"TARGETS_CONFIG_PATH"`
+	TargetsConfigPath      string        `envconfig:"TARGETS_CONFIG_PATH" default:"/var/run/cloud-run-events/broker/targets"`
 	HandlerConcurrency     int           `envconfig:"HANDLER_CONCURRENCY"`
 	MaxConcurrencyPerEvent int           `envconfig:"MAX_CONCURRENCY_PER_EVENT"`
 	TimeoutPerEvent        time.Duration `envconfig:"TIMEOUT_PER_EVENT"`


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Give a default value to TARGETS_CONFIG_PATH. Alternatively we can mark it as `required`
- If `PROJECT_ID` is not set, we get it from metadata.
- 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

/assign @yolocs 