### PR TITLE
Inject clients to context before using it in broker retry main

### DIFF
--- a/cmd/broker/retry/main.go
+++ b/cmd/broker/retry/main.go
@@ -56,7 +56,7 @@ var (
 type envConfig struct {
 	PodName            string        `envconfig:"POD_NAME" required:"true"`
 	ProjectID          string        `envconfig:"PROJECT_ID"`
-	TargetsConfigPath  string        `envconfig:"TARGETS_CONFIG_PATH"`
+	TargetsConfigPath  string        `envconfig:"TARGETS_CONFIG_PATH" default:"/var/run/cloud-run-events/broker/targets"`
 	HandlerConcurrency int           `envconfig:"HANDLER_CONCURRENCY"`
 	TimeoutPerEvent    time.Duration `envconfig:"TIMEOUT_PER_EVENT"`
 }
@@ -77,6 +77,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error building kubeconfig: %v", err)
 	}
+	ctx, informers := injection.Default.SetupInformers(ctx, cfg)
 
 	var env envConfig
 	if err := envconfig.Process("", &env); err != nil {
@@ -94,8 +95,6 @@ func main() {
 	}); perr != nil {
 		log.Fatalf("Timed out attempting to get k8s version: %v", err)
 	}
-
-	ctx, informers := injection.Default.SetupInformers(ctx, cfg)
 
 	loggingConfig, err := sharedmain.GetLoggingConfig(ctx)
 	if err != nil {


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Give a  good default value to broker config path env var
- Inject clients before using them, otherwise it fails with
```
{"level":"panic","ts":1587080360.8897164,"logger":"fallback","caller":"clie
tive.dev/pkg/client/injection/kube/client.Get\n\tgithub.com/google/knative-
me.main\n\truntime/proc.go:203"}
panic: Unable to fetch k8s.io/client-go/kubernetes.Interface from context.
```
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
