### PR TITLE
Increase coverage of non-generated broker types code

### DIFF
--- a/pkg/apis/broker/v1beta1/broker_lifecycle_test.go
+++ b/pkg/apis/broker/v1beta1/broker_lifecycle_test.go
@@ -320,6 +320,17 @@ func TestBrokerConditionStatus(t *testing.T) {
 			if test.wantConditionStatus != got {
 				t.Errorf("unexpected readiness: want %v, got %v", test.wantConditionStatus, got)
 			}
+			happy := bs.IsReady()
+			switch test.wantConditionStatus {
+			case corev1.ConditionTrue:
+				if !happy {
+					t.Error("expected happy true, got false")
+				}
+			case corev1.ConditionFalse, corev1.ConditionUnknown:
+				if happy {
+					t.Error("expected happy false, got true")
+				}
+			}
 		})
 	}
 }

--- a/pkg/apis/broker/v1beta1/broker_types_test.go
+++ b/pkg/apis/broker/v1beta1/broker_types_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	eventingv1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
 )
 
 func TestBroker_GetGroupVersionKind(t *testing.T) {
@@ -33,5 +34,15 @@ func TestBroker_GetGroupVersionKind(t *testing.T) {
 	got := b.GetGroupVersionKind()
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("(GetGroupVersionKind (-want +got): %v", diff)
+	}
+}
+
+func TestBroker_GetUntypedSpec(t *testing.T) {
+	b := Broker{
+		Spec: eventingv1beta1.BrokerSpec{},
+	}
+	s := b.GetUntypedSpec()
+	if _, ok := s.(eventingv1beta1.BrokerSpec); !ok {
+		t.Errorf("untyped spec was not a BrokerSpec")
 	}
 }

--- a/pkg/apis/broker/v1beta1/register_test.go
+++ b/pkg/apis/broker/v1beta1/register_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestKind(t *testing.T) {
+	want := schema.GroupKind{
+		Group: "eventing.knative.dev",
+		Kind:  "Broker",
+	}
+	got := Kind("Broker")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("(Kind (-want +got): %v", diff)
+	}
+}
+
+func TestResource(t *testing.T) {
+	want := schema.GroupResource{
+		Group:    "eventing.knative.dev",
+		Resource: "brokers",
+	}
+	got := Resource("brokers")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("(Kind (-want +got): %v", diff)
+	}
+}
+
+func TestAddKnownTypes(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := addKnownTypes(scheme); err != nil {
+		t.Errorf("error in addKnownTypes: %w", err)
+	}
+
+	want := []string{
+		"Broker",
+		"BrokerList",
+		"Trigger",
+		"TriggerList",
+	}
+	got := scheme.KnownTypes(schema.GroupVersion{Group: "eventing.knative.dev", Version: "v1beta1"})
+
+	for _, tn := range want {
+		if _, exist := got[tn]; !exist {
+			t.Errorf("type %s doesn't exist in scheme", tn)
+		}
+	}
+}

--- a/pkg/apis/broker/v1beta1/test_helper.go
+++ b/pkg/apis/broker/v1beta1/test_helper.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 type testHelper struct{}
@@ -36,8 +37,14 @@ func (t testHelper) ReadyBrokerStatus() *BrokerStatus {
 	return bs
 }
 
+func (t testHelper) UnconfiguredBrokerStatus() *BrokerStatus {
+	bs := &BrokerStatus{}
+	return bs
+}
+
 func (t testHelper) UnknownBrokerStatus() *BrokerStatus {
 	bs := &BrokerStatus{}
+	bs.InitializeConditions()
 	return bs
 }
 
@@ -58,4 +65,36 @@ func (t testHelper) AvailableEndpoints() *corev1.Endpoints {
 			}},
 		}},
 	}
+}
+
+func (t testHelper) ReadyDependencyStatus() *duckv1.KResource {
+	kr := &duckv1.KResource{}
+	kr.Status.SetConditions(apis.Conditions{{
+		Type:   "Ready",
+		Status: corev1.ConditionTrue,
+	}})
+	return kr
+}
+
+func (t testHelper) UnconfiguredDependencyStatus() *duckv1.KResource {
+	kr := &duckv1.KResource{}
+	return kr
+}
+
+func (t testHelper) UnknownDependencyStatus() *duckv1.KResource {
+	kr := &duckv1.KResource{}
+	kr.Status.SetConditions(apis.Conditions{{
+		Type:   "Ready",
+		Status: corev1.ConditionUnknown,
+	}})
+	return kr
+}
+
+func (t testHelper) FalseDependencyStatus() *duckv1.KResource {
+	kr := &duckv1.KResource{}
+	kr.Status.SetConditions(apis.Conditions{{
+		Type:   "Ready",
+		Status: corev1.ConditionFalse,
+	}})
+	return kr
 }

--- a/pkg/apis/broker/v1beta1/trigger_types_test.go
+++ b/pkg/apis/broker/v1beta1/trigger_types_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	eventingv1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
 )
 
 func TestTrigger_GetGroupVersionKind(t *testing.T) {
@@ -33,5 +34,15 @@ func TestTrigger_GetGroupVersionKind(t *testing.T) {
 	got := trig.GetGroupVersionKind()
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("(GetGroupVersionKind (-want +got): %v", diff)
+	}
+}
+
+func TestTrigger_GetUntypedSpec(t *testing.T) {
+	b := Trigger{
+		Spec: eventingv1beta1.TriggerSpec{},
+	}
+	s := b.GetUntypedSpec()
+	if _, ok := s.(eventingv1beta1.TriggerSpec); !ok {
+		t.Errorf("untyped spec was not a TriggerSpec")
 	}
 }


### PR DESCRIPTION
Fixes #885.

Now the only type code that's not covered should be generated code (deepcopy) and code that can't actually be hit (default cases on unrecognized types)

## Proposed Changes

- Improve coverage of API types for Broker and Trigger
