### PR TITLE
Cleanups for broker handler

### DIFF
--- a/pkg/broker/config/cache_test.go
+++ b/pkg/broker/config/cache_test.go
@@ -128,7 +128,7 @@ func TestCachedTargetsRange(t *testing.T) {
 	t.Run("range brokers", func(t *testing.T) {
 		gotBrokers := make(map[string]*Broker)
 		targets.RangeBrokers(func(b *Broker) bool {
-			gotBrokers[BrokerKey(b.Namespace, b.Name)] = b
+			gotBrokers[b.Key()] = b
 			return true
 		})
 		if diff := cmp.Diff(val.Brokers, gotBrokers); diff != "" {
@@ -471,7 +471,7 @@ func TestGetBrokerOrTarget(t *testing.T) {
 
 	t.Run("get target by key", func(t *testing.T) {
 		wantTargets := t1
-		gotTargets, _ := targets.GetTargetByKey(TriggerKey(t1.Namespace, t1.Broker, t1.Name))
+		gotTargets, _ := targets.GetTargetByKey(t1.Key())
 		if diff := cmp.Diff(wantTargets, gotTargets); diff != "" {
 			t.Errorf("GetTargetByKey (-want,+got): %v", diff)
 		}

--- a/pkg/broker/config/config.go
+++ b/pkg/broker/config/config.go
@@ -96,3 +96,13 @@ func SplitTriggerKey(key string) (string, string, string) {
 	keys := strings.Split(key, "/")
 	return keys[0], keys[1], keys[2]
 }
+
+// Key returns the target key.
+func (t *Target) Key() string {
+	return TriggerKey(t.Namespace, t.Broker, t.Name)
+}
+
+// Key returns the broker key.
+func (b *Broker) Key() string {
+	return BrokerKey(b.Namespace, b.Name)
+}

--- a/pkg/broker/config/config_test.go
+++ b/pkg/broker/config/config_test.go
@@ -27,3 +27,11 @@ func TestBrokerKey(t *testing.T) {
 		t.Errorf("unexpected readiness: want %v, got %v", want, got)
 	}
 }
+
+func TestTriggerKeyAndSplitTriggerKey(t *testing.T) {
+	want := "namespace/broker/target"
+	got := TriggerKey(SplitTriggerKey(want))
+	if got != want {
+		t.Errorf("unexpected readiness: want %v, got %v", want, got)
+	}
+}

--- a/pkg/broker/config/config_test.go
+++ b/pkg/broker/config/config_test.go
@@ -27,11 +27,3 @@ func TestBrokerKey(t *testing.T) {
 		t.Errorf("unexpected readiness: want %v, got %v", want, got)
 	}
 }
-
-func TestTriggerKeyAndSplitTriggerKey(t *testing.T) {
-	want := "namespace/broker/target"
-	got := TriggerKey(SplitTriggerKey(want))
-	if got != want {
-		t.Errorf("unexpected readiness: want %v, got %v", want, got)
-	}
-}

--- a/pkg/broker/handler/context/broker.go
+++ b/pkg/broker/handler/context/broker.go
@@ -18,40 +18,21 @@ package context
 
 import (
 	"context"
-
-	"github.com/google/knative-gcp/pkg/broker/config"
 )
-
-// The key used to store/retrieve broker key in the context.
-type brokerKeyKey struct{}
 
 // The key used to store/retrieve broker in the context.
 type brokerKey struct{}
 
 // WithBrokerKey sets a broker key in the context.
 func WithBrokerKey(ctx context.Context, key string) context.Context {
-	return context.WithValue(ctx, brokerKeyKey{}, key)
+	return context.WithValue(ctx, brokerKey{}, key)
 }
 
 // GetBrokerKey gets the broker key from the context.
 func GetBrokerKey(ctx context.Context) (string, error) {
-	untyped := ctx.Value(brokerKeyKey{})
+	untyped := ctx.Value(brokerKey{})
 	if untyped == nil {
 		return "", ErrBrokerKeyNotPresent
 	}
 	return untyped.(string), nil
-}
-
-// WithBroker sets a broker in the context.
-func WithBroker(ctx context.Context, b *config.Broker) context.Context {
-	return context.WithValue(ctx, brokerKey{}, b)
-}
-
-// GetBroker gets a broker from the context.
-func GetBroker(ctx context.Context) (*config.Broker, error) {
-	untyped := ctx.Value(brokerKey{})
-	if untyped == nil {
-		return nil, ErrBrokerNotPresent
-	}
-	return untyped.(*config.Broker), nil
 }

--- a/pkg/broker/handler/context/broker_test.go
+++ b/pkg/broker/handler/context/broker_test.go
@@ -19,10 +19,6 @@ package context
 import (
 	"context"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
-
-	"github.com/google/knative-gcp/pkg/broker/config"
 )
 
 func TestBrokerKey(t *testing.T) {
@@ -39,34 +35,5 @@ func TestBrokerKey(t *testing.T) {
 	}
 	if gotKey != wantKey {
 		t.Errorf("broker key from context got=%s, want=%s", gotKey, wantKey)
-	}
-}
-
-func TestBroker(t *testing.T) {
-	_, err := GetBroker(context.Background())
-	if err != ErrBrokerNotPresent {
-		t.Errorf("error from GetBroker got=%v, want=%v", err, ErrBrokerNotPresent)
-	}
-
-	wantBroker := &config.Broker{
-		Name:      "broker",
-		Namespace: "ns",
-		Address:   "address",
-		Targets: map[string]*config.Target{
-			"target": {
-				Name:      "target",
-				Namespace: "ns",
-			},
-		},
-	}
-
-	ctx := WithBroker(context.Background(), wantBroker)
-	gotBroker, err := GetBroker(ctx)
-	if err != nil {
-		t.Errorf("unexpected error from GetBroker: %v", err)
-	}
-
-	if diff := cmp.Diff(wantBroker, gotBroker); diff != "" {
-		t.Errorf("broker from context (-want,+got): %v", diff)
 	}
 }

--- a/pkg/broker/handler/context/errs.go
+++ b/pkg/broker/handler/context/errs.go
@@ -19,7 +19,6 @@ package context
 import "errors"
 
 var (
-	ErrTargetNotPresent    = errors.New("target not present in the context")
-	ErrBrokerNotPresent    = errors.New("broker not present in the context")
+	ErrTargetKeyNotPresent = errors.New("target key not present in the context")
 	ErrBrokerKeyNotPresent = errors.New("broker key not present in the context")
 )

--- a/pkg/broker/handler/context/target.go
+++ b/pkg/broker/handler/context/target.go
@@ -18,22 +18,20 @@ package context
 
 import (
 	"context"
-
-	"github.com/google/knative-gcp/pkg/broker/config"
 )
 
 type targetKey struct{}
 
-// WithTarget sets a target in the context.
-func WithTarget(ctx context.Context, t *config.Target) context.Context {
-	return context.WithValue(ctx, targetKey{}, t)
+// WithTargetKey sets a target key in the context.
+func WithTargetKey(ctx context.Context, key string) context.Context {
+	return context.WithValue(ctx, targetKey{}, key)
 }
 
-// GetTarget gets a target from the context.
-func GetTarget(ctx context.Context) (*config.Target, error) {
+// GetTargetKey gets a target key from the context.
+func GetTargetKey(ctx context.Context) (string, error) {
 	untyped := ctx.Value(targetKey{})
 	if untyped == nil {
-		return nil, ErrTargetNotPresent
+		return "", ErrTargetKeyNotPresent
 	}
-	return untyped.(*config.Target), nil
+	return untyped.(string), nil
 }

--- a/pkg/broker/handler/context/target_test.go
+++ b/pkg/broker/handler/context/target_test.go
@@ -19,30 +19,18 @@ package context
 import (
 	"context"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
-
-	"github.com/google/knative-gcp/pkg/broker/config"
 )
 
-func TestTarget(t *testing.T) {
-	_, err := GetTarget(context.Background())
-	if err != ErrTargetNotPresent {
-		t.Errorf("error from GetTarget got=%v, want=%v", err, ErrTargetNotPresent)
+func TestTargetKey(t *testing.T) {
+	_, err := GetTargetKey(context.Background())
+	if err != ErrTargetKeyNotPresent {
+		t.Errorf("error from GetTargetKey got=%v, want=%v", err, ErrTargetKeyNotPresent)
 	}
 
-	wantTarget := &config.Target{
-		Name:      "target",
-		Namespace: "ns",
-		Address:   "address",
-		Broker:    "broker",
-	}
-	ctx := WithTarget(context.Background(), wantTarget)
-	gotTarget, err := GetTarget(ctx)
-	if err != nil {
-		t.Errorf("unexpected error from GetTarget: %v", err)
-	}
-	if diff := cmp.Diff(wantTarget, gotTarget); diff != "" {
-		t.Errorf("target from context (-want,+got): %v", diff)
+	wantTarget := "my-target"
+	ctx := WithTargetKey(context.Background(), wantTarget)
+	gotTarget, err := GetTargetKey(ctx)
+	if gotTarget != wantTarget {
+		t.Errorf("GetTargetKey got=%v, want=%v", gotTarget, wantTarget)
 	}
 }

--- a/pkg/broker/handler/pool/fanout/pool_test.go
+++ b/pkg/broker/handler/pool/fanout/pool_test.go
@@ -122,8 +122,8 @@ func TestSyncPoolE2E(t *testing.T) {
 	b2 := genTestBroker(ctx, t, ps)
 	targets := memory.NewTargets(&config.TargetsConfig{
 		Brokers: map[string]*config.Broker{
-			config.BrokerKey(b1.Namespace, b1.Name): b1,
-			config.BrokerKey(b2.Namespace, b2.Name): b2,
+			b1.Key(): b1,
+			b2.Key(): b2,
 		},
 	})
 	b1t1, b1t1Client, b1t1close := addTestTargetToBroker(t, targets, b1.Name, nil)
@@ -319,7 +319,7 @@ func assertHandlers(t *testing.T, p *SyncPool, targets config.Targets) {
 	})
 
 	targets.RangeBrokers(func(b *config.Broker) bool {
-		wantHandlers[config.BrokerKey(b.Namespace, b.Name)] = true
+		wantHandlers[b.Key()] = true
 		return true
 	})
 

--- a/pkg/broker/handler/pool/options.go
+++ b/pkg/broker/handler/pool/options.go
@@ -17,12 +17,14 @@ limitations under the License.
 package pool
 
 import (
+	"fmt"
 	"runtime"
 	"time"
 
 	"cloud.google.com/go/pubsub"
 	cev2 "github.com/cloudevents/sdk-go/v2"
 	ceclient "github.com/cloudevents/sdk-go/v2/client"
+	"github.com/google/knative-gcp/pkg/utils"
 )
 
 var (
@@ -30,24 +32,6 @@ var (
 	defaultMaxConcurrencyPerEvent = 1
 	defaultTimeout                = 10 * time.Minute
 )
-
-var defaultCeClient ceclient.Client
-
-func init() {
-	p, err := cev2.NewHTTP()
-	if err != nil {
-		panic(err)
-	}
-	c, err := cev2.NewClientObserved(p,
-		ceclient.WithUUIDs(),
-		ceclient.WithTimeNow(),
-		ceclient.WithTracePropagation(),
-	)
-	if err != nil {
-		panic(err)
-	}
-	defaultCeClient = c
-}
 
 // Options holds all the options for create handler pool.
 type Options struct {
@@ -72,7 +56,7 @@ type Options struct {
 }
 
 // NewOptions creates a Options.
-func NewOptions(opts ...Option) *Options {
+func NewOptions(opts ...Option) (*Options, error) {
 	opt := &Options{
 		HandlerConcurrency:     defaultHandlerConcurrency,
 		MaxConcurrencyPerEvent: defaultMaxConcurrencyPerEvent,
@@ -82,10 +66,33 @@ func NewOptions(opts ...Option) *Options {
 	for _, o := range opts {
 		o(opt)
 	}
-	if opt.EventRequester == nil {
-		opt.EventRequester = defaultCeClient
+	if opt.ProjectID == "" {
+		pid, err := utils.ProjectID(opt.ProjectID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get default ProjectID: %w", err)
+		}
+		opt.ProjectID = pid
 	}
-	return opt
+	if opt.EventRequester == nil {
+		c, err := defaultCeClient()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create default CloudEvents client: %w", err)
+		}
+		opt.EventRequester = c
+	}
+	return opt, nil
+}
+
+func defaultCeClient() (ceclient.Client, error) {
+	p, err := cev2.NewHTTP()
+	if err != nil {
+		panic(err)
+	}
+	return cev2.NewClientObserved(p,
+		ceclient.WithUUIDs(),
+		ceclient.WithTimeNow(),
+		ceclient.WithTracePropagation(),
+	)
 }
 
 // Option is for providing individual option.

--- a/pkg/broker/handler/pool/options_test.go
+++ b/pkg/broker/handler/pool/options_test.go
@@ -26,7 +26,10 @@ import (
 
 func TestWithProjectID(t *testing.T) {
 	want := "random"
-	opt := NewOptions(WithProjectID(want))
+	opt, err := NewOptions(WithProjectID(want))
+	if err != nil {
+		t.Errorf("NewOptions got unexpected error: %v", err)
+	}
 	if opt.ProjectID != want {
 		t.Errorf("options project id got=%s, want=%s", opt.ProjectID, want)
 	}
@@ -34,7 +37,11 @@ func TestWithProjectID(t *testing.T) {
 
 func TestWithHandlerConcurrency(t *testing.T) {
 	want := 10
-	opt := NewOptions(WithHandlerConcurrency(want))
+	// Always add project id because in some env the default value can't be retrieved.
+	opt, err := NewOptions(WithHandlerConcurrency(want), WithProjectID("pid"))
+	if err != nil {
+		t.Errorf("NewOptions got unexpected error: %v", err)
+	}
 	if opt.HandlerConcurrency != want {
 		t.Errorf("options handler concurrency got=%d, want=%d", opt.HandlerConcurrency, want)
 	}
@@ -42,7 +49,11 @@ func TestWithHandlerConcurrency(t *testing.T) {
 
 func TestWithMaxConcurrency(t *testing.T) {
 	want := 10
-	opt := NewOptions(WithMaxConcurrentPerEvent(want))
+	// Always add project id because in some env the default value can't be retrieved.
+	opt, err := NewOptions(WithMaxConcurrentPerEvent(want), WithProjectID("pid"))
+	if err != nil {
+		t.Errorf("NewOptions got unexpected error: %v", err)
+	}
 	if opt.MaxConcurrencyPerEvent != want {
 		t.Errorf("options max concurrency per event got=%d, want=%d", opt.MaxConcurrencyPerEvent, want)
 	}
@@ -50,7 +61,11 @@ func TestWithMaxConcurrency(t *testing.T) {
 
 func TestWithTimeout(t *testing.T) {
 	want := 10 * time.Minute
-	opt := NewOptions(WithTimeoutPerEvent(want))
+	// Always add project id because in some env the default value can't be retrieved.
+	opt, err := NewOptions(WithTimeoutPerEvent(want), WithProjectID("pid"))
+	if err != nil {
+		t.Errorf("NewOptions got unexpected error: %v", err)
+	}
 	if opt.TimeoutPerEvent != want {
 		t.Errorf("options timeout per event got=%v, want=%v", opt.TimeoutPerEvent, want)
 	}
@@ -61,25 +76,41 @@ func TestWithReceiveSettings(t *testing.T) {
 		NumGoroutines: 10,
 		MaxExtension:  time.Minute,
 	}
-	opt := NewOptions(WithPubsubReceiveSettings(want))
+	// Always add project id because in some env the default value can't be retrieved.
+	opt, err := NewOptions(WithPubsubReceiveSettings(want), WithProjectID("pid"))
+	if err != nil {
+		t.Errorf("NewOptions got unexpected error: %v", err)
+	}
 	if diff := cmp.Diff(want, opt.PubsubReceiveSettings); diff != "" {
 		t.Errorf("options ReceiveSettings (-want,+got): %v", diff)
 	}
 }
 
 func TestWithPubsubClient(t *testing.T) {
-	opt := NewOptions()
+	// Always add project id because in some env the default value can't be retrieved.
+	opt, err := NewOptions(WithProjectID("pid"))
+	if err != nil {
+		t.Errorf("NewOptions got unexpected error: %v", err)
+	}
 	if opt.PubsubClient != nil {
 		t.Errorf("options PubsubClient got=%v, want=nil", opt.PubsubClient)
 	}
-	opt = NewOptions(WithPubsubClient(&pubsub.Client{}))
+	// Always add project id because in some env the default value can't be retrieved.
+	opt, err = NewOptions(WithPubsubClient(&pubsub.Client{}), WithProjectID("pid"))
+	if err != nil {
+		t.Errorf("NewOptions got unexpected error: %v", err)
+	}
 	if opt.PubsubClient == nil {
 		t.Error("options PubsubClient got=nil, want=non-nil client")
 	}
 }
 
 func TestWithSignal(t *testing.T) {
-	opt := NewOptions(WithSyncSignal(make(chan struct{})))
+	// Always add project id because in some env the default value can't be retrieved.
+	opt, err := NewOptions(WithSyncSignal(make(chan struct{})), WithProjectID("pid"))
+	if err != nil {
+		t.Errorf("NewOptions got unexpected error: %v", err)
+	}
 	if opt.SyncSignal == nil {
 		t.Error("options SyncSignal is nil")
 	}

--- a/pkg/broker/handler/pool/options_test.go
+++ b/pkg/broker/handler/pool/options_test.go
@@ -37,7 +37,7 @@ func TestWithProjectID(t *testing.T) {
 
 func TestWithHandlerConcurrency(t *testing.T) {
 	want := 10
-	// Always add project id because in some env the default value can't be retrieved.
+	// Always add project id because the default value can only be retrieved on GCE/GKE machines.
 	opt, err := NewOptions(WithHandlerConcurrency(want), WithProjectID("pid"))
 	if err != nil {
 		t.Errorf("NewOptions got unexpected error: %v", err)
@@ -49,7 +49,7 @@ func TestWithHandlerConcurrency(t *testing.T) {
 
 func TestWithMaxConcurrency(t *testing.T) {
 	want := 10
-	// Always add project id because in some env the default value can't be retrieved.
+	// Always add project id because the default value can only be retrieved on GCE/GKE machines.
 	opt, err := NewOptions(WithMaxConcurrentPerEvent(want), WithProjectID("pid"))
 	if err != nil {
 		t.Errorf("NewOptions got unexpected error: %v", err)
@@ -61,7 +61,7 @@ func TestWithMaxConcurrency(t *testing.T) {
 
 func TestWithTimeout(t *testing.T) {
 	want := 10 * time.Minute
-	// Always add project id because in some env the default value can't be retrieved.
+	// Always add project id because the default value can only be retrieved on GCE/GKE machines.
 	opt, err := NewOptions(WithTimeoutPerEvent(want), WithProjectID("pid"))
 	if err != nil {
 		t.Errorf("NewOptions got unexpected error: %v", err)
@@ -76,7 +76,7 @@ func TestWithReceiveSettings(t *testing.T) {
 		NumGoroutines: 10,
 		MaxExtension:  time.Minute,
 	}
-	// Always add project id because in some env the default value can't be retrieved.
+	// Always add project id because the default value can only be retrieved on GCE/GKE machines.
 	opt, err := NewOptions(WithPubsubReceiveSettings(want), WithProjectID("pid"))
 	if err != nil {
 		t.Errorf("NewOptions got unexpected error: %v", err)
@@ -87,7 +87,7 @@ func TestWithReceiveSettings(t *testing.T) {
 }
 
 func TestWithPubsubClient(t *testing.T) {
-	// Always add project id because in some env the default value can't be retrieved.
+	// Always add project id because the default value can only be retrieved on GCE/GKE machines.
 	opt, err := NewOptions(WithProjectID("pid"))
 	if err != nil {
 		t.Errorf("NewOptions got unexpected error: %v", err)
@@ -95,7 +95,7 @@ func TestWithPubsubClient(t *testing.T) {
 	if opt.PubsubClient != nil {
 		t.Errorf("options PubsubClient got=%v, want=nil", opt.PubsubClient)
 	}
-	// Always add project id because in some env the default value can't be retrieved.
+	// Always add project id because the default value can only be retrieved on GCE/GKE machines.
 	opt, err = NewOptions(WithPubsubClient(&pubsub.Client{}), WithProjectID("pid"))
 	if err != nil {
 		t.Errorf("NewOptions got unexpected error: %v", err)
@@ -106,7 +106,7 @@ func TestWithPubsubClient(t *testing.T) {
 }
 
 func TestWithSignal(t *testing.T) {
-	// Always add project id because in some env the default value can't be retrieved.
+	// Always add project id because the default value can only be retrieved on GCE/GKE machines.
 	opt, err := NewOptions(WithSyncSignal(make(chan struct{})), WithProjectID("pid"))
 	if err != nil {
 		t.Errorf("NewOptions got unexpected error: %v", err)

--- a/pkg/broker/handler/pool/retry/pool.go
+++ b/pkg/broker/handler/pool/retry/pool.go
@@ -47,9 +47,13 @@ type SyncPool struct {
 
 // StartSyncPool starts the sync pool.
 func StartSyncPool(ctx context.Context, targets config.ReadonlyTargets, opts ...pool.Option) (*SyncPool, error) {
+	options, err := pool.NewOptions(opts...)
+	if err != nil {
+		return nil, err
+	}
 	p := &SyncPool{
 		targets: targets,
-		options: pool.NewOptions(opts...),
+		options: options,
 	}
 	if err := p.syncOnce(ctx); err != nil {
 		return nil, err
@@ -86,31 +90,16 @@ func (p *SyncPool) syncOnce(ctx context.Context) error {
 	})
 
 	p.targets.RangeAllTargets(func(t *config.Target) bool {
-		tk := config.TriggerKey(t.Namespace, t.Broker, t.Name)
-		bk := config.BrokerKey(t.Namespace, t.Broker)
-		broker, ok := p.targets.GetBrokerByKey(bk)
-		if !ok {
-			// If corresponding broker doesn't exist, no need to process retry.
-			// TODO Need to revisit it for desired behavior of retry if the broker gets deleted.
-			logging.FromContext(ctx).Error(fmt.Sprintf("event broker %q doesn't exist in config", bk), zap.String("trigger", t.Name))
-			return true
-		}
-
 		// There is already a handler for the trigger, skip.
-		if _, ok := p.pool.Load(tk); ok {
+		if _, ok := p.pool.Load(t.Key()); ok {
 			return true
 		}
 
 		opts := []pubsub.Option{
+			pubsub.WithProjectID(p.options.ProjectID),
 			pubsub.WithTopicID(t.RetryQueue.Topic),
 			pubsub.WithSubscriptionID(t.RetryQueue.Subscription),
 			pubsub.WithReceiveSettings(&p.options.PubsubReceiveSettings),
-		}
-
-		if p.options.ProjectID != "" {
-			opts = append(opts, pubsub.WithProjectID(p.options.ProjectID))
-		} else {
-			opts = append(opts, pubsub.WithProjectIDFromDefaultEnv())
 		}
 
 		if p.options.PubsubClient != nil {
@@ -118,7 +107,7 @@ func (p *SyncPool) syncOnce(ctx context.Context) error {
 		}
 		ps, err := pubsub.New(ctx, opts...)
 		if err != nil {
-			logging.FromContext(ctx).Error("failed to create pubsub protocol", zap.String("trigger", t.Name), zap.Error(err))
+			logging.FromContext(ctx).Error("failed to create pubsub protocol", zap.String("trigger", t.Key()), zap.Error(err))
 			errs++
 			return true
 		}
@@ -133,19 +122,20 @@ func (p *SyncPool) syncOnce(ctx context.Context) error {
 		}
 
 		// Deliver processor needs the broker in the context for reply.
-		tctx := handlerctx.WithBroker(ctx, broker)
+		tctx := handlerctx.WithBrokerKey(ctx, config.BrokerKey(t.Namespace, t.Broker))
+		tctx = handlerctx.WithTargetKey(tctx, t.Key())
 		// Start the handler with target in context.
-		h.Start(handlerctx.WithTarget(tctx, t), func(err error) {
+		h.Start(tctx, func(err error) {
 			if err != nil {
-				logging.FromContext(ctx).Error("handler for broker has stopped with error", zap.String("trigger", t.Name), zap.Error(err))
+				logging.FromContext(ctx).Error("handler for broker has stopped with error", zap.String("trigger", t.Key()), zap.Error(err))
 			} else {
-				logging.FromContext(ctx).Info("handler for broker has stopped", zap.String("trigger", t.Name))
+				logging.FromContext(ctx).Info("handler for broker has stopped", zap.String("trigger", t.Key()))
 			}
 			// Make sure the handler is deleted from the pool.
 			p.pool.Delete(h)
 		})
 
-		p.pool.Store(tk, h)
+		p.pool.Store(t.Key(), h)
 		return true
 	})
 

--- a/pkg/broker/handler/pool/retry/pool.go
+++ b/pkg/broker/handler/pool/retry/pool.go
@@ -117,7 +117,7 @@ func (p *SyncPool) syncOnce(ctx context.Context) error {
 			PubsubEvents: ps,
 			Processor: processors.ChainProcessors(
 				// TODO filter processor may be added in the future, but need more discussion for that.
-				&deliver.Processor{Requester: p.options.EventRequester},
+				&deliver.Processor{Requester: p.options.EventRequester, Targets: p.targets},
 			),
 		}
 

--- a/pkg/broker/handler/pool/retry/pool_test.go
+++ b/pkg/broker/handler/pool/retry/pool_test.go
@@ -111,7 +111,7 @@ func assertHandlers(t *testing.T, p *SyncPool, targets config.Targets) {
 	})
 
 	targets.RangeAllTargets(func(t *config.Target) bool {
-		wantHandlers[config.TriggerKey(t.Namespace, t.Broker, t.Name)] = true
+		wantHandlers[t.Key()] = true
 		return true
 	})
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add `Key()` function to `config.Broker` and `config.Target` for easier access
- For consistency, now only put keys in context and have each processor use the key to find broker/trigger.
- Provide default project ID via `pool.Options`.


Refs:
- https://github.com/google/knative-gcp/issues/835
- https://github.com/google/knative-gcp/pull/841