### PR TITLE
Reconcile handlers on decouple/retry subscription updates

### DIFF
--- a/pkg/broker/handler/handler.go
+++ b/pkg/broker/handler/handler.go
@@ -75,8 +75,6 @@ func (h *Handler) Stop() {
 
 func (h *Handler) handle(ctx context.Context) {
 	for {
-		// TODO(yolocs): we need to update dep for fix:
-		// https://github.com/cloudevents/sdk-go/pull/430
 		msg, err := h.PubsubEvents.Receive(ctx)
 		// It doesn't seem like that these errors will even happen.
 		if err == io.EOF {

--- a/pkg/broker/handler/handler_test.go
+++ b/pkg/broker/handler/handler_test.go
@@ -85,6 +85,9 @@ func TestHandler(t *testing.T) {
 	}
 	h.Start(ctx, func(err error) {})
 	defer h.Stop()
+	if !h.IsAlive() {
+		t.Error("start handler didn't bring it alive")
+	}
 
 	testEvent := event.New()
 	testEvent.SetID("id")

--- a/pkg/broker/handler/pool/fanout/pool.go
+++ b/pkg/broker/handler/pool/fanout/pool.go
@@ -60,6 +60,9 @@ type handlerCache struct {
 }
 
 func (hc *handlerCache) requiresRestart(b *config.Broker) bool {
+	if !hc.IsAlive() {
+		return true
+	}
 	if b == nil || b.DecoupleQueue == nil {
 		return true
 	}
@@ -179,8 +182,6 @@ func (p *SyncPool) SyncOnce(ctx context.Context) error {
 			} else {
 				logging.FromContext(ctx).Info("handler for broker has stopped", zap.String("broker", b.Key()))
 			}
-			// Make sure the handler is deleted from the pool.
-			p.pool.Delete(b.Key())
 		})
 
 		p.pool.Store(b.Key(), hc)

--- a/pkg/broker/handler/pool/fanout/pool.go
+++ b/pkg/broker/handler/pool/fanout/pool.go
@@ -177,6 +177,7 @@ func (p *SyncPool) SyncOnce(ctx context.Context) error {
 		}
 		// Start the handler with broker key in context.
 		hc.Start(handlerctx.WithBrokerKey(ctx, b.Key()), func(err error) {
+			// We will anyway get an error because of https://github.com/cloudevents/sdk-go/issues/470
 			if err != nil {
 				logging.FromContext(ctx).Error("handler for broker has stopped with error", zap.String("broker", b.Key()), zap.Error(err))
 			} else {

--- a/pkg/broker/handler/pool/fanout/pool.go
+++ b/pkg/broker/handler/pool/fanout/pool.go
@@ -130,7 +130,6 @@ func (p *SyncPool) SyncOnce(ctx context.Context) error {
 	})
 
 	p.targets.RangeBrokers(func(b *config.Broker) bool {
-		// There is already a handler for the broker, skip.
 		if value, ok := p.pool.Load(b.Key()); ok {
 			// Skip if we don't need to restart the handler.
 			if !value.(*handlerCache).requiresRestart(b) {

--- a/pkg/broker/handler/pool/retry/pool.go
+++ b/pkg/broker/handler/pool/retry/pool.go
@@ -54,6 +54,9 @@ type handlerCache struct {
 }
 
 func (hc *handlerCache) requiresRestart(t *config.Target) bool {
+	if !hc.IsAlive() {
+		return true
+	}
 	if t == nil || t.RetryQueue == nil {
 		return true
 	}
@@ -152,8 +155,6 @@ func (p *SyncPool) SyncOnce(ctx context.Context) error {
 			} else {
 				logging.FromContext(ctx).Info("handler for trigger has stopped", zap.String("trigger", t.Key()))
 			}
-			// Make sure the handler is deleted from the pool.
-			p.pool.Delete(t.Key())
 		})
 
 		p.pool.Store(t.Key(), hc)

--- a/pkg/broker/handler/pool/retry/pool.go
+++ b/pkg/broker/handler/pool/retry/pool.go
@@ -141,7 +141,6 @@ func (p *SyncPool) SyncOnce(ctx context.Context) error {
 				PubsubEvents: ps,
 				Processor: processors.ChainProcessors(
 					&filter.Processor{Targets: p.targets},
-					// TODO filter processor may be added in the future, but need more discussion for that.
 					&deliver.Processor{DeliverClient: p.deliverClient, Targets: p.targets},
 				),
 			},

--- a/pkg/broker/handler/pool/retry/pool.go
+++ b/pkg/broker/handler/pool/retry/pool.go
@@ -107,7 +107,6 @@ func (p *SyncPool) SyncOnce(ctx context.Context) error {
 	})
 
 	p.targets.RangeAllTargets(func(t *config.Target) bool {
-		// There is already a handler for the trigger, skip.
 		if value, ok := p.pool.Load(t.Key()); ok {
 			// Skip if we don't need to restart the handler.
 			if !value.(*handlerCache).requiresRestart(t) {

--- a/pkg/broker/handler/pool/retry/pool.go
+++ b/pkg/broker/handler/pool/retry/pool.go
@@ -150,6 +150,7 @@ func (p *SyncPool) SyncOnce(ctx context.Context) error {
 		tctx = handlerctx.WithTargetKey(tctx, t.Key())
 		// Start the handler with target in context.
 		hc.Start(tctx, func(err error) {
+			// We will anyway get an error because of https://github.com/cloudevents/sdk-go/issues/470
 			if err != nil {
 				logging.FromContext(ctx).Error("handler for trigger has stopped with error", zap.String("trigger", t.Key()), zap.Error(err))
 			} else {

--- a/pkg/broker/handler/pool/retry/pool_test.go
+++ b/pkg/broker/handler/pool/retry/pool_test.go
@@ -204,6 +204,7 @@ func TestRetrySyncPoolE2E(t *testing.T) {
 
 		// Send the same event to different trigger topic.
 		helper.SendEventToRetryQueue(ctx, t, t1.Key(), &e1)
+		helper.SendEventToRetryQueue(ctx, t, t2.Key(), &e1)
 		<-vctx.Done()
 	})
 


### PR DESCRIPTION
Fixes https://github.com/google/knative-gcp/issues/838

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Reconcile handlers on decouple/retry subscription updates
- Stop deleting the handler from pool on handler exit. This is dangerous because such a deletion could remove a newly created handler for the same broker. Now instead, store/delete handlers always happen in the same thread.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Reconcile handlers on decouple/retry subscription updates
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
