### PR TITLE
[WIP] Add Targets Config Map Reconciler

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1816,7 +1816,6 @@
     "github.com/cloudevents/sdk-go/v2/protocol/http",
     "github.com/cloudevents/sdk-go/v2/protocol/pubsub",
     "github.com/fsnotify/fsnotify",
-    "github.com/gogo/protobuf/proto",
     "github.com/golang/protobuf/jsonpb",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/ptypes",

--- a/pkg/reconciler/broker/targets.go
+++ b/pkg/reconciler/broker/targets.go
@@ -1,0 +1,205 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/knative-gcp/pkg/broker/config"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/typed/core/v1"
+	"knative.dev/eventing/pkg/logging"
+)
+
+const (
+	targetsCMKey          = "targets"
+	targetsFileName       = "targets.txt"
+	targetsCMResyncPeriod = 10 * time.Second
+)
+
+type BrokerConfigUpdater interface {
+	UpdateBrokerConfig(context.Context, *config.Broker) error
+}
+
+type updateReq struct {
+	broker  *config.Broker
+	replyCh chan error
+}
+
+type targetsReconciler struct {
+	targetsName, targetsNS string
+	targets                *config.TargetsConfig
+	updateCh               chan updateReq
+	configMaps             v1.ConfigMapInterface
+	logger                 *zap.Logger
+}
+
+func NewTargetsReconciler(ctx context.Context, client kubernetes.Interface, targetsNS, targetsName string) BrokerConfigUpdater {
+	r := &targetsReconciler{
+		targetsName: targetsName,
+		targetsNS:   targetsNS,
+		updateCh:    make(chan updateReq),
+		configMaps:  client.CoreV1().ConfigMaps(targetsNS),
+		logger:      logging.FromContext(ctx),
+	}
+	if err := r.loadTargetsConfig(ctx); err != nil {
+		r.logger.Error("error loading targets config", zap.Error(err))
+		r.targets = new(config.TargetsConfig)
+	}
+	go r.reconcile(ctx)
+	return r
+}
+
+func (r *targetsReconciler) UpdateBrokerConfig(ctx context.Context, b *config.Broker) error {
+	if b.Name == "" || b.Namespace == "" {
+		return fmt.Errorf("broker missing namespace or name: %s", prototext.MarshalOptions{}.Format(b))
+	}
+
+	req := updateReq{
+		broker:  b,
+		replyCh: make(chan error, 1),
+	}
+	select {
+	case r.updateCh <- req:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	select {
+	case err := <-req.replyCh:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// loadTargetsConfig retrieves the targets ConfigMap and populates r.targets.
+func (r *targetsReconciler) loadTargetsConfig(ctx context.Context) error {
+	logger := r.logger.With(zap.String("targetsName", r.targetsName), zap.String("targetsNS", r.targetsNS))
+	logger.Debug("Loading targets config from configmap")
+	targetsConfigMap, err := r.configMaps.Get(r.targetsName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			r.targets = &config.TargetsConfig{
+				Brokers: make(map[string]*config.Broker),
+			}
+			return nil
+		}
+		return fmt.Errorf("error getting targets ConfigMap: %w", err)
+	}
+
+	targets := new(config.TargetsConfig)
+	if err := proto.Unmarshal(targetsConfigMap.BinaryData[targetsCMKey], targets); err != nil {
+		return err
+	}
+	r.logger.Debug("Loaded targets config from ConfigMap",
+		zap.String("resourceVersion", targetsConfigMap.ResourceVersion))
+
+	r.targets = targets
+	return nil
+}
+
+func (r *targetsReconciler) reconcile(ctx context.Context) {
+	var writing, waiting []chan<- error
+	var writeCh <-chan error
+	var lastErr error
+	for {
+		var resync <-chan time.Time
+		var resyncTimer *time.Timer
+		if writeCh == nil {
+			resyncTimer = time.NewTimer(targetsCMResyncPeriod)
+			resync = resyncTimer.C
+		}
+
+		select {
+		case req := <-r.updateCh:
+			k := config.BrokerKey(req.broker.Namespace, req.broker.Name)
+			if proto.Equal(req.broker, r.targets.Brokers[k]) {
+				if waiting != nil {
+					waiting = append(waiting, req.replyCh)
+					break
+				}
+				if writeCh != nil {
+					writing = append(writing, req.replyCh)
+					break
+				}
+				if lastErr == nil {
+					req.replyCh <- nil
+					break
+				}
+			}
+			r.targets.GetBrokers()[k] = req.broker
+			if writeCh != nil {
+				waiting = append(waiting, req.replyCh)
+				break
+			}
+			writeCh = r.startWrite()
+			writing = append(writing, req.replyCh)
+
+		case lastErr = <-writeCh:
+			writeCh = nil
+			for _, ch := range writing {
+				ch <- lastErr
+			}
+			writing, waiting = waiting, nil
+			if writing == nil {
+				break
+			}
+			writeCh = r.startWrite()
+
+		case <-resync:
+			writeCh = r.startWrite()
+
+		case <-ctx.Done():
+			r.logger.Info("targets reconciler stopped", zap.Error(ctx.Err()))
+			if resyncTimer != nil {
+				resyncTimer.Stop()
+			}
+			return
+		}
+
+		if resyncTimer != nil {
+			resyncTimer.Stop()
+		}
+	}
+}
+
+func (r *targetsReconciler) startWrite() <-chan error {
+	writeCh := make(chan error, 1)
+	go r.writeTargets(writeCh, proto.Clone(r.targets).(*config.TargetsConfig))
+	return writeCh
+}
+
+func (r *targetsReconciler) writeTargets(replyCh chan<- error, targets *config.TargetsConfig) (err error) {
+	defer func() {
+		replyCh <- err
+	}()
+
+	r.logger.Debug("writing targets config", zap.Any("targetsConfig", targets))
+
+	targetsData, err := proto.Marshal(targets)
+	if err != nil {
+		return
+	}
+	targetsText := prototext.Format(targets)
+
+	targetsConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      r.targetsName,
+			Namespace: r.targetsNS,
+		},
+		BinaryData: map[string][]byte{targetsCMKey: targetsData},
+		// Write out the text version for debugging purposes only
+		Data: map[string]string{targetsFileName: targetsText},
+	}
+	_, err = r.configMaps.Update(targetsConfigMap)
+	if errors.IsNotFound(err) {
+		_, err = r.configMaps.Create(targetsConfigMap)
+	}
+	return
+}

--- a/pkg/reconciler/testing/configmap.go
+++ b/pkg/reconciler/testing/configmap.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 Google LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ConfigMapOption func(*corev1.ConfigMap)
+
+func NewConfigMap(name, namespace string, opts ...ConfigMapOption) *corev1.ConfigMap {
+	c := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+func WithData(data map[string]string) ConfigMapOption {
+	return func(c *corev1.ConfigMap) {
+		c.Data = data
+	}
+}
+
+func WithBinaryData(data map[string][]uint8) ConfigMapOption {
+	return func(c *corev1.ConfigMap) {
+		c.BinaryData = data
+	}
+}


### PR DESCRIPTION
Closes #830

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add a targets configmap reconciler which is responsible for writing broker config changes to the targets configmap. 
- Create a simple BrokerConfigUpdater through which the broker reconciler can communicate with the targets reconciler.
