### PR TITLE
Add observability package with setup and teardown functions

### DIFF
--- a/cmd/broker/ingress/main.go
+++ b/cmd/broker/ingress/main.go
@@ -17,19 +17,34 @@ limitations under the License.
 package main
 
 import (
+	"flag"
+	"log"
+
 	"github.com/google/knative-gcp/pkg/broker/ingress"
+	"github.com/google/knative-gcp/pkg/observability"
 	"github.com/google/knative-gcp/pkg/utils"
 	"github.com/google/knative-gcp/pkg/utils/appcredentials"
 	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/zap"
+	"knative.dev/pkg/injection"
+	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
+)
+
+var (
+	masterURL  = flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	kubeconfig = flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 )
 
 type envConfig struct {
 	Port      int    `envconfig:"PORT" default:"8080"`
 	ProjectID string `envconfig:"PROJECT_ID"`
 }
+
+const (
+	componentName = "broker-ingress"
+)
 
 // main creates and starts an ingress handler using default options.
 // 1. It listens on port specified by "PORT" env var, or default 8080 if env var is not set
@@ -39,11 +54,25 @@ type envConfig struct {
 func main() {
 	appcredentials.MustExistOrUnsetEnv()
 
-	// Since we pass nil, a default config with no error will be returned.
-	cfg, _ := logging.NewConfigFromMap(nil)
-	logger, _ := logging.NewLoggerFromConfig(cfg, "broker-ingress")
 	ctx := signals.NewContext()
-	ctx = logging.WithLogger(ctx, logger)
+
+	cfg, err := sharedmain.GetConfig(*masterURL, *kubeconfig)
+	if err != nil {
+		log.Fatal("Error building kubeconfig", err)
+	}
+
+	log.Printf("Registering %d clients", len(injection.Default.GetClients()))
+	log.Printf("Registering %d informer factories", len(injection.Default.GetInformerFactories()))
+	log.Printf("Registering %d informers", len(injection.Default.GetInformers()))
+
+	ctx, _ = injection.Default.SetupInformers(ctx, cfg)
+
+	ctx, flush, err := observability.SetupDynamicConfig(ctx, componentName)
+	if err != nil {
+		log.Fatal("Error setting up dynamic observability configuration", err)
+	}
+	defer flush()
+	logger := logging.FromContext(ctx)
 
 	var env envConfig
 	if err := envconfig.Process("", &env); err != nil {

--- a/config/broker/deployments/broker.yaml
+++ b/config/broker/deployments/broker.yaml
@@ -40,6 +40,16 @@ spec:
           value: /var/secrets/google/key.json        
         - name: PORT
           value: "8080"
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: cloud.google.com/events
         volumeMounts:
         - name: broker-config
           mountPath: /var/run/cloud-run-events/broker

--- a/pkg/observability/observability.go
+++ b/pkg/observability/observability.go
@@ -3,17 +3,13 @@ package observability
 
 import (
 	"context"
-	"log"
 	"os"
 
 	"go.uber.org/zap"
 	"knative.dev/eventing/pkg/tracing"
-	kubeclient "knative.dev/pkg/client/injection/kube/client"
-	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
-	"knative.dev/pkg/system"
 	tracingconfig "knative.dev/pkg/tracing/config"
 )
 
@@ -21,17 +17,13 @@ import (
 // configmaps. Returns an updated context with logging and function to flush telemetry which should
 // be called before exit.
 func SetupDynamicConfig(ctx context.Context, componentName string) (context.Context, func(), error) {
+	sharedmain.MemStatsOrDie(ctx)
 	// Set up our logger.
-	loggingConfig, err := sharedmain.GetLoggingConfig(ctx)
-	if err != nil {
-		log.Fatal("Error loading/parsing logging configuration: ", err)
-	}
-	logger, atomicLevel := logging.NewLoggerFromConfig(loggingConfig, componentName)
+	logger, atomicLevel := sharedmain.SetupLoggerOrDie(ctx, componentName)
 	// Watch the logging config map and dynamically update logging levels.
-	configMapWatcher := configmap.NewInformedWatcher(kubeclient.Get(ctx), system.Namespace())
-
+	configMapWatcher := sharedmain.SetupConfigMapWatchOrDie(ctx, logger)
 	// Watch the logging config map and dynamically update logging levels.
-	configMapWatcher.Watch(logging.ConfigMapName(), logging.UpdateLevelFromConfigMap(logger, atomicLevel, componentName))
+	sharedmain.WatchLoggingConfigOrDie(ctx, configMapWatcher, logger, atomicLevel, componentName)
 	// Watch the observability config map
 	configMapWatcher.Watch(metrics.ConfigMapName(), metrics.UpdateExporterFromConfigMap(componentName, logger))
 	// Watch the tracing config map
@@ -41,7 +33,7 @@ func SetupDynamicConfig(ctx context.Context, componentName string) (context.Cont
 
 	configmapCtx, cancel := context.WithCancel(ctx)
 	// configMapWatcher does not block, so start it first.
-	if err = configMapWatcher.Start(configmapCtx.Done()); err != nil {
+	if err := configMapWatcher.Start(configmapCtx.Done()); err != nil {
 		logger.Warn("Failed to start ConfigMap watcher", zap.Error(err))
 	}
 	return logging.WithLogger(ctx, logger), func() { cancel(); flushExporters(logger) }, nil

--- a/pkg/observability/observability.go
+++ b/pkg/observability/observability.go
@@ -1,0 +1,56 @@
+// Package observability contains common setup and utilities for metrics, logging, and tracing.
+package observability
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"go.uber.org/zap"
+	"knative.dev/eventing/pkg/tracing"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/injection/sharedmain"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/metrics"
+	"knative.dev/pkg/system"
+	tracingconfig "knative.dev/pkg/tracing/config"
+)
+
+// SetupDynamicConfig sets up logging, metrics, and tracing by watching observability
+// configmaps. Returns an updated context with logging and function to flush telemetry which should
+// be called before exit.
+func SetupDynamicConfig(ctx context.Context, componentName string) (context.Context, func(), error) {
+	// Set up our logger.
+	loggingConfig, err := sharedmain.GetLoggingConfig(ctx)
+	if err != nil {
+		log.Fatal("Error loading/parsing logging configuration: ", err)
+	}
+	logger, atomicLevel := logging.NewLoggerFromConfig(loggingConfig, componentName)
+	// Watch the logging config map and dynamically update logging levels.
+	configMapWatcher := configmap.NewInformedWatcher(kubeclient.Get(ctx), system.Namespace())
+
+	// Watch the logging config map and dynamically update logging levels.
+	configMapWatcher.Watch(logging.ConfigMapName(), logging.UpdateLevelFromConfigMap(logger, atomicLevel, componentName))
+	// Watch the observability config map
+	configMapWatcher.Watch(metrics.ConfigMapName(), metrics.UpdateExporterFromConfigMap(componentName, logger))
+	// Watch the tracing config map
+	if err := tracing.SetupDynamicPublishing(logger, configMapWatcher, componentName, tracingconfig.ConfigName); err != nil {
+		return ctx, nil, err
+	}
+
+	configmapCtx, cancel := context.WithCancel(ctx)
+	// configMapWatcher does not block, so start it first.
+	if err = configMapWatcher.Start(configmapCtx.Done()); err != nil {
+		logger.Warn("Failed to start ConfigMap watcher", zap.Error(err))
+	}
+	return logging.WithLogger(ctx, logger), func() { cancel(); flushExporters(logger) }, nil
+}
+
+// TODO: flush tracers
+func flushExporters(logger *zap.SugaredLogger) {
+	logger.Sync()
+	metrics.FlushExporter()
+	os.Stdout.Sync()
+	os.Stderr.Sync()
+}


### PR DESCRIPTION
Fixes #855

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Adds trace exporting to all broker components.
- Adds metric exporting to broker ingress.
- Adds pkg/observability package which is handles common setup and teardown logic for logging, metrics, and tracing.
