### PR TITLE
Remove pubsub.cloud.google.com/crd-install label selector

### DIFF
--- a/docs/install/install-knative-gcp.md
+++ b/docs/install/install-knative-gcp.md
@@ -30,8 +30,6 @@
         which cause intermittent errors:
 
         ```shell
-        kubectl apply --selector pubsub.cloud.google.com/crd-install=true \
-        --filename https://github.com/google/knative-gcp/releases/download/{{< version >}}/cloud-run-events.yaml
         kubectl apply --selector messaging.cloud.google.com/crd-install=true \
         --filename https://github.com/google/knative-gcp/releases/download/{{< version >}}/cloud-run-events.yaml
         kubectl apply --selector events.cloud.google.com/crd-install=true \


### PR DESCRIPTION
Remove pubsub.cloud.google.com/crd-install label selector, which seems to no longer be used.

Fixes #848.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Remove pubsub.cloud.google.com/crd-install label selector, which seems to no longer be used.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```
