### PR TITLE
Properly handle io.EOF from receiver

### DIFF
--- a/pkg/broker/handler/handler.go
+++ b/pkg/broker/handler/handler.go
@@ -18,6 +18,7 @@ package handler
 
 import (
 	"context"
+	"io"
 	"time"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
@@ -77,7 +78,11 @@ func (h *Handler) handle(ctx context.Context) {
 		// TODO(yolocs): we need to update dep for fix:
 		// https://github.com/cloudevents/sdk-go/pull/430
 		msg, err := h.PubsubEvents.Receive(ctx)
-		if err != nil {
+		// It doesn't seem like that these errors will even happen.
+		if err == io.EOF {
+			logging.FromContext(ctx).Warn("handler goroutine no longer receiving messages from Pubsub")
+			break
+		} else if err != nil {
 			logging.FromContext(ctx).Error("failed to receive the next message from Pubsub", zap.Error(err))
 			continue
 		}


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- When the internal incoming message channel in the pubsub protocol is closed, it will return io.EOF. In which case we need to exit the handler goroutine. But the channel doesn't get closed anywhere in the pubsub protocol. So in reality, not sure if it will ever happen.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Properly handle cloudevents io.EOF in broker handler.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
