### PR TITLE
Truncate pubsub names if greater than 255 chars

### DIFF
--- a/pkg/reconciler/broker/resources/names_test.go
+++ b/pkg/reconciler/broker/resources/names_test.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -26,9 +27,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-//TODO verify topic and sub name can't be longer than 255 chars
-
 const testUID = "11186600-4003-4ad6-90e7-22780053debf"
+
+var maxName = strings.Repeat("n", k8sNameMax)
+
+var maxNamespace = strings.Repeat("s", k8sNamespaceMax)
 
 func TestGenerateDecouplingTopicName(t *testing.T) {
 	testCases := []struct {
@@ -46,12 +49,25 @@ func TestGenerateDecouplingTopicName(t *testing.T) {
 		n:    "more-dashes",
 		uid:  testUID,
 		want: fmt.Sprintf("cre-bkr_with-dashes_more-dashes_%s", testUID),
+	}, {
+		ns:   maxNamespace,
+		n:    maxName,
+		uid:  testUID,
+		want: fmt.Sprintf("cre-bkr_%s_%s_%s", maxNamespace, strings.Repeat("n", 146), testUID),
+	}, {
+		ns:   "default",
+		n:    maxName,
+		uid:  testUID,
+		want: fmt.Sprintf("cre-bkr_default_%s_%s", strings.Repeat("n", 146+(k8sNamespaceMax-7)), testUID),
 	}}
 
 	for _, tc := range testCases {
 		got := GenerateDecouplingTopicName(broker(tc.ns, tc.n, tc.uid))
+		if len(got) > pubsubMax {
+			t.Errorf("name length %d is greater than %d", len(got), pubsubMax)
+		}
 		if diff := cmp.Diff(tc.want, got); diff != "" {
-			t.Errorf("unexpected (want, +got) = %v", diff)
+			t.Errorf("unexpected (-want, +got) = %v", diff)
 		}
 	}
 }
