### PR TITLE
Use pstest to Test Broker Ingress

### DIFF
--- a/pkg/broker/ingress/handler_test.go
+++ b/pkg/broker/ingress/handler_test.go
@@ -136,17 +136,15 @@ func TestHandler(t *testing.T) {
 	}
 
 	client := nethttp.Client{}
-	t.Cleanup(client.CloseIdleConnections)
+	defer client.CloseIdleConnections()
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := logging.WithLogger(context.Background(), logtest.TestLogger(t))
 			ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
-			t.Cleanup(cancel)
+			defer cancel()
 
 			psSrv := pstest.NewServer()
-			t.Cleanup(func() {
-				psSrv.Close()
-			})
+			defer psSrv.Close()
 
 			url := createAndStartIngress(ctx, t, psSrv)
 			rec := setupTestReceiver(ctx, t, psSrv)

--- a/pkg/broker/ingress/handler_test.go
+++ b/pkg/broker/ingress/handler_test.go
@@ -227,12 +227,12 @@ func setupTestReceiver(ctx context.Context, t *testing.T, psSrv *pstest.Server) 
 // createAndStartIngress creates an ingress and calls its Start() method in a goroutine.
 func createAndStartIngress(ctx context.Context, t *testing.T, psSrv *pstest.Server) (string, func()) {
 	p, cancel := createPubsubClient(ctx, t, psSrv)
-	decouple, err1 := NewMultiTopicDecoupleSink(ctx,
+	decouple, err := NewMultiTopicDecoupleSink(ctx,
 		WithBrokerConfig(memory.NewTargets(brokerConfig)),
 		WithPubsubClient(p))
-	if err1 != nil {
+	if err != nil {
 		cancel()
-		t.Fatalf("Failed to create decouple sink: %v", err1)
+		t.Fatalf("Failed to create decouple sink: %v", err)
 	}
 
 	receiver := &testHttpMessageReceiver{urlCh: make(chan string)}

--- a/pkg/broker/ingress/handler_test.go
+++ b/pkg/broker/ingress/handler_test.go
@@ -158,7 +158,7 @@ func TestHandler(t *testing.T) {
 func createAndStartIngress(t *testing.T) (h *handler, url string, cleanup func()) {
 	decouple, err1 := NewMultiTopicDecoupleSink(context.Background(),
 		WithBrokerConfig(memory.NewTargets(brokerConfig)),
-		WithPubsubClient(newFakePubsubClient(t)))
+		WithClient(newFakePubsubClient(t)))
 	if err1 != nil {
 		t.Fatalf("Failed to create decouple sink: %v", err1)
 	}

--- a/pkg/broker/ingress/multi_topic_decouple_sink.go
+++ b/pkg/broker/ingress/multi_topic_decouple_sink.go
@@ -37,7 +37,8 @@ import (
 const projectEnvKey = "PROJECT_ID"
 
 // NewMultiTopicDecoupleSink creates a new multiTopicDecoupleSink.
-func NewMultiTopicDecoupleSink(ctx context.Context, options ...MultiTopicDecoupleSinkOption) (sink *multiTopicDecoupleSink, err error) {
+func NewMultiTopicDecoupleSink(ctx context.Context, options ...MultiTopicDecoupleSinkOption) (*multiTopicDecoupleSink, error) {
+	var err error
 	opts := new(multiTopicDecoupleSinkOptions)
 	for _, opt := range options {
 		opt(opts)
@@ -48,14 +49,14 @@ func NewMultiTopicDecoupleSink(ctx context.Context, options ...MultiTopicDecoupl
 		if opts.pubsub == nil {
 			var projectID string
 			if projectID, err = utils.ProjectID(os.Getenv(projectEnvKey)); err != nil {
-				return
+				return nil, err
 			}
 			if opts.pubsub, err = pubsub.NewClient(ctx, projectID); err != nil {
-				return
+				return nil, err
 			}
 		}
 		if opts.client, err = newPubSubClient(ctx, opts.pubsub); err != nil {
-			return
+			return nil, err
 		}
 	}
 
@@ -65,12 +66,12 @@ func NewMultiTopicDecoupleSink(ctx context.Context, options ...MultiTopicDecoupl
 		}
 	}
 
-	sink = &multiTopicDecoupleSink{
+	sink := &multiTopicDecoupleSink{
 		logger:       logging.FromContext(ctx),
 		client:       opts.client,
 		brokerConfig: opts.brokerConfig,
 	}
-	return
+	return sink, nil
 }
 
 // multiTopicDecoupleSink implements DecoupleSink and routes events to pubsub topics corresponding

--- a/pkg/broker/ingress/multi_topic_decouple_sink_test.go
+++ b/pkg/broker/ingress/multi_topic_decouple_sink_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/knative-gcp/pkg/broker/config"
 	"github.com/google/knative-gcp/pkg/broker/config/memory"
+	"knative.dev/pkg/logging"
+	logtest "knative.dev/pkg/logging/testing"
 )
 
 func TestMultiTopicDecoupleSink(t *testing.T) {
@@ -149,10 +151,11 @@ func TestMultiTopicDecoupleSink(t *testing.T) {
 			fakeClient := newFakePubsubClient(t)
 			brokerConfig := memory.NewTargets(tt.brokerConfig)
 			for _, testCase := range tt.cases {
+				ctx := logging.WithLogger(context.Background(), logtest.TestLogger(t))
 				if testCase.clientErrFn != nil {
 					testCase.clientErrFn(fakeClient)
 				}
-				sink, err := NewMultiTopicDecoupleSink(context.Background(), WithBrokerConfig(brokerConfig), WithClient(fakeClient))
+				sink, err := NewMultiTopicDecoupleSink(ctx, WithBrokerConfig(brokerConfig), WithClient(fakeClient))
 				if err != nil {
 					t.Fatalf("Failed to create decouple sink: %v", err)
 				}

--- a/pkg/broker/ingress/multi_topic_decouple_sink_test.go
+++ b/pkg/broker/ingress/multi_topic_decouple_sink_test.go
@@ -152,7 +152,7 @@ func TestMultiTopicDecoupleSink(t *testing.T) {
 				if testCase.clientErrFn != nil {
 					testCase.clientErrFn(fakeClient)
 				}
-				sink, err := NewMultiTopicDecoupleSink(context.Background(), WithBrokerConfig(brokerConfig), WithPubsubClient(fakeClient))
+				sink, err := NewMultiTopicDecoupleSink(context.Background(), WithBrokerConfig(brokerConfig), WithClient(fakeClient))
 				if err != nil {
 					t.Fatalf("Failed to create decouple sink: %v", err)
 				}

--- a/pkg/broker/ingress/options.go
+++ b/pkg/broker/ingress/options.go
@@ -18,8 +18,8 @@ package ingress
 
 import (
 	"context"
-	"fmt"
 
+	"cloud.google.com/go/pubsub"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/knative-gcp/pkg/broker/config"
 	"knative.dev/eventing/pkg/kncloudevents"
@@ -40,28 +40,41 @@ func WithPort(port int) HandlerOption {
 func WithProjectID(id string) HandlerOption {
 	return func(h *handler) error {
 		ctx := context.Background()
-		client, err := newPubSubClient(ctx, id)
+		p, err := pubsub.NewClient(ctx, id)
 		if err != nil {
-			return fmt.Errorf("failed to create pubsub client: %v", err)
+			return err
 		}
-		h.decouple, err = NewMultiTopicDecoupleSink(context.Background(), WithPubsubClient(client))
+		h.decouple, err = NewMultiTopicDecoupleSink(context.Background(), WithPubsubClient(p))
 		return err
 	}
 }
 
 // MultiTopicDecoupleSinkOption is the option to configure multiTopicDecoupleSink.
-type MultiTopicDecoupleSinkOption func(sink *multiTopicDecoupleSink)
+type MultiTopicDecoupleSinkOption func(sink *multiTopicDecoupleSinkOptions)
+
+type multiTopicDecoupleSinkOptions struct {
+	client       cloudevents.Client
+	pubsub       *pubsub.Client
+	brokerConfig config.ReadonlyTargets
+}
+
+// WithClient specifies an eventing client to use.
+func WithClient(client cloudevents.Client) MultiTopicDecoupleSinkOption {
+	return func(opts *multiTopicDecoupleSinkOptions) {
+		opts.client = client
+	}
+}
 
 // WithPubsubClient specifies the pubsub client to use.
-func WithPubsubClient(client cloudevents.Client) MultiTopicDecoupleSinkOption {
-	return func(sink *multiTopicDecoupleSink) {
-		sink.client = client
+func WithPubsubClient(client *pubsub.Client) MultiTopicDecoupleSinkOption {
+	return func(opts *multiTopicDecoupleSinkOptions) {
+		opts.pubsub = client
 	}
 }
 
 // WithBrokerConfig specifies the broker config. It can be created by reading a configmap mount.
 func WithBrokerConfig(brokerConfig config.ReadonlyTargets) MultiTopicDecoupleSinkOption {
-	return func(sink *multiTopicDecoupleSink) {
-		sink.brokerConfig = brokerConfig
+	return func(opts *multiTopicDecoupleSinkOptions) {
+		opts.brokerConfig = brokerConfig
 	}
 }

--- a/pkg/broker/ingress/options.go
+++ b/pkg/broker/ingress/options.go
@@ -66,9 +66,9 @@ func WithClient(client cloudevents.Client) MultiTopicDecoupleSinkOption {
 }
 
 // WithPubsubClient specifies the pubsub client to use.
-func WithPubsubClient(client *pubsub.Client) MultiTopicDecoupleSinkOption {
+func WithPubsubClient(ps *pubsub.Client) MultiTopicDecoupleSinkOption {
 	return func(opts *multiTopicDecoupleSinkOptions) {
-		opts.pubsub = client
+		opts.pubsub = ps
 	}
 }
 


### PR DESCRIPTION
This allows the handler test to effectively function as an integration test connecting over GRPC to the test pubsub server.

Fixes #786
See #781