### PR TITLE
Have broker fanout handle timeout gracefully for each individual target

### DIFF
--- a/cmd/broker/fanout/main.go
+++ b/cmd/broker/fanout/main.go
@@ -54,12 +54,14 @@ var (
 )
 
 type envConfig struct {
-	PodName                string        `envconfig:"POD_NAME" required:"true"`
-	ProjectID              string        `envconfig:"PROJECT_ID"`
-	TargetsConfigPath      string        `envconfig:"TARGETS_CONFIG_PATH" default:"/var/run/cloud-run-events/broker/targets"`
-	HandlerConcurrency     int           `envconfig:"HANDLER_CONCURRENCY"`
-	MaxConcurrencyPerEvent int           `envconfig:"MAX_CONCURRENCY_PER_EVENT"`
-	TimeoutPerEvent        time.Duration `envconfig:"TIMEOUT_PER_EVENT"`
+	PodName                string `envconfig:"POD_NAME" required:"true"`
+	ProjectID              string `envconfig:"PROJECT_ID"`
+	TargetsConfigPath      string `envconfig:"TARGETS_CONFIG_PATH" default:"/var/run/cloud-run-events/broker/targets"`
+	HandlerConcurrency     int    `envconfig:"HANDLER_CONCURRENCY"`
+	MaxConcurrencyPerEvent int    `envconfig:"MAX_CONCURRENCY_PER_EVENT"`
+
+	// Max to 10m.
+	TimeoutPerEvent time.Duration `envconfig:"TIMEOUT_PER_EVENT"`
 }
 
 func main() {

--- a/cmd/broker/retry/main.go
+++ b/cmd/broker/retry/main.go
@@ -54,11 +54,13 @@ var (
 )
 
 type envConfig struct {
-	PodName            string        `envconfig:"POD_NAME" required:"true"`
-	ProjectID          string        `envconfig:"PROJECT_ID"`
-	TargetsConfigPath  string        `envconfig:"TARGETS_CONFIG_PATH" default:"/var/run/cloud-run-events/broker/targets"`
-	HandlerConcurrency int           `envconfig:"HANDLER_CONCURRENCY"`
-	TimeoutPerEvent    time.Duration `envconfig:"TIMEOUT_PER_EVENT"`
+	PodName            string `envconfig:"POD_NAME" required:"true"`
+	ProjectID          string `envconfig:"PROJECT_ID"`
+	TargetsConfigPath  string `envconfig:"TARGETS_CONFIG_PATH" default:"/var/run/cloud-run-events/broker/targets"`
+	HandlerConcurrency int    `envconfig:"HANDLER_CONCURRENCY"`
+
+	// Max to 10m.
+	TimeoutPerEvent time.Duration `envconfig:"TIMEOUT_PER_EVENT"`
 }
 
 func main() {

--- a/pkg/broker/handler/pool/fanout/pool.go
+++ b/pkg/broker/handler/pool/fanout/pool.go
@@ -109,6 +109,10 @@ func NewSyncPool(ctx context.Context, targets config.ReadonlyTargets, opts ...po
 		return nil, err
 	}
 
+	if options.TimeoutPerEvent < 5*time.Second {
+		return nil, fmt.Errorf("timeout per event cannot be lower than %v", 5*time.Second)
+	}
+
 	p := &SyncPool{
 		targets:            targets,
 		options:            options,

--- a/pkg/broker/handler/pool/fanout/pool_test.go
+++ b/pkg/broker/handler/pool/fanout/pool_test.go
@@ -213,7 +213,7 @@ func TestFanoutSyncPoolE2E(t *testing.T) {
 		go helper.VerifyNextTargetRetryEvent(ctx, t, t1.Key(), &e)
 		// The same event should be received by t2.
 		go helper.VerifyNextTargetEvent(vctx, t, t2.Key(), &e)
-		// But t2 should receive any retry event because the initial delay
+		// But t2 shouldn't receive any retry event because the initial delay
 		// was successful.
 		go helper.VerifyNextTargetRetryEvent(vctx, t, t2.Key(), nil)
 

--- a/pkg/broker/handler/pool/fanout/pool_test.go
+++ b/pkg/broker/handler/pool/fanout/pool_test.go
@@ -193,14 +193,14 @@ func TestFanoutSyncPoolE2E(t *testing.T) {
 		vctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
 
-		go helper.VerifyAndRespondNextTargetEvent(ctx, t, t3.Key(), &e, nil, http.StatusInternalServerError)
+		go helper.VerifyAndRespondNextTargetEvent(ctx, t, t3.Key(), &e, nil, http.StatusInternalServerError, 0)
 		go helper.VerifyNextTargetRetryEvent(ctx, t, t3.Key(), &e)
 
 		helper.SendEventToDecoupleQueue(ctx, t, b2.Key(), &e)
 		<-vctx.Done()
 	})
 
-	t.Run("event initial delivery failed with timeout was sent to retry queue", func(t *testing.T) {
+	t.Run("event with delivery timeout was sent to retry queue", func(t *testing.T) {
 		// Set timeout context so that verification can be done before
 		// exiting test func.
 		vctx, cancel := context.WithTimeout(ctx, 2*time.Second)
@@ -233,7 +233,7 @@ func TestFanoutSyncPoolE2E(t *testing.T) {
 		vctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
 
-		go helper.VerifyAndRespondNextTargetEvent(ctx, t, t3.Key(), &e, &reply, http.StatusOK)
+		go helper.VerifyAndRespondNextTargetEvent(ctx, t, t3.Key(), &e, &reply, http.StatusOK, 0)
 		go helper.VerifyNextBrokerIngressEvent(ctx, t, b2.Key(), &reply)
 
 		helper.SendEventToDecoupleQueue(ctx, t, b2.Key(), &e)

--- a/pkg/broker/handler/pool/options_test.go
+++ b/pkg/broker/handler/pool/options_test.go
@@ -60,13 +60,23 @@ func TestWithMaxConcurrency(t *testing.T) {
 }
 
 func TestWithTimeout(t *testing.T) {
-	want := 10 * time.Minute
+	want := 2 * time.Minute
 	// Always add project id because the default value can only be retrieved on GCE/GKE machines.
 	opt, err := NewOptions(WithTimeoutPerEvent(want), WithProjectID("pid"))
 	if err != nil {
 		t.Errorf("NewOptions got unexpected error: %v", err)
 	}
 	if opt.TimeoutPerEvent != want {
+		t.Errorf("options timeout per event got=%v, want=%v", opt.TimeoutPerEvent, want)
+	}
+
+	// Set timeout greater than the max value and verify it fallbacks to the max value.
+	// Always add project id because the default value can only be retrieved on GCE/GKE machines.
+	opt, err = NewOptions(WithTimeoutPerEvent(20*time.Minute), WithProjectID("pid"))
+	if err != nil {
+		t.Errorf("NewOptions got unexpected error: %v", err)
+	}
+	if opt.TimeoutPerEvent != maxTime {
 		t.Errorf("options timeout per event got=%v, want=%v", opt.TimeoutPerEvent, want)
 	}
 }
@@ -102,5 +112,17 @@ func TestWithPubsubClient(t *testing.T) {
 	}
 	if opt.PubsubClient == nil {
 		t.Error("options PubsubClient got=nil, want=non-nil client")
+	}
+}
+
+func TestWithDeliveryTimeout(t *testing.T) {
+	want := 10 * time.Minute
+	// Always add project id because the default value can only be retrieved on GCE/GKE machines.
+	opt, err := NewOptions(WithDeliveryTimeout(want), WithProjectID("pid"))
+	if err != nil {
+		t.Errorf("NewOptions got unexpected error: %v", err)
+	}
+	if opt.TimeoutPerEvent != want {
+		t.Errorf("options timeout per event got=%v, want=%v", opt.DeliveryTimeout, want)
 	}
 }

--- a/pkg/broker/handler/pool/options_test.go
+++ b/pkg/broker/handler/pool/options_test.go
@@ -76,8 +76,8 @@ func TestWithTimeout(t *testing.T) {
 	if err != nil {
 		t.Errorf("NewOptions got unexpected error: %v", err)
 	}
-	if opt.TimeoutPerEvent != maxTime {
-		t.Errorf("options timeout per event got=%v, want=%v", opt.TimeoutPerEvent, want)
+	if opt.TimeoutPerEvent != maxTimeout {
+		t.Errorf("options timeout per event got=%v, want=%v", opt.TimeoutPerEvent, maxTimeout)
 	}
 }
 

--- a/pkg/broker/handler/processors/deliver/processor.go
+++ b/pkg/broker/handler/processors/deliver/processor.go
@@ -51,8 +51,8 @@ type Processor struct {
 	// to the retry topic.
 	DeliverRetryClient ceclient.Client
 
-	// Timeout is the delivery timeout.
-	// If set, the delivery will be time-boxed.
+	// DeliverTimeout is the timeout applied to cancel delivery.
+	// If zero, not additional timeout is applied.
 	DeliverTimeout time.Duration
 }
 


### PR DESCRIPTION
Fixes https://github.com/google/knative-gcp/issues/954

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Fanout delivery for each target is now timeboxed. On timeout, it will send the event to retry queue. It has a slightly shorter timeout than the handler timeout. This is necessary because otherwise the handler timeout will cause the same event being re-delivered to all targets.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Have broker fanout handle timeout gracefully for each individual target
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
