### PR TITLE
Allow unit tests to run locally

### DIFF
--- a/pkg/broker/config/memory/memory_test.go
+++ b/pkg/broker/config/memory/memory_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package memory
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/google/knative-gcp/pkg/broker/config"
@@ -186,46 +184,4 @@ func assertBroker(t *testing.T, want *config.Broker, namespace, name string, tar
 	if !proto.Equal(want, got) {
 		t.Errorf("GetBroker got broker=%+v, want=%+v", got, want)
 	}
-}
-
-func ExampleMutateBroker() {
-	val := &config.TargetsConfig{}
-	targets := NewTargets(val)
-
-	// Create a new broker with targets.
-	targets.MutateBroker("ns", "broker", func(m config.BrokerMutation) {
-		m.SetID("b-uid").SetAddress("broker.example.com").SetState(config.State_READY)
-		m.SetDecoupleQueue(&config.Queue{
-			Topic:        "topic",
-			Subscription: "sub",
-		})
-		m.UpsertTargets(&config.Target{
-			Id:      "uid-1",
-			Address: "consumer1.example.com",
-			Broker:  "broker",
-			FilterAttributes: map[string]string{
-				"app": "foo",
-			},
-			Name:      "t1",
-			Namespace: "ns",
-			RetryQueue: &config.Queue{
-				Topic:        "topic1",
-				Subscription: "sub1",
-			},
-		})
-	})
-
-	fmt.Println(strings.Trim(targets.String(), " "))
-
-	// Delete the broker.
-	targets.MutateBroker("ns", "broker", func(m config.BrokerMutation) {
-		m.Delete()
-	})
-	if _, ok := targets.GetBroker("ns", "broker"); !ok {
-		fmt.Println("Broker deleted.")
-	}
-
-	// Output:
-	// brokers:{key:"ns/broker" value:{id:"b-uid" name:"broker" namespace:"ns" address:"broker.example.com" decouple_queue:{topic:"topic" subscription:"sub"} targets:{key:"t1" value:{id:"uid-1" name:"t1" namespace:"ns" broker:"broker" address:"consumer1.example.com" filter_attributes:{key:"app" value:"foo"} retry_queue:{topic:"topic1" subscription:"sub1"}}} state:READY}}
-	// Broker deleted.
 }

--- a/pkg/reconciler/events/auditlogs/controller.go
+++ b/pkg/reconciler/events/auditlogs/controller.go
@@ -57,7 +57,17 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
+	return newControllerWithIAMPolicyManager(
+		ctx,
+		cmw,
+		iam.DefaultIAMPolicyManager())
+}
 
