### PR TITLE
Send events to retry queue on initial delivery failure

### DIFF
--- a/pkg/broker/handler/pool/fanout/pool_test.go
+++ b/pkg/broker/handler/pool/fanout/pool_test.go
@@ -327,3 +327,5 @@ func assertHandlers(t *testing.T, p *SyncPool, targets config.Targets) {
 		t.Errorf("handlers map (-want,+got): %v", diff)
 	}
 }
+
+// TODO(yolocs): refactor helper functions.

--- a/pkg/broker/handler/processors/deliver/processor_test.go
+++ b/pkg/broker/handler/processors/deliver/processor_test.go
@@ -23,12 +23,17 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/pstest"
 	cev2 "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/cloudevents/sdk-go/v2/protocol"
 	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
+	cepubsub "github.com/cloudevents/sdk-go/v2/protocol/pubsub"
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
 
 	"github.com/google/knative-gcp/pkg/broker/config"
 	"github.com/google/knative-gcp/pkg/broker/config/memory"
@@ -135,7 +140,7 @@ func TestDeliverSuccess(t *testing.T) {
 	}
 }
 
-func TestDeliverFailure(t *testing.T) {
+func TestDeliverFailureNoRetry(t *testing.T) {
 	targetClient, err := cehttp.New()
 	if err != nil {
 		t.Fatalf("failed to create target cloudevents client: %v", err)
@@ -192,4 +197,191 @@ func TestDeliverFailure(t *testing.T) {
 	if err := p.Process(ctx, &origin); err == nil {
 		t.Error("expected error from processing")
 	}
+}
+
+func TestDeliverFailureRetrySuccess(t *testing.T) {
+	ctx := context.Background()
+	targetClient, err := cehttp.New()
+	if err != nil {
+		t.Fatalf("failed to create target cloudevents client: %v", err)
+	}
+	requester, err := cev2.NewDefaultClient()
+	if err != nil {
+		t.Fatalf("failed to create requester cloudevents client: %v", err)
+	}
+	targetSvr := httptest.NewServer(targetClient)
+	defer targetSvr.Close()
+
+	srv, c, close := testPubsubClient(ctx, t, "test-project")
+	defer close()
+	if _, err := c.CreateTopic(ctx, "test-retry-topic"); err != nil {
+		t.Fatalf("failed to create test pubsub topc: %v", err)
+	}
+	ps, err := cepubsub.New(ctx, cepubsub.WithClient(c), cepubsub.WithProjectID("test-project"))
+	if err != nil {
+		t.Fatalf("failed to create pubsub protocol: %v", err)
+	}
+
+	broker := &config.Broker{Namespace: "ns", Name: "broker"}
+	target := &config.Target{
+		Namespace: "ns",
+		Name:      "target",
+		Broker:    "broker",
+		Address:   targetSvr.URL,
+		RetryQueue: &config.Queue{
+			Topic: "test-retry-topic",
+		},
+	}
+	testTargets := memory.NewEmptyTargets()
+	testTargets.MutateBroker("ns", "broker", func(bm config.BrokerMutation) {
+		bm.UpsertTargets(target)
+	})
+	ctx = handlerctx.WithBrokerKey(ctx, broker.Key())
+	ctx = handlerctx.WithTargetKey(ctx, target.Key())
+
+	p := &Processor{
+		Requester:      requester,
+		Targets:        testTargets,
+		RetryOnFailure: true,
+		RetryEvents:    ps,
+	}
+
+	origin := event.New()
+	origin.SetID("id")
+	origin.SetSource("source")
+	origin.SetSubject("subject")
+	origin.SetType("type")
+	origin.SetTime(time.Now())
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		msg, resp, err := targetClient.Respond(ctx)
+		if err != nil {
+			t.Errorf("unexpected error from target receiving event: %v", err)
+		}
+		// Due to https://github.com/cloudevents/sdk-go/issues/433
+		// it's not possible to use Receive to easily return error.
+		if err := resp(ctx, nil, &cehttp.Result{StatusCode: http.StatusInternalServerError}); err != nil {
+			t.Errorf("unexpected error from target responding event: %v", err)
+		}
+		defer msg.Finish(nil)
+	}()
+
+	if err := p.Process(ctx, &origin); err != nil {
+		t.Errorf("unexpected error from processing: %v", err)
+	}
+
+	// Verify pubsub message published.
+	if len(srv.Messages()) != 1 {
+		t.Errorf("pubsub messages published count got=%d, want=1", len(srv.Messages()))
+	}
+	ceMsg := cepubsub.NewMessage(toFakePubsubMessage(srv.Messages()[0]))
+	gotEvent, err := binding.ToEvent(ctx, ceMsg)
+	if err != nil {
+		t.Errorf("retry message sent couldn't be decode as a cloudevent: %v", err)
+	}
+	// Force the time to be the same so that we can compare easier.
+	gotEvent.SetTime(origin.Time())
+	if diff := cmp.Diff(&origin, gotEvent); diff != "" {
+		t.Errorf("retry message as event (-want,+got): %v", diff)
+	}
+}
+
+func TestDeliverFailureRetryFailure(t *testing.T) {
+	ctx := context.Background()
+	targetClient, err := cehttp.New()
+	if err != nil {
+		t.Fatalf("failed to create target cloudevents client: %v", err)
+	}
+	requester, err := cev2.NewDefaultClient()
+	if err != nil {
+		t.Fatalf("failed to create requester cloudevents client: %v", err)
+	}
+	targetSvr := httptest.NewServer(targetClient)
+	defer targetSvr.Close()
+
+	_, c, close := testPubsubClient(ctx, t, "test-project")
+	defer close()
+	// Don't create the retry topic to make it fail.
+	ps, err := cepubsub.New(ctx, cepubsub.WithClient(c), cepubsub.WithProjectID("test-project"))
+	if err != nil {
+		t.Fatalf("failed to create pubsub protocol: %v", err)
+	}
+
+	broker := &config.Broker{Namespace: "ns", Name: "broker"}
+	target := &config.Target{
+		Namespace: "ns",
+		Name:      "target",
+		Broker:    "broker",
+		Address:   targetSvr.URL,
+		RetryQueue: &config.Queue{
+			Topic: "test-retry-topic",
+		},
+	}
+	testTargets := memory.NewEmptyTargets()
+	testTargets.MutateBroker("ns", "broker", func(bm config.BrokerMutation) {
+		bm.UpsertTargets(target)
+	})
+	ctx = handlerctx.WithBrokerKey(ctx, broker.Key())
+	ctx = handlerctx.WithTargetKey(ctx, target.Key())
+
+	p := &Processor{
+		Requester:      requester,
+		Targets:        testTargets,
+		RetryOnFailure: true,
+		RetryEvents:    ps,
+	}
+
+	origin := event.New()
+	origin.SetID("id")
+	origin.SetSource("source")
+	origin.SetSubject("subject")
+	origin.SetType("type")
+	origin.SetTime(time.Now())
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		msg, resp, err := targetClient.Respond(ctx)
+		if err != nil {
+			t.Errorf("unexpected error from target receiving event: %v", err)
+		}
+		// Due to https://github.com/cloudevents/sdk-go/issues/433
+		// it's not possible to use Receive to easily return error.
+		if err := resp(ctx, nil, &cehttp.Result{StatusCode: http.StatusInternalServerError}); err != nil {
+			t.Errorf("unexpected error from target responding event: %v", err)
+		}
+		defer msg.Finish(nil)
+	}()
+
+	if err := p.Process(ctx, &origin); err == nil {
+		t.Error("expected error from processing")
+	}
+}
+
+func toFakePubsubMessage(m *pstest.Message) *pubsub.Message {
+	return &pubsub.Message{
+		ID:         m.ID,
+		Attributes: m.Attributes,
+		Data:       m.Data,
+	}
+}
+
+func testPubsubClient(ctx context.Context, t *testing.T, projectID string) (*pstest.Server, *pubsub.Client, func()) {
+	t.Helper()
+	srv := pstest.NewServer()
+	conn, err := grpc.Dial(srv.Addr, grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("failed to dial test pubsub connection: %v", err)
+	}
+	close := func() {
+		srv.Close()
+		conn.Close()
+	}
+	c, err := pubsub.NewClient(ctx, projectID, option.WithGRPCConn(conn))
+	if err != nil {
+		t.Fatalf("failed to create test pubsub client: %v", err)
+	}
+	return srv, c, close
 }


### PR DESCRIPTION
Fixes https://github.com/google/knative-gcp/issues/834

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Modify deliver processor to also support retry

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Broker: send events to retry queue on initial delivery failure
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
