### PR TITLE
Unit test no longer tries to find credentials

### DIFF
--- a/pkg/broker/handler/pool/retry/pool_test.go
+++ b/pkg/broker/handler/pool/retry/pool_test.go
@@ -22,19 +22,28 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/pstest"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/knative-gcp/pkg/broker/config"
 	"github.com/google/knative-gcp/pkg/broker/config/memory"
 	"github.com/google/knative-gcp/pkg/broker/handler/pool"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
 )
 
 // TODO could reuse some fanout UT test function here. Needing a semi e2e test, perhaps could be combined with fanout semi e2e test, or reuse some function.
 // TODO making some fanout UT test/e2e test function shared.
 func TestWatchAndSync(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	testProject := "test-project"
+	ps, psCleanup := createTestPubsubClient(ctx, t, testProject)
+	defer psCleanup()
 	signal := make(chan struct{})
 	targets := memory.NewEmptyTargets()
-	p, err := StartSyncPool(context.Background(), targets,
+	p, err := StartSyncPool(ctx, targets,
+		pool.WithPubsubClient(ps),
 		pool.WithProjectID(testProject),
 		pool.WithSyncSignal(signal),
 	)
@@ -135,4 +144,23 @@ func makeTarget(name, brokerName, namespace string) *config.Target {
 			Subscription: "sub",
 		},
 	}
+}
+
+// TODO merge with testPubsubClient() in pkg/broker/handler/pool/fanout/pool_test.go.
+func createTestPubsubClient(ctx context.Context, t *testing.T, projectID string) (*pubsub.Client, func()) {
+	t.Helper()
+	srv := pstest.NewServer()
+	conn, err := grpc.Dial(srv.Addr, grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("failed to dial test pubsub connection: %v", err)
+	}
+	cleanup := func() {
+		srv.Close()
+		conn.Close()
+	}
+	c, err := pubsub.NewClient(ctx, projectID, option.WithGRPCConn(conn))
+	if err != nil {
+		t.Fatalf("failed to create test pubsub client: %v", err)
+	}
+	return c, cleanup
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Unit test no longer tries to find credentials, instead a mocked client is used.

---

Before this change, the test would fail on my mac:

```
go test github.com/google/knative-gcp/pkg/broker/handler/pool/retry -count 1
{"level":"error","ts":1587068675.976608,"logger":"fallback","caller":"retry/pool.go:110","msg":"failed to create pubsub protocol","trigger":"ns-1/broker-0/old","error":"pubsub: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.","stacktrace":"github.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).syncOnce.func2\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:110\ngithub.com/google/knative-gcp/pkg/broker/config.(*CachedTargets).RangeAllTargets\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/config/cache.go:52\ngithub.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).syncOnce\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:92\ngithub.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).watch\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:73"}
{"level":"error","ts":1587068675.976786,"logger":"fallback","caller":"retry/pool.go:110","msg":"failed to create pubsub protocol","trigger":"ns-1/broker-1/old","error":"pubsub: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.","stacktrace":"github.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).syncOnce.func2\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:110\ngithub.com/google/knative-gcp/pkg/broker/config.(*CachedTargets).RangeAllTargets\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/config/cache.go:52\ngithub.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).syncOnce\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:92\ngithub.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).watch\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:73"}
{"level":"error","ts":1587068675.976817,"logger":"fallback","caller":"retry/pool.go:110","msg":"failed to create pubsub protocol","trigger":"ns-0/broker-1/old","error":"pubsub: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.","stacktrace":"github.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).syncOnce.func2\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:110\ngithub.com/google/knative-gcp/pkg/broker/config.(*CachedTargets).RangeAllTargets\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/config/cache.go:52\ngithub.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).syncOnce\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:92\ngithub.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).watch\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:73"}
{"level":"error","ts":1587068675.9768379,"logger":"fallback","caller":"retry/pool.go:110","msg":"failed to create pubsub protocol","trigger":"ns-0/broker-0/old","error":"pubsub: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.","stacktrace":"github.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).syncOnce.func2\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:110\ngithub.com/google/knative-gcp/pkg/broker/config.(*CachedTargets).RangeAllTargets\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/config/cache.go:52\ngithub.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).syncOnce\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:92\ngithub.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).watch\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:73"}
{"level":"error","ts":1587068675.976854,"logger":"fallback","caller":"retry/pool.go:74","msg":"failed to sync handlers pool on watch signal","error":"4 errors happened during handlers pool sync","stacktrace":"github.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).watch\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:74"}
{"level":"error","ts":1587068676.978128,"logger":"fallback","caller":"retry/pool.go:110","msg":"failed to create pubsub protocol","trigger":"ns-0/broker-1/new","error":"pubsub: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.","stacktrace":"github.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).syncOnce.func2\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:110\ngithub.com/google/knative-gcp/pkg/broker/config.(*CachedTargets).RangeAllTargets\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/config/cache.go:52\ngithub.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).syncOnce\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:92\ngithub.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).watch\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:73"}
{"level":"error","ts":1587068676.9781928,"logger":"fallback","caller":"retry/pool.go:110","msg":"failed to create pubsub protocol","trigger":"ns-0/broker-0/new","error":"pubsub: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.","stacktrace":"github.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).syncOnce.func2\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:110\ngithub.com/google/knative-gcp/pkg/broker/config.(*CachedTargets).RangeAllTargets\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/config/cache.go:52\ngithub.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).syncOnce\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:92\ngithub.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).watch\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:73"}
{"level":"error","ts":1587068676.978221,"logger":"fallback","caller":"retry/pool.go:110","msg":"failed to create pubsub protocol","trigger":"ns-1/broker-0/new","error":"pubsub: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.","stacktrace":"github.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).syncOnce.func2\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:110\ngithub.com/google/knative-gcp/pkg/broker/config.(*CachedTargets).RangeAllTargets\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/config/cache.go:52\ngithub.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).syncOnce\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:92\ngithub.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).watch\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:73"}
{"level":"error","ts":1587068676.978246,"logger":"fallback","caller":"retry/pool.go:110","msg":"failed to create pubsub protocol","trigger":"ns-1/broker-1/new","error":"pubsub: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.","stacktrace":"github.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).syncOnce.func2\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:110\ngithub.com/google/knative-gcp/pkg/broker/config.(*CachedTargets).RangeAllTargets\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/config/cache.go:52\ngithub.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).syncOnce\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:92\ngithub.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).watch\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:73"}
{"level":"error","ts":1587068676.978264,"logger":"fallback","caller":"retry/pool.go:74","msg":"failed to sync handlers pool on watch signal","error":"4 errors happened during handlers pool sync","stacktrace":"github.com/google/knative-gcp/pkg/broker/handler/pool/retry.(*SyncPool).watch\n\t/Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/pool/retry/pool.go:74"}
--- FAIL: TestWatchAndSync (3.01s)
    --- FAIL: TestWatchAndSync/adding_some_brokers_with_their_targets (1.00s)
        pool_test.go:65: handlers map (-want,+got):   map[string]bool{
            -   "ns-0/broker-0/old": true,
            -   "ns-0/broker-1/old": true,
            -   "ns-1/broker-0/old": true,
            -   "ns-1/broker-1/old": true,
              }
    --- FAIL: TestWatchAndSync/delete_and_adding_targets_in_brokers (1.00s)
        pool_test.go:82: handlers map (-want,+got):   map[string]bool{
            -   "ns-0/broker-0/new": true,
            -   "ns-0/broker-1/new": true,
            -   "ns-1/broker-0/new": true,
            -   "ns-1/broker-1/new": true,
              }
FAIL
FAIL    github.com/google/knative-gcp/pkg/broker/handler/pool/retry     3.185s
FAIL

```