+func newControllerWithIAMPolicyManager(
+	ctx context.Context,
+	cmw configmap.Watcher,
+	ipm iam.IAMPolicyManager,
+) *controller.Impl {
 	pullsubscriptionInformer := pullsubscriptioninformers.Get(ctx)
 	topicInformer := topicinformers.Get(ctx)
 	cloudauditlogssourceInformer := cloudauditlogssourceinformers.Get(ctx)
@@ -65,7 +75,7 @@ func NewController(
 
 	r := &Reconciler{
 		PubSubBase:             pubsub.NewPubSubBaseWithAdapter(ctx, controllerAgentName, receiveAdapterName, converters.CloudAuditLogsConverter, cmw),
-		Identity:               identity.NewIdentity(ctx, iam.DefaultIAMPolicyManager()),
+		Identity:               identity.NewIdentity(ctx, ipm),
 		auditLogsSourceLister:  cloudauditlogssourceInformer.Lister(),
 		logadminClientProvider: glogadmin.NewClient,
 		pubsubClientProvider:   gpubsub.NewClient,

--- a/pkg/reconciler/events/auditlogs/controller_test.go
+++ b/pkg/reconciler/events/auditlogs/controller_test.go
@@ -19,6 +19,7 @@ package auditlogs
 import (
 	"testing"
 
+	iamtesting "github.com/google/knative-gcp/pkg/reconciler/testing"
 	"knative.dev/pkg/configmap"
 	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
@@ -37,9 +38,9 @@ func TestNew(t *testing.T) {
 	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
-	c := NewController(ctx, configmap.NewStaticWatcher())
+	c := newControllerWithIAMPolicyManager(ctx, configmap.NewStaticWatcher(), iamtesting.NoopIAMPolicyManager)
 
 	if c == nil {
-		t.Fatal("Expected NewController to return a non-nil value")
+		t.Fatal("Expected newControllerWithIAMPolicyManager to return a non-nil value")
 	}
 }

--- a/pkg/reconciler/events/build/controller.go
+++ b/pkg/reconciler/events/build/controller.go
@@ -50,14 +50,24 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
+	return newControllerWithIAMPolicyManager(
+		ctx,
+		cmw,
+		iam.DefaultIAMPolicyManager())
+}
 
+func newControllerWithIAMPolicyManager(
+	ctx context.Context,
+	cmw configmap.Watcher,
+	ipm iam.IAMPolicyManager,
+) *controller.Impl {
 	pullsubscriptionInformer := pullsubscriptioninformers.Get(ctx)
 	cloudbuildsourceInformer := cloudbuildsourceinformers.Get(ctx)
 	serviceAccountInformer := serviceaccountinformers.Get(ctx)
 
 	r := &Reconciler{
 		PubSubBase:             pubsub.NewPubSubBaseWithAdapter(ctx, controllerAgentName, receiveAdapterName, converters.CloudBuildConverter, cmw),
-		Identity:               identity.NewIdentity(ctx, iam.DefaultIAMPolicyManager()),
+		Identity:               identity.NewIdentity(ctx, ipm),
 		buildLister:            cloudbuildsourceInformer.Lister(),
 		serviceAccountLister:   serviceAccountInformer.Lister(),
 		pullsubscriptionLister: pullsubscriptionInformer.Lister(),

--- a/pkg/reconciler/events/build/controller_test.go
+++ b/pkg/reconciler/events/build/controller_test.go
@@ -19,6 +19,7 @@ package build
 import (
 	"testing"
 
+	iamtesting "github.com/google/knative-gcp/pkg/reconciler/testing"
 	"knative.dev/pkg/configmap"
 	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
@@ -37,9 +38,9 @@ func TestNew(t *testing.T) {
 	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
-	c := NewController(ctx, configmap.NewStaticWatcher())
+	c := newControllerWithIAMPolicyManager(ctx, configmap.NewStaticWatcher(), iamtesting.NoopIAMPolicyManager)
 
 	if c == nil {
-		t.Fatal("Expected NewController to return a non-nil value")
+		t.Fatal("Expected newControllerWithIAMPolicyManager to return a non-nil value")
 	}
 }

--- a/pkg/reconciler/events/pubsub/controller.go
+++ b/pkg/reconciler/events/pubsub/controller.go
@@ -52,14 +52,24 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
+	return newControllerWithIAMPolicyManager(
+		ctx,
+		cmw,
+		iam.DefaultIAMPolicyManager())
+}
 
+func newControllerWithIAMPolicyManager(
+	ctx context.Context,
+	cmw configmap.Watcher,
+	ipm iam.IAMPolicyManager,
+) *controller.Impl {
 	pullsubscriptionInformer := pullsubscriptioninformers.Get(ctx)
 	cloudpubsubsourceInformer := cloudpubsubsourceinformers.Get(ctx)
 	serviceAccountInformer := serviceaccountinformers.Get(ctx)
 
 	r := &Reconciler{
 		PubSubBase:             pubsub.NewPubSubBase(ctx, controllerAgentName, receiveAdapterName, cmw),
-		Identity:               identity.NewIdentity(ctx, iam.DefaultIAMPolicyManager()),
+		Identity:               identity.NewIdentity(ctx, ipm),
 		pubsubLister:           cloudpubsubsourceInformer.Lister(),
 		pullsubscriptionLister: pullsubscriptionInformer.Lister(),
 		serviceAccountLister:   serviceAccountInformer.Lister(),

--- a/pkg/reconciler/events/pubsub/controller_test.go
+++ b/pkg/reconciler/events/pubsub/controller_test.go
@@ -19,6 +19,7 @@ package pubsub
 import (
 	"testing"
 
+	iamtesting "github.com/google/knative-gcp/pkg/reconciler/testing"
 	"knative.dev/pkg/configmap"
 	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
@@ -37,9 +38,9 @@ func TestNew(t *testing.T) {
 	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
-	c := NewController(ctx, configmap.NewStaticWatcher())
+	c := newControllerWithIAMPolicyManager(ctx, configmap.NewStaticWatcher(), iamtesting.NoopIAMPolicyManager)
 
 	if c == nil {
-		t.Fatal("Expected NewController to return a non-nil value")
+		t.Fatal("Expected newControllerWithIAMPolicyManager to return a non-nil value")
 	}
 }

--- a/pkg/reconciler/events/scheduler/controller.go
+++ b/pkg/reconciler/events/scheduler/controller.go
@@ -54,7 +54,17 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
+	return newControllerWithIAMPolicyManager(
+		ctx,
+		cmw,
+		iam.DefaultIAMPolicyManager())
+}
 
+func newControllerWithIAMPolicyManager(
+	ctx context.Context,
+	cmw configmap.Watcher,
+	ipm iam.IAMPolicyManager,
+) *controller.Impl {
 	pullsubscriptionInformer := pullsubscriptioninformers.Get(ctx)
 	topicInformer := topicinformers.Get(ctx)
 	cloudschedulersourceInformer := cloudschedulersourceinformers.Get(ctx)
@@ -62,7 +72,7 @@ func NewController(
 
 	c := &Reconciler{
 		PubSubBase:           pubsub.NewPubSubBase(ctx, controllerAgentName, receiveAdapterName, cmw),
-		Identity:             identity.NewIdentity(ctx, iam.DefaultIAMPolicyManager()),
+		Identity:             identity.NewIdentity(ctx, ipm),
 		schedulerLister:      cloudschedulersourceInformer.Lister(),
 		createClientFn:       gscheduler.NewClient,
 		serviceAccountLister: serviceAccountInformer.Lister(),

--- a/pkg/reconciler/events/scheduler/controller_test.go
+++ b/pkg/reconciler/events/scheduler/controller_test.go
@@ -19,6 +19,7 @@ package scheduler
 import (
 	"testing"
 
+	iamtesting "github.com/google/knative-gcp/pkg/reconciler/testing"
 	"knative.dev/pkg/configmap"
 	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
@@ -38,9 +39,9 @@ func TestNew(t *testing.T) {
 	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
-	c := NewController(ctx, configmap.NewStaticWatcher())
+	c := newControllerWithIAMPolicyManager(ctx, configmap.NewStaticWatcher(), iamtesting.NoopIAMPolicyManager)
 
 	if c == nil {
-		t.Fatal("Expected NewController to return a non-nil value")
+		t.Fatal("Expected newControllerWithIAMPolicyManager to return a non-nil value")
 	}
 }

--- a/pkg/reconciler/events/storage/controller.go
+++ b/pkg/reconciler/events/storage/controller.go
@@ -54,7 +54,17 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
+	return newControllerWithIAMPolicyManager(
+		ctx,
+		cmw,
+		iam.DefaultIAMPolicyManager())
+}
 
+func newControllerWithIAMPolicyManager(
+	ctx context.Context,
+	cmw configmap.Watcher,
+	ipm iam.IAMPolicyManager,
+) *controller.Impl {
 	pullsubscriptionInformer := pullsubscriptioninformers.Get(ctx)
 	topicInformer := topicinformers.Get(ctx)
 	cloudstoragesourceInformer := cloudstoragesourceinformers.Get(ctx)
@@ -62,7 +72,7 @@ func NewController(
 
 	r := &Reconciler{
 		PubSubBase:           pubsub.NewPubSubBase(ctx, controllerAgentName, receiveAdapterName, cmw),
-		Identity:             identity.NewIdentity(ctx, iam.DefaultIAMPolicyManager()),
+		Identity:             identity.NewIdentity(ctx, ipm),
 		storageLister:        cloudstoragesourceInformer.Lister(),
 		createClientFn:       gstorage.NewClient,
 		serviceAccountLister: serviceAccountInformer.Lister(),

--- a/pkg/reconciler/events/storage/controller_test.go
+++ b/pkg/reconciler/events/storage/controller_test.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"testing"
 
+	iamtesting "github.com/google/knative-gcp/pkg/reconciler/testing"
 	"knative.dev/pkg/configmap"
 	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
@@ -38,9 +39,9 @@ func TestNew(t *testing.T) {
 	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
-	c := NewController(ctx, configmap.NewStaticWatcher())
+	c := newControllerWithIAMPolicyManager(ctx, configmap.NewStaticWatcher(), iamtesting.NoopIAMPolicyManager)
 
 	if c == nil {
-		t.Fatal("Expected NewController to return a non-nil value")
+		t.Fatal("Expected newControllerWithIAMPolicyManager to return a non-nil value")
 	}
 }

--- a/pkg/reconciler/messaging/channel/controller.go
+++ b/pkg/reconciler/messaging/channel/controller.go
@@ -49,7 +49,17 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
+	return newControllerWithIAMPolicyManager(
+		ctx,
+		cmw,
+		iam.DefaultIAMPolicyManager())
+}
 
+func newControllerWithIAMPolicyManager(
+	ctx context.Context,
+	cmw configmap.Watcher,
+	ipm iam.IAMPolicyManager,
+) *controller.Impl {
 	channelInformer := channelinformer.Get(ctx)
 
 	topicInformer := topicinformer.Get(ctx)
@@ -58,7 +68,7 @@ func NewController(
 
 	r := &Reconciler{
 		Base:                   reconciler.NewBase(ctx, controllerAgentName, cmw),
-		Identity:               identity.NewIdentity(ctx, iam.DefaultIAMPolicyManager()),
+		Identity:               identity.NewIdentity(ctx, ipm),
 		channelLister:          channelInformer.Lister(),
 		topicLister:            topicInformer.Lister(),
 		pullSubscriptionLister: pullSubscriptionInformer.Lister(),

--- a/pkg/reconciler/messaging/channel/controller_test.go
+++ b/pkg/reconciler/messaging/channel/controller_test.go
@@ -39,6 +39,6 @@ func TestNew(t *testing.T) {
 	c := newControllerWithIAMPolicyManager(ctx, configmap.NewStaticWatcher(), iamtesting.NoopIAMPolicyManager)
 
 	if c == nil {
-		t.Fatal("Expected NewController to return a non-nil value")
+		t.Fatal("Expected newControllerWithIAMPolicyManager to return a non-nil value")
 	}
 }

--- a/pkg/reconciler/messaging/channel/controller_test.go
+++ b/pkg/reconciler/messaging/channel/controller_test.go
@@ -19,6 +19,7 @@ package channel
 import (
 	"testing"
 
+	iamtesting "github.com/google/knative-gcp/pkg/reconciler/testing"
 	"knative.dev/pkg/configmap"
 	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
@@ -35,7 +36,7 @@ func TestNew(t *testing.T) {
 	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
-	c := NewController(ctx, configmap.NewStaticWatcher())
+	c := newControllerWithIAMPolicyManager(ctx, configmap.NewStaticWatcher(), iamtesting.NoopIAMPolicyManager)
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")

--- a/pkg/reconciler/pubsub/pullsubscription/keda/controller.go
+++ b/pkg/reconciler/pubsub/pullsubscription/keda/controller.go
@@ -70,7 +70,17 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
+	return newControllerWithIAMPolicyManager(
+		ctx,
+		cmw,
+		iam.DefaultIAMPolicyManager())
+}
 
+func newControllerWithIAMPolicyManager(
+	ctx context.Context,
+	cmw configmap.Watcher,
+	ipm iam.IAMPolicyManager,
+) *controller.Impl {
 	deploymentInformer := deploymentinformer.Get(ctx)
 	pullSubscriptionInformer := pullsubscriptioninformers.Get(ctx)
 	serviceAccountInformer := serviceaccountinformers.Get(ctx)
@@ -89,7 +99,7 @@ func NewController(
 	r := &Reconciler{
 		Base: &psreconciler.Base{
 			PubSubBase:             pubsubBase,
-			Identity:               identity.NewIdentity(ctx, iam.DefaultIAMPolicyManager()),
+			Identity:               identity.NewIdentity(ctx, ipm),
 			DeploymentLister:       deploymentInformer.Lister(),
 			PullSubscriptionLister: pullSubscriptionInformer.Lister(),
 			ReceiveAdapterImage:    env.ReceiveAdapter,

--- a/pkg/reconciler/pubsub/pullsubscription/keda/controller_test.go
+++ b/pkg/reconciler/pubsub/pullsubscription/keda/controller_test.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"testing"
 
+	iamtesting "github.com/google/knative-gcp/pkg/reconciler/testing"
+
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/logging"
 	logtesting "knative.dev/pkg/logging/testing"
@@ -51,7 +53,7 @@ func TestNew(t *testing.T) {
 
 	_ = os.Setenv("PUBSUB_RA_IMAGE", "PUBSUB_RA_IMAGE")
 
-	c := NewController(ctx, configmap.NewStaticWatcher(
+	c := newControllerWithIAMPolicyManager(ctx, configmap.NewStaticWatcher(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      logging.ConfigMapName(),
@@ -73,7 +75,8 @@ func TestNew(t *testing.T) {
 			},
 			Data: map[string]string{},
 		},
-	))
+	),
+		iamtesting.NoopIAMPolicyManager)
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")

--- a/pkg/reconciler/pubsub/pullsubscription/keda/controller_test.go
+++ b/pkg/reconciler/pubsub/pullsubscription/keda/controller_test.go
@@ -79,6 +79,6 @@ func TestNew(t *testing.T) {
 		iamtesting.NoopIAMPolicyManager)
 
 	if c == nil {
-		t.Fatal("Expected NewController to return a non-nil value")
+		t.Fatal("Expected newControllerWithIAMPolicyManager to return a non-nil value")
 	}
 }

--- a/pkg/reconciler/pubsub/pullsubscription/static/controller.go
+++ b/pkg/reconciler/pubsub/pullsubscription/static/controller.go
@@ -66,7 +66,17 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
+	return newControllerWithIAMPolicyManager(
+		ctx,
+		cmw,
+		iam.DefaultIAMPolicyManager())
+}
 
+func newControllerWithIAMPolicyManager(
+	ctx context.Context,
+	cmw configmap.Watcher,
+	ipm iam.IAMPolicyManager,
+) *controller.Impl {
 	deploymentInformer := deploymentinformer.Get(ctx)
 	pullSubscriptionInformer := pullsubscriptioninformers.Get(ctx)
 	serviceAccountInformer := serviceaccountinformers.Get(ctx)
@@ -85,7 +95,7 @@ func NewController(
 	r := &Reconciler{
 		Base: &psreconciler.Base{
 			PubSubBase:             pubsubBase,
-			Identity:               identity.NewIdentity(ctx, iam.DefaultIAMPolicyManager()),
+			Identity:               identity.NewIdentity(ctx, ipm),
 			DeploymentLister:       deploymentInformer.Lister(),
 			PullSubscriptionLister: pullSubscriptionInformer.Lister(),
 			ReceiveAdapterImage:    env.ReceiveAdapter,

--- a/pkg/reconciler/pubsub/pullsubscription/static/controller_test.go
+++ b/pkg/reconciler/pubsub/pullsubscription/static/controller_test.go
@@ -74,6 +74,6 @@ func TestNew(t *testing.T) {
 		iamtesting.NoopIAMPolicyManager)
 
 	if c == nil {
-		t.Fatal("Expected NewController to return a non-nil value")
+		t.Fatal("Expected newControllerWithIAMPolicyManager to return a non-nil value")
 	}
 }

--- a/pkg/reconciler/pubsub/pullsubscription/static/controller_test.go
+++ b/pkg/reconciler/pubsub/pullsubscription/static/controller_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"testing"
 
+	iamtesting "github.com/google/knative-gcp/pkg/reconciler/testing"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/logging"
 	logtesting "knative.dev/pkg/logging/testing"
@@ -47,7 +48,7 @@ func TestNew(t *testing.T) {
 
 	_ = os.Setenv("PUBSUB_RA_IMAGE", "PUBSUB_RA_IMAGE")
 
-	c := NewController(ctx, configmap.NewStaticWatcher(
+	c := newControllerWithIAMPolicyManager(ctx, configmap.NewStaticWatcher(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      logging.ConfigMapName(),
@@ -69,7 +70,8 @@ func TestNew(t *testing.T) {
 			},
 			Data: map[string]string{},
 		},
-	))
+	),
+		iamtesting.NoopIAMPolicyManager)
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")

--- a/pkg/reconciler/pubsub/topic/controller.go
+++ b/pkg/reconciler/pubsub/topic/controller.go
@@ -60,6 +60,17 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
+	return newControllerWithIAMPolicyManager(
+		ctx,
+		cmw,
+		iam.DefaultIAMPolicyManager())
+}
+
+func newControllerWithIAMPolicyManager(
+	ctx context.Context,
+	cmw configmap.Watcher,
+	ipm iam.IAMPolicyManager,
+) *controller.Impl {
 	topicInformer := topicinformer.Get(ctx)
 	serviceInformer := serviceinformer.Get(ctx)
 	serviceAccountInformer := serviceaccountinformers.Get(ctx)
@@ -77,7 +88,7 @@ func NewController(
 
 	r := &Reconciler{
 		PubSubBase:     pubsubBase,
-		Identity:       identity.NewIdentity(ctx, iam.DefaultIAMPolicyManager()),
+		Identity:       identity.NewIdentity(ctx, ipm),
 		topicLister:    topicInformer.Lister(),
 		serviceLister:  serviceInformer.Lister(),
 		publisherImage: env.Publisher,

--- a/pkg/reconciler/pubsub/topic/controller_test.go
+++ b/pkg/reconciler/pubsub/topic/controller_test.go
@@ -58,6 +58,6 @@ func TestNew(t *testing.T) {
 		iamtesting.NoopIAMPolicyManager)
 
 	if c == nil {
-		t.Fatal("Expected NewController to return a non-nil value")
+		t.Fatal("Expected newControllerWithIAMPolicyManager to return a non-nil value")
 	}
 }

--- a/pkg/reconciler/pubsub/topic/controller_test.go
+++ b/pkg/reconciler/pubsub/topic/controller_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"testing"
 
+	iamtesting "github.com/google/knative-gcp/pkg/reconciler/testing"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/system"
@@ -44,15 +45,17 @@ func TestNew(t *testing.T) {
 
 	_ = os.Setenv("PUBSUB_PUBLISHER_IMAGE", "PUBSUB_PUBLISHER_IMAGE")
 
-	c := NewController(ctx, configmap.NewStaticWatcher(
-		&corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      tracingconfig.ConfigName,
-				Namespace: system.Namespace(),
-			},
-			Data: map[string]string{},
-		},
-	))
+	c := newControllerWithIAMPolicyManager(
+		ctx,
+		configmap.NewStaticWatcher(
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tracingconfig.ConfigName,
+					Namespace: system.Namespace(),
+				},
+				Data: map[string]string{},
+			}),
+		iamtesting.NoopIAMPolicyManager)
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")


### PR DESCRIPTION
## Proposed Changes

- Unit tests pass when run locally.
  - Use the `NoopIAMPolicyManager`.
  - Remove `ExampleMutateBroker`.
    - The output seemed to be non-deterministic. Seemingly swapping between one and two spaces between elements. In addition it depends on the protobuf's Format which says:

      ```
      // Do not depend on the output being stable. It may change over time across
      // different versions of the program.
      ```

Local unit tests had been failing with messages like:
```
go test ./pkg/reconciler/pubsub/pullsubscription/static
--- FAIL: TestNew (0.00s)
    logger.go:130: 2020-04-23T12:34:47.596-0700 DEBUG   cloud-run-events-pubsub-pullsubscription-controller     reconciler/reconciler.go:171    Creating stats reporter {"events.cloud.google.com/controller": "cloud-run-events-pubsub-pullsubscription-controller"}
panic: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information. [recovered]
        panic: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.

goroutine 14 [running]:
testing.tRunner.func1.1(0x26044a0, 0xc000536130)
        /usr/local/go/src/testing/testing.go:941 +0x3d0
testing.tRunner.func1(0xc0002bc120)
        /usr/local/go/src/testing/testing.go:944 +0x3f9
panic(0x26044a0, 0xc000536130)
        /usr/local/go/src/runtime/panic.go:967 +0x166
github.com/google/knative-gcp/pkg/reconciler/identity/iam.DefaultIAMPolicyManager.func1()
        /Users/harwayne/go/src/github.com/google/knative-gcp/pkg/reconciler/identity/iam/iam_policy.go:84 +0x111
sync.(*Once).doSlow(0x3e86238, 0x299bc98)
        /usr/local/go/src/sync/once.go:66 +0xec
sync.(*Once).Do(...)
        /usr/local/go/src/sync/once.go:57
github.com/google/knative-gcp/pkg/reconciler/identity/iam.DefaultIAMPolicyManager(0x2761de0, 0xc00099a640)
        /Users/harwayne/go/src/github.com/google/knative-gcp/pkg/reconciler/identity/iam/iam_policy.go:81 +0x65
github.com/google/knative-gcp/pkg/reconciler/pubsub/pullsubscription/static.NewController(0x2ceb880, 0xc0009a1110, 0x2cc0340, 0xc00001b278, 0x0)
        /Users/harwayne/go/src/github.com/google/knative-gcp/pkg/reconciler/pubsub/pullsubscription/static/controller.go:88 +0x43b
github.com/google/knative-gcp/pkg/reconciler/pubsub/pullsubscription/static.TestNew(0xc0002bc120)
        /Users/harwayne/go/src/github.com/google/knative-gcp/pkg/reconciler/pubsub/pullsubscription/static/controller_test.go:50 +0x390
testing.tRunner(0xc0002bc120, 0x299bcb8)
        /usr/local/go/src/testing/testing.go:992 +0xdc
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:1043 +0x357
FAIL    github.com/google/knative-gcp/pkg/reconciler/pubsub/pullsubscription/static     0.373s
FAIL
```

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```