@@ -72,10 +88,23 @@ func TestGenerateDecouplingSubscriptionName(t *testing.T) {
 		n:    "more-dashes",
 		uid:  testUID,
 		want: fmt.Sprintf("cre-bkr_with-dashes_more-dashes_%s", testUID),
+	}, {
+		ns:   maxNamespace,
+		n:    maxName,
+		uid:  testUID,
+		want: fmt.Sprintf("cre-bkr_%s_%s_%s", maxNamespace, strings.Repeat("n", 146), testUID),
+	}, {
+		ns:   "default",
+		n:    maxName,
+		uid:  testUID,
+		want: fmt.Sprintf("cre-bkr_default_%s_%s", strings.Repeat("n", 146+(k8sNamespaceMax-7)), testUID),
 	}}
 
 	for _, tc := range testCases {
 		got := GenerateDecouplingSubscriptionName(broker(tc.ns, tc.n, tc.uid))
+		if len(got) > pubsubMax {
+			t.Errorf("name length %d is greater than %d", len(got), pubsubMax)
+		}
 		if diff := cmp.Diff(tc.want, got); diff != "" {
 			t.Errorf("unexpected (want, +got) = %v", diff)
 		}
@@ -98,10 +127,23 @@ func TestGenerateRetryTopicName(t *testing.T) {
 		n:    "more-dashes",
 		uid:  testUID,
 		want: fmt.Sprintf("cre-tgr_with-dashes_more-dashes_%s", testUID),
+	}, {
+		ns:   maxNamespace,
+		n:    maxName,
+		uid:  testUID,
+		want: fmt.Sprintf("cre-tgr_%s_%s_%s", maxNamespace, strings.Repeat("n", 146), testUID),
+	}, {
+		ns:   "default",
+		n:    maxName,
+		uid:  testUID,
+		want: fmt.Sprintf("cre-tgr_default_%s_%s", strings.Repeat("n", 146+(k8sNamespaceMax-7)), testUID),
 	}}
 
 	for _, tc := range testCases {
 		got := GenerateRetryTopicName(trigger(tc.ns, tc.n, tc.uid))
+		if len(got) > pubsubMax {
+			t.Errorf("name length %d is greater than %d", len(got), pubsubMax)
+		}
 		if diff := cmp.Diff(tc.want, got); diff != "" {
 			t.Errorf("unexpected (want, +got) = %v", diff)
 		}
@@ -124,10 +166,23 @@ func TestGenerateRetrySubscriptionName(t *testing.T) {
 		n:    "more-dashes",
 		uid:  testUID,
 		want: fmt.Sprintf("cre-tgr_with-dashes_more-dashes_%s", testUID),
+	}, {
+		ns:   maxNamespace,
+		n:    maxName,
+		uid:  testUID,
+		want: fmt.Sprintf("cre-tgr_%s_%s_%s", maxNamespace, strings.Repeat("n", 146), testUID),
+	}, {
+		ns:   "default",
+		n:    maxName,
+		uid:  testUID,
+		want: fmt.Sprintf("cre-tgr_default_%s_%s", strings.Repeat("n", 146+(k8sNamespaceMax-7)), testUID),
 	}}
 
 	for _, tc := range testCases {
-		got := GenerateRetryTopicName(trigger(tc.ns, tc.n, tc.uid))
+		got := GenerateRetrySubscriptionName(trigger(tc.ns, tc.n, tc.uid))
+		if len(got) > pubsubMax {
+			t.Errorf("name length %d is greater than %d", len(got), pubsubMax)
+		}
 		if diff := cmp.Diff(tc.want, got); diff != "" {
 			t.Errorf("unexpected (want, +got) = %v", diff)
 		}

--- a/pkg/reconciler/broker/resources/names_test.go
+++ b/pkg/reconciler/broker/resources/names_test.go
@@ -27,7 +27,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-const testUID = "11186600-4003-4ad6-90e7-22780053debf"
+const (
+	testUID          = "11186600-4003-4ad6-90e7-22780053debf"
+	truncatedNameMax = 146
+)
 
 var maxName = strings.Repeat("n", k8sNameMax)
 
@@ -53,12 +56,12 @@ func TestGenerateDecouplingTopicName(t *testing.T) {
 		ns:   maxNamespace,
 		n:    maxName,
 		uid:  testUID,
-		want: fmt.Sprintf("cre-bkr_%s_%s_%s", maxNamespace, strings.Repeat("n", 146), testUID),
+		want: fmt.Sprintf("cre-bkr_%s_%s_%s", maxNamespace, strings.Repeat("n", truncatedNameMax), testUID),
 	}, {
 		ns:   "default",
 		n:    maxName,
 		uid:  testUID,
-		want: fmt.Sprintf("cre-bkr_default_%s_%s", strings.Repeat("n", 146+(k8sNamespaceMax-7)), testUID),
+		want: fmt.Sprintf("cre-bkr_default_%s_%s", strings.Repeat("n", truncatedNameMax+(k8sNamespaceMax-7)), testUID),
 	}}
 
 	for _, tc := range testCases {
@@ -92,12 +95,12 @@ func TestGenerateDecouplingSubscriptionName(t *testing.T) {
 		ns:   maxNamespace,
 		n:    maxName,
 		uid:  testUID,
-		want: fmt.Sprintf("cre-bkr_%s_%s_%s", maxNamespace, strings.Repeat("n", 146), testUID),
+		want: fmt.Sprintf("cre-bkr_%s_%s_%s", maxNamespace, strings.Repeat("n", truncatedNameMax), testUID),
 	}, {
 		ns:   "default",
 		n:    maxName,
 		uid:  testUID,
-		want: fmt.Sprintf("cre-bkr_default_%s_%s", strings.Repeat("n", 146+(k8sNamespaceMax-7)), testUID),
+		want: fmt.Sprintf("cre-bkr_default_%s_%s", strings.Repeat("n", truncatedNameMax+(k8sNamespaceMax-7)), testUID),
 	}}
 
 	for _, tc := range testCases {
@@ -131,12 +134,12 @@ func TestGenerateRetryTopicName(t *testing.T) {
 		ns:   maxNamespace,
 		n:    maxName,
 		uid:  testUID,
-		want: fmt.Sprintf("cre-tgr_%s_%s_%s", maxNamespace, strings.Repeat("n", 146), testUID),
+		want: fmt.Sprintf("cre-tgr_%s_%s_%s", maxNamespace, strings.Repeat("n", truncatedNameMax), testUID),
 	}, {
 		ns:   "default",
 		n:    maxName,
 		uid:  testUID,
-		want: fmt.Sprintf("cre-tgr_default_%s_%s", strings.Repeat("n", 146+(k8sNamespaceMax-7)), testUID),
+		want: fmt.Sprintf("cre-tgr_default_%s_%s", strings.Repeat("n", truncatedNameMax+(k8sNamespaceMax-7)), testUID),
 	}}
 
 	for _, tc := range testCases {
@@ -170,12 +173,12 @@ func TestGenerateRetrySubscriptionName(t *testing.T) {
 		ns:   maxNamespace,
 		n:    maxName,
 		uid:  testUID,
-		want: fmt.Sprintf("cre-tgr_%s_%s_%s", maxNamespace, strings.Repeat("n", 146), testUID),
+		want: fmt.Sprintf("cre-tgr_%s_%s_%s", maxNamespace, strings.Repeat("n", truncatedNameMax), testUID),
 	}, {
 		ns:   "default",
 		n:    maxName,
 		uid:  testUID,
-		want: fmt.Sprintf("cre-tgr_default_%s_%s", strings.Repeat("n", 146+(k8sNamespaceMax-7)), testUID),
+		want: fmt.Sprintf("cre-tgr_default_%s_%s", strings.Repeat("n", truncatedNameMax+(k8sNamespaceMax-7)), testUID),
 	}}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fixes #831
Supersedes #942

Since we append the UID to the resource name, there's no need to use a hashed truncate to guarantee uniqueness of the truncated name as in `kmeta.ChildName`.

## Proposed Changes

- Truncate pubsub resource names deterministically if they would be greater than 255 characters