### PR TITLE
Truncate pubsub names if greater than 255 chars

### DIFF
--- a/pkg/reconciler/broker/resources/names.go
+++ b/pkg/reconciler/broker/resources/names.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	brokerv1beta1 "github.com/google/knative-gcp/pkg/apis/broker/v1beta1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // For reference, the minimum number of characters available for a name
@@ -47,32 +48,32 @@ const (
 // Broker. If the topic name would be longer than allowed by PubSub, the
 // Broker name is truncated to fit.
 func GenerateDecouplingTopicName(b *brokerv1beta1.Broker) string {
-	return truncatedPubsubResourceName("cre-bkr", b.Namespace, b.Name, string(b.UID))
+	return truncatedPubsubResourceName("cre-bkr", b.Namespace, b.Name, b.UID)
 }
 
 // GenerateDecouplingSubscriptionName generates a deterministic subscription
 // name for a Broker. If the subscription name would be longer than allowed by
 // PubSub, the Broker name is truncated to fit.
 func GenerateDecouplingSubscriptionName(b *brokerv1beta1.Broker) string {
-	return truncatedPubsubResourceName("cre-bkr", b.Namespace, b.Name, string(b.UID))
+	return truncatedPubsubResourceName("cre-bkr", b.Namespace, b.Name, b.UID)
 }
 
 // GenerateRetryTopicName generates a deterministic topic name for a Trigger.
 // If the topic name would be longer than allowed by PubSub, the Trigger name is
 // truncated to fit.
 func GenerateRetryTopicName(t *brokerv1beta1.Trigger) string {
-	return truncatedPubsubResourceName("cre-tgr", t.Namespace, t.Name, string(t.UID))
+	return truncatedPubsubResourceName("cre-tgr", t.Namespace, t.Name, t.UID)
 }
 
 // GenerateRetrySubscriptionName generates a deterministic subscription name
 // for a Trigger. If the subscription name would be longer than allowed by
 // PubSub, the Trigger name is truncated to fit.
 func GenerateRetrySubscriptionName(t *brokerv1beta1.Trigger) string {
-	return truncatedPubsubResourceName("cre-tgr", t.Namespace, t.Name, string(t.UID))
+	return truncatedPubsubResourceName("cre-tgr", t.Namespace, t.Name, t.UID)
 }
 
-func truncatedPubsubResourceName(prefix, ns, n, uid string) string {
-	s := fmt.Sprintf("%s_%s_%s_%s", prefix, ns, n, uid)
+func truncatedPubsubResourceName(prefix, ns, n string, uid types.UID) string {
+	s := fmt.Sprintf("%s_%s_%s_%s", prefix, ns, n, string(uid))
 	if len(s) <= pubsubMax {
 		return s
 	}
@@ -81,7 +82,7 @@ func truncatedPubsubResourceName(prefix, ns, n, uid string) string {
 	nameOver := len(s) - pubsubMax
 	nameMax := len(n) - nameOver
 
-	return fmt.Sprintf("%s_%s_%s_%s", prefix, ns, hashedTruncate(n, nameMax), uid)
+	return fmt.Sprintf("%s_%s_%s_%s", prefix, ns, hashedTruncate(n, nameMax), string(uid))
 }
 
 // hashedTruncate truncates a string longer than l by replacing the end of the

--- a/pkg/reconciler/broker/resources/names.go
+++ b/pkg/reconciler/broker/resources/names.go
@@ -17,10 +17,23 @@ limitations under the License.
 package resources
 
 import (
+	"crypto/md5"
 	"fmt"
 
 	brokerv1beta1 "github.com/google/knative-gcp/pkg/apis/broker/v1beta1"
 )
+
+// For reference, the minimum number of characters available for a name
+// is 146. However, any name longer than 146 will be truncated and suffixed
+// with a 32-char hash, making its max length 114 chars.
+//
+// pubsub resource name max length: 255 chars
+// Namespace max length: 63 chars
+// broker name max length: 253 chars
+// trigger name max length: 253 chars
+// uid length: 36 chars
+// prefix + separators: 10 chars
+// 255 - 10 - 63 - 36 = 146
 
 const (
 	pubsubMax       = 255
@@ -30,34 +43,60 @@ const (
 	md5Len          = 32
 )
 
-//TODO check length < 256 chars and truncate
-// pubsub resource max length: 255 chars
-// Namespace max length: 63 chars
-// broker name max length: 253 chars
-// trigger name max length: 253 chars
-// uid length: 36 chars
-// prefix + separators: 10 chars
-// 255 - 10 - 36 - 63 = 146 chars for name
-
 // GenerateDecouplingTopicName generates a deterministic topic name for a
-// Broker.
+// Broker. If the topic name would be longer than allowed by PubSub, the
+// Broker name is truncated to fit.
 func GenerateDecouplingTopicName(b *brokerv1beta1.Broker) string {
-	return fmt.Sprintf("cre-bkr_%s_%s_%s", b.Namespace, b.Name, string(b.UID))
+	return truncatedPubsubResourceName("cre-bkr", b.Namespace, b.Name, string(b.UID))
 }
 
 // GenerateDecouplingSubscriptionName generates a deterministic subscription
-// name for a Broker.
+// name for a Broker. If the subscription name would be longer than allowed by
+// PubSub, the Broker name is truncated to fit.
 func GenerateDecouplingSubscriptionName(b *brokerv1beta1.Broker) string {
-	return fmt.Sprintf("cre-bkr_%s_%s_%s", b.Namespace, b.Name, string(b.UID))
+	return truncatedPubsubResourceName("cre-bkr", b.Namespace, b.Name, string(b.UID))
 }
 
 // GenerateRetryTopicName generates a deterministic topic name for a Trigger.
+// If the topic name would be longer than allowed by PubSub, the Trigger name is
+// truncated to fit.
 func GenerateRetryTopicName(t *brokerv1beta1.Trigger) string {
-	return fmt.Sprintf("cre-tgr_%s_%s_%s", t.Namespace, t.Name, string(t.UID))
+	return truncatedPubsubResourceName("cre-tgr", t.Namespace, t.Name, string(t.UID))
 }
 
 // GenerateRetrySubscriptionName generates a deterministic subscription name
-// for a Trigger.
+// for a Trigger. If the subscription name would be longer than allowed by
+// PubSub, the Trigger name is truncated to fit.
 func GenerateRetrySubscriptionName(t *brokerv1beta1.Trigger) string {
-	return fmt.Sprintf("cre-tgr_%s_%s_%s", t.Namespace, t.Name, string(t.UID))
+	return truncatedPubsubResourceName("cre-tgr", t.Namespace, t.Name, string(t.UID))
+}
+
+func truncatedPubsubResourceName(prefix, ns, n, uid string) string {
+	s := fmt.Sprintf("%s_%s_%s_%s", prefix, ns, n, uid)
+	if len(s) <= pubsubMax {
+		return s
+	}
+	// Calculate how much the name needs to be truncated by.
+	// The prefix, namespace, and uid are never truncated.
+	nameOver := len(s) - pubsubMax
+	nameMax := len(n) - nameOver
+
+	return fmt.Sprintf("%s_%s_%s_%s", prefix, ns, hashedTruncate(n, nameMax), uid)
+}
+
+// hashedTruncate truncates a string longer than l by replacing the end of the
+// string with a hash of its contents. Panics if l is less than the length of
+// the hash value (currently 32 characters).
+func hashedTruncate(s string, max int) string {
+	// Check for minimum length immediately to ensure it always fails even if
+	// the string is short
+	if max < md5Len {
+		panic(fmt.Errorf("truncated length %d cannot be less than %d", max, md5Len))
+	}
+	if len(s) <= max {
+		return s
+	}
+	h := md5.Sum([]byte(s))
+	headLen := max - md5Len
+	return s[:headLen] + fmt.Sprintf("%x", h)
 }

--- a/pkg/reconciler/broker/resources/names_test.go
+++ b/pkg/reconciler/broker/resources/names_test.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -26,16 +27,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-//TODO verify topic and sub name can't be longer than 255 chars
-
 const testUID = "11186600-4003-4ad6-90e7-22780053debf"
 
-var maxName = genString("n", k8sNameMax)
+var maxName = strings.Repeat("n", k8sNameMax)
 
 // fmt.Sprintf("%x", md5.Sum([]byte(maxName)))
 var maxNameHash = "1c6d61b118caf1b3e5c8c4404f34b4a2"
 
-var maxNamespace = genString("ns", k8sNamespaceMax)
+var maxNamespace = strings.Repeat("s", k8sNamespaceMax)
 
 func TestGenerateDecouplingTopicName(t *testing.T) {
 	testCases := []struct {
@@ -57,12 +56,12 @@ func TestGenerateDecouplingTopicName(t *testing.T) {
 		ns:   maxNamespace,
 		n:    maxName,
 		uid:  testUID,
-		want: fmt.Sprintf("cre-bkr_%s_%s%s_%s", maxNamespace, genString("n", 146-md5Len), maxNameHash, testUID),
+		want: fmt.Sprintf("cre-bkr_%s_%s%s_%s", maxNamespace, strings.Repeat("n", 146-md5Len), maxNameHash, testUID),
 	}, {
 		ns:   "default",
 		n:    maxName,
 		uid:  testUID,
-		want: fmt.Sprintf("cre-bkr_default_%s%s_%s", genString("n", 146-md5Len+(k8sNamespaceMax-7)), maxNameHash, testUID),
+		want: fmt.Sprintf("cre-bkr_default_%s%s_%s", strings.Repeat("n", 146-md5Len+(k8sNamespaceMax-7)), maxNameHash, testUID),
 	}}
 
 	for _, tc := range testCases {
@@ -96,12 +95,12 @@ func TestGenerateDecouplingSubscriptionName(t *testing.T) {
 		ns:   maxNamespace,
 		n:    maxName,
 		uid:  testUID,
-		want: fmt.Sprintf("cre-bkr_%s_%s%s_%s", maxNamespace, genString("n", 146-md5Len), maxNameHash, testUID),
+		want: fmt.Sprintf("cre-bkr_%s_%s%s_%s", maxNamespace, strings.Repeat("n", 146-md5Len), maxNameHash, testUID),
 	}, {
 		ns:   "default",
 		n:    maxName,
 		uid:  testUID,
-		want: fmt.Sprintf("cre-bkr_default_%s%s_%s", genString("n", 146-md5Len+(k8sNamespaceMax-7)), maxNameHash, testUID),
+		want: fmt.Sprintf("cre-bkr_default_%s%s_%s", strings.Repeat("n", 146-md5Len+(k8sNamespaceMax-7)), maxNameHash, testUID),
 	}}
 
 	for _, tc := range testCases {
@@ -135,12 +134,12 @@ func TestGenerateRetryTopicName(t *testing.T) {
 		ns:   maxNamespace,
 		n:    maxName,
 		uid:  testUID,
-		want: fmt.Sprintf("cre-tgr_%s_%s%s_%s", maxNamespace, genString("n", 146-md5Len), maxNameHash, testUID),
+		want: fmt.Sprintf("cre-tgr_%s_%s%s_%s", maxNamespace, strings.Repeat("n", 146-md5Len), maxNameHash, testUID),
 	}, {
 		ns:   "default",
 		n:    maxName,
 		uid:  testUID,
-		want: fmt.Sprintf("cre-tgr_default_%s%s_%s", genString("n", 146-md5Len+(k8sNamespaceMax-7)), maxNameHash, testUID),
+		want: fmt.Sprintf("cre-tgr_default_%s%s_%s", strings.Repeat("n", 146-md5Len+(k8sNamespaceMax-7)), maxNameHash, testUID),
 	}}
 
 	for _, tc := range testCases {
@@ -174,12 +173,12 @@ func TestGenerateRetrySubscriptionName(t *testing.T) {
 		ns:   maxNamespace,
 		n:    maxName,
 		uid:  testUID,
-		want: fmt.Sprintf("cre-tgr_%s_%s%s_%s", maxNamespace, genString("n", 146-md5Len), maxNameHash, testUID),
+		want: fmt.Sprintf("cre-tgr_%s_%s%s_%s", maxNamespace, strings.Repeat("n", 146-md5Len), maxNameHash, testUID),
 	}, {
 		ns:   "default",
 		n:    maxName,
 		uid:  testUID,
-		want: fmt.Sprintf("cre-tgr_default_%s%s_%s", genString("n", 146-md5Len+(k8sNamespaceMax-7)), maxNameHash, testUID),
+		want: fmt.Sprintf("cre-tgr_default_%s%s_%s", strings.Repeat("n", 146-md5Len+(k8sNamespaceMax-7)), maxNameHash, testUID),
 	}}
 
 	for _, tc := range testCases {
@@ -238,20 +237,4 @@ func Test_hashedTruncatePanic(t *testing.T) {
 
 	// no panic when max == 32
 	hashedTruncate("", 32)
-}
-
-func genString(p string, l int) string {
-	for len(p) < l {
-		p += p
-	}
-	return p[:l]
-}
-
-func Test_genString(t *testing.T) {
-	if l := len(genString("a", 10)); l != 10 {
-		t.Errorf("wrong length: expected 10, got %d", l)
-	}
-	if l := len(genString("abc", 1000)); l != 1000 {
-		t.Errorf("wrong length: expected 1000, got %d", l)
-	}
 }

--- a/pkg/reconciler/broker/resources/names_test.go
+++ b/pkg/reconciler/broker/resources/names_test.go
@@ -30,6 +30,13 @@ import (
 
 const testUID = "11186600-4003-4ad6-90e7-22780053debf"
 
+var maxName = genString("n", k8sNameMax)
+
+// fmt.Sprintf("%x", md5.Sum([]byte(maxName)))
+var maxNameHash = "1c6d61b118caf1b3e5c8c4404f34b4a2"
+
+var maxNamespace = genString("ns", k8sNamespaceMax)
+
 func TestGenerateDecouplingTopicName(t *testing.T) {
 	testCases := []struct {
 		ns   string
@@ -46,12 +53,25 @@ func TestGenerateDecouplingTopicName(t *testing.T) {
 		n:    "more-dashes",
 		uid:  testUID,
 		want: fmt.Sprintf("cre-bkr_with-dashes_more-dashes_%s", testUID),
+	}, {
+		ns:   maxNamespace,
+		n:    maxName,
+		uid:  testUID,
+		want: fmt.Sprintf("cre-bkr_%s_%s%s_%s", maxNamespace, genString("n", 146-md5Len), maxNameHash, testUID),
+	}, {
+		ns:   "default",
+		n:    maxName,
+		uid:  testUID,
+		want: fmt.Sprintf("cre-bkr_default_%s%s_%s", genString("n", 146-md5Len+(k8sNamespaceMax-7)), maxNameHash, testUID),
 	}}
 
 	for _, tc := range testCases {
 		got := GenerateDecouplingTopicName(broker(tc.ns, tc.n, tc.uid))
+		if len(got) > pubsubMax {
+			t.Errorf("name length %d is greater than %d", len(got), pubsubMax)
+		}
 		if diff := cmp.Diff(tc.want, got); diff != "" {
-			t.Errorf("unexpected (want, +got) = %v", diff)
+			t.Errorf("unexpected (-want, +got) = %v", diff)
 		}
 	}
 }
@@ -72,10 +92,23 @@ func TestGenerateDecouplingSubscriptionName(t *testing.T) {
 		n:    "more-dashes",
 		uid:  testUID,
 		want: fmt.Sprintf("cre-bkr_with-dashes_more-dashes_%s", testUID),
+	}, {
+		ns:   maxNamespace,
+		n:    maxName,
+		uid:  testUID,
+		want: fmt.Sprintf("cre-bkr_%s_%s%s_%s", maxNamespace, genString("n", 146-md5Len), maxNameHash, testUID),
+	}, {
+		ns:   "default",
+		n:    maxName,
+		uid:  testUID,
+		want: fmt.Sprintf("cre-bkr_default_%s%s_%s", genString("n", 146-md5Len+(k8sNamespaceMax-7)), maxNameHash, testUID),
 	}}
 
 	for _, tc := range testCases {
 		got := GenerateDecouplingSubscriptionName(broker(tc.ns, tc.n, tc.uid))
+		if len(got) > pubsubMax {
+			t.Errorf("name length %d is greater than %d", len(got), pubsubMax)
+		}
 		if diff := cmp.Diff(tc.want, got); diff != "" {
 			t.Errorf("unexpected (want, +got) = %v", diff)
 		}
@@ -98,10 +131,23 @@ func TestGenerateRetryTopicName(t *testing.T) {
 		n:    "more-dashes",
 		uid:  testUID,
 		want: fmt.Sprintf("cre-tgr_with-dashes_more-dashes_%s", testUID),
+	}, {
+		ns:   maxNamespace,
+		n:    maxName,
+		uid:  testUID,
+		want: fmt.Sprintf("cre-tgr_%s_%s%s_%s", maxNamespace, genString("n", 146-md5Len), maxNameHash, testUID),
+	}, {
+		ns:   "default",
+		n:    maxName,
+		uid:  testUID,
+		want: fmt.Sprintf("cre-tgr_default_%s%s_%s", genString("n", 146-md5Len+(k8sNamespaceMax-7)), maxNameHash, testUID),
 	}}
 
 	for _, tc := range testCases {
 		got := GenerateRetryTopicName(trigger(tc.ns, tc.n, tc.uid))
+		if len(got) > pubsubMax {
+			t.Errorf("name length %d is greater than %d", len(got), pubsubMax)
+		}
 		if diff := cmp.Diff(tc.want, got); diff != "" {
 			t.Errorf("unexpected (want, +got) = %v", diff)
 		}
@@ -124,10 +170,23 @@ func TestGenerateRetrySubscriptionName(t *testing.T) {
 		n:    "more-dashes",
 		uid:  testUID,
 		want: fmt.Sprintf("cre-tgr_with-dashes_more-dashes_%s", testUID),
+	}, {
+		ns:   maxNamespace,
+		n:    maxName,
+		uid:  testUID,
+		want: fmt.Sprintf("cre-tgr_%s_%s%s_%s", maxNamespace, genString("n", 146-md5Len), maxNameHash, testUID),
+	}, {
+		ns:   "default",
+		n:    maxName,
+		uid:  testUID,
+		want: fmt.Sprintf("cre-tgr_default_%s%s_%s", genString("n", 146-md5Len+(k8sNamespaceMax-7)), maxNameHash, testUID),
 	}}
 
 	for _, tc := range testCases {
-		got := GenerateRetryTopicName(trigger(tc.ns, tc.n, tc.uid))
+		got := GenerateRetrySubscriptionName(trigger(tc.ns, tc.n, tc.uid))
+		if len(got) > pubsubMax {
+			t.Errorf("name length %d is greater than %d", len(got), pubsubMax)
+		}
 		if diff := cmp.Diff(tc.want, got); diff != "" {
 			t.Errorf("unexpected (want, +got) = %v", diff)
 		}
@@ -151,5 +210,48 @@ func trigger(ns, n, uid string) *brokerv1beta1.Trigger {
 			Name:      n,
 			UID:       types.UID(uid),
 		},
+	}
+}
+
+func checkPanic(t *testing.T, f func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		}
+	}()
+	f()
+}
+
+func Test_hashedTruncate(t *testing.T) {
+	want := "nnn" + maxNameHash
+	if got := hashedTruncate(maxName, 35); got != want {
+		t.Errorf("Expected %q, got %q", want, got)
+	}
+}
+
+func Test_hashedTruncatePanic(t *testing.T) {
+	// panic when string is longer than max
+	checkPanic(t, func() { hashedTruncate("abcde", 4) })
+
+	// panic when string is shorter than max
+	checkPanic(t, func() { hashedTruncate("", 31) })
+
+	// no panic when max == 32
+	hashedTruncate("", 32)
+}
+
+func genString(p string, l int) string {
+	for len(p) < l {
+		p += p
+	}
+	return p[:l]
+}
+
+func Test_genString(t *testing.T) {
+	if l := len(genString("a", 10)); l != 10 {
+		t.Errorf("wrong length: expected 10, got %d", l)
+	}
+	if l := len(genString("abc", 1000)); l != 1000 {
+		t.Errorf("wrong length: expected 1000, got %d", l)
 	}
 }


### PR DESCRIPTION
Uses similar hashing strategy as kmeta.ChildName. Can't use kmeta.ChildName directly because the concatenation is different and the max length is greater.

Fixes #831

## Proposed Changes

- Truncate pubsub resource names deterministically if they would be greater than 255 characters