### PR TITLE
Unpin k8s.io/gengo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ replace (
 	k8s.io/apimachinery => k8s.io/apimachinery v0.16.5-beta.1
 	k8s.io/client-go => k8s.io/client-go v0.16.4
 	k8s.io/code-generator => k8s.io/code-generator v0.16.5-beta.1
-	k8s.io/gengo => k8s.io/gengo v0.0.0-20190907103519-ebc107f98eab
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20190918143330-0270cf2f1c1d
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1219,8 +1219,12 @@ k8s.io/component-base v0.17.2/go.mod h1:zMPW3g5aH7cHJpKYQ/ZsGMcgbsA/VyhEugF3QT1a
 k8s.io/component-base v0.17.4/go.mod h1:5BRqHMbbQPm2kKu35v3G+CpVq4K0RJKC7TRioF0I9lE=
 k8s.io/csi-translation-lib v0.17.0/go.mod h1:HEF7MEz7pOLJCnxabi45IPkhSsE/KmxPQksuCrHKWls=
 k8s.io/csi-translation-lib v0.17.4/go.mod h1:CsxmjwxEI0tTNMzffIAcgR9lX4wOh6AKHdxQrT7L0oo=
-k8s.io/gengo v0.0.0-20190907103519-ebc107f98eab h1:j4L8spMe0tFfBvvW6lrc0c+Ql8+nnkcV3RYfi3eSwGY=
-k8s.io/gengo v0.0.0-20190907103519-ebc107f98eab/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20190306031000-7a1b7fb0289f/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20191108084044-e500ee069b5c/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20200205140755-e0e292d8aa12 h1:pZzawYyz6VRNPVYpqGv61LWCimQv1BihyeqFrp50/G4=
+k8s.io/gengo v0.0.0-20200205140755-e0e292d8aa12/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.1/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=

--- a/vendor/k8s.io/gengo/args/args.go
+++ b/vendor/k8s.io/gengo/args/args.go
@@ -112,7 +112,7 @@ func (g *GeneratorArgs) LoadGoBoilerplate() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	b = bytes.Replace(b, []byte("YEAR"), []byte(strconv.Itoa(time.Now().Year())), -1)
+	b = bytes.Replace(b, []byte("YEAR"), []byte(strconv.Itoa(time.Now().UTC().Year())), -1)
 
 	if g.GeneratedByCommentTemplate != "" {
 		if len(b) != 0 {
@@ -158,6 +158,9 @@ func (g *GeneratorArgs) InputIncludes(p *types.Package) bool {
 		d := dir
 		if strings.HasSuffix(d, "...") {
 			d = strings.TrimSuffix(d, "...")
+		}
+		if strings.HasPrefix(d, "./vendor/") {
+			d = strings.TrimPrefix(d, "./vendor/")
 		}
 		if strings.HasPrefix(p.Path, d) {
 			return true

--- a/vendor/k8s.io/gengo/generator/default_package.go
+++ b/vendor/k8s.io/gengo/generator/default_package.go
@@ -26,6 +26,8 @@ type DefaultPackage struct {
 	PackageName string
 	// Import path of the package, and the location on disk of the package.
 	PackagePath string
+	// The location of the package on disk.
+	Source string
 
 	// Emitted at the top of every file.
 	HeaderText []byte
@@ -43,8 +45,9 @@ type DefaultPackage struct {
 	FilterFunc func(*Context, *types.Type) bool
 }
 
-func (d *DefaultPackage) Name() string { return d.PackageName }
-func (d *DefaultPackage) Path() string { return d.PackagePath }
+func (d *DefaultPackage) Name() string       { return d.PackageName }
+func (d *DefaultPackage) Path() string       { return d.PackagePath }
+func (d *DefaultPackage) SourcePath() string { return d.Source }
 
 func (d *DefaultPackage) Filter(c *Context, t *types.Type) bool {
 	if d.FilterFunc != nil {

--- a/vendor/k8s.io/gengo/generator/execute.go
+++ b/vendor/k8s.io/gengo/generator/execute.go
@@ -233,11 +233,13 @@ func (c *Context) ExecutePackage(outDir string, p Package) error {
 		if f == nil {
 			// This is the first generator to reference this file, so start it.
 			f = &File{
-				Name:        g.Filename(),
-				FileType:    fileType,
-				PackageName: p.Name(),
-				Header:      p.Header(g.Filename()),
-				Imports:     map[string]struct{}{},
+				Name:              g.Filename(),
+				FileType:          fileType,
+				PackageName:       p.Name(),
+				PackagePath:       p.Path(),
+				PackageSourcePath: p.SourcePath(),
+				Header:            p.Header(g.Filename()),
+				Imports:           map[string]struct{}{},
 			}
 			files[f.Name] = f
 		} else {

--- a/vendor/k8s.io/gengo/generator/transitive_closure.go
+++ b/vendor/k8s.io/gengo/generator/transitive_closure.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generator
+
+import "sort"
+
+type edge struct {
+	from string
+	to   string
+}
+
+func transitiveClosure(in map[string][]string) map[string][]string {
+	adj := make(map[edge]bool)
+	imports := make(map[string]struct{})
+	for from, tos := range in {
+		for _, to := range tos {
+			adj[edge{from, to}] = true
+			imports[to] = struct{}{}
+		}
+	}
+
+	// Warshal's algorithm
+	for k := range in {
+		for i := range in {
+			if !adj[edge{i, k}] {
+				continue
+			}
+			for j := range imports {
+				if adj[edge{i, j}] {
+					continue
+				}
+				if adj[edge{k, j}] {
+					adj[edge{i, j}] = true
+				}
+			}
+		}
+	}
+
+	out := make(map[string][]string, len(in))
+	for i := range in {
+		for j := range imports {
+			if adj[edge{i, j}] {
+				out[i] = append(out[i], j)
+			}
+		}
+
+		sort.Strings(out[i])
+	}
+
+	return out
+}

--- a/vendor/k8s.io/gengo/namer/order.go
+++ b/vendor/k8s.io/gengo/namer/order.go
@@ -43,6 +43,9 @@ func (o *Orderer) OrderUniverse(u types.Universe) []*types.Type {
 		for _, v := range p.Variables {
 			list.types = append(list.types, v)
 		}
+		for _, v := range p.Constants {
+			list.types = append(list.types, v)
+		}
 	}
 	sort.Sort(list)
 	return list.types

--- a/vendor/k8s.io/gengo/namer/plural_namer.go
+++ b/vendor/k8s.io/gengo/namer/plural_namer.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/gengo/types"
 )
 
-var consonants = "bcdfghjklmnpqrsttvwxyz"
+var consonants = "bcdfghjklmnpqrstvwxyz"
 
 type pluralNamer struct {
 	// key is the case-sensitive type name, value is the case-insensitive

--- a/vendor/k8s.io/gengo/parser/parse.go
+++ b/vendor/k8s.io/gengo/parser/parse.go
@@ -28,6 +28,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -227,12 +228,16 @@ func (b *Builder) AddDirRecursive(dir string) error {
 		klog.Warningf("Ignoring directory %v: %v", dir, err)
 	}
 
-	// filepath.Walk includes the root dir, but we already did that, so we'll
-	// remove that prefix and rebuild a package import path.
-	prefix := b.buildPackages[dir].Dir
+	// filepath.Walk does not follow symlinks. We therefore evaluate symlinks and use that with
+	// filepath.Walk.
+	realPath, err := filepath.EvalSymlinks(b.buildPackages[dir].Dir)
+	if err != nil {
+		return err
+	}
+
 	fn := func(filePath string, info os.FileInfo, err error) error {
 		if info != nil && info.IsDir() {
-			rel := filepath.ToSlash(strings.TrimPrefix(filePath, prefix))
+			rel := filepath.ToSlash(strings.TrimPrefix(filePath, realPath))
 			if rel != "" {
 				// Make a pkg path.
 				pkg := path.Join(string(canonicalizeImportPath(b.buildPackages[dir].ImportPath)), rel)
@@ -245,7 +250,7 @@ func (b *Builder) AddDirRecursive(dir string) error {
 		}
 		return nil
 	}
-	if err := filepath.Walk(b.buildPackages[dir].Dir, fn); err != nil {
+	if err := filepath.Walk(realPath, fn); err != nil {
 		return err
 	}
 	return nil
@@ -330,6 +335,12 @@ func (b *Builder) addDir(dir string, userRequested bool) error {
 	return nil
 }
 
+var regexErrPackageNotFound = regexp.MustCompile(`^unable to import ".*?": cannot find package ".*?" in any of:`)
+
+func isErrPackageNotFound(err error) bool {
+	return regexErrPackageNotFound.MatchString(err.Error())
+}
+
 // importPackage is a function that will be called by the type check package when it
 // needs to import a go package. 'path' is the import path.
 func (b *Builder) importPackage(dir string, userRequested bool) (*tc.Package, error) {
@@ -352,6 +363,11 @@ func (b *Builder) importPackage(dir string, userRequested bool) (*tc.Package, er
 
 		// Add it.
 		if err := b.addDir(dir, userRequested); err != nil {
+			if isErrPackageNotFound(err) {
+				klog.V(6).Info(err)
+				return nil, nil
+			}
+
 			return nil, err
 		}
 
@@ -543,6 +559,10 @@ func (b *Builder) findTypesIn(pkgPath importPathString, u *types.Universe) error
 		tv, ok := obj.(*tc.Var)
 		if ok && !tv.IsField() {
 			b.addVariable(*u, nil, tv)
+		}
+		tconst, ok := obj.(*tc.Const)
+		if ok {
+			b.addConstant(*u, nil, tconst)
 		}
 	}
 
@@ -742,7 +762,10 @@ func (b *Builder) walkType(u types.Universe, useName *types.Name, in tc.Type) *t
 			if out.Methods == nil {
 				out.Methods = map[string]*types.Type{}
 			}
-			out.Methods[t.Method(i).Name()] = b.walkType(u, nil, t.Method(i).Type())
+			method := t.Method(i)
+			mt := b.walkType(u, nil, method.Type())
+			mt.CommentLines = splitLines(b.priorCommentLines(method.Pos(), 1).Text())
+			out.Methods[method.Name()] = mt
 		}
 		return out
 	case *tc.Named:
@@ -774,7 +797,10 @@ func (b *Builder) walkType(u types.Universe, useName *types.Name, in tc.Type) *t
 				if out.Methods == nil {
 					out.Methods = map[string]*types.Type{}
 				}
-				out.Methods[t.Method(i).Name()] = b.walkType(u, nil, t.Method(i).Type())
+				method := t.Method(i)
+				mt := b.walkType(u, nil, method.Type())
+				mt.CommentLines = splitLines(b.priorCommentLines(method.Pos(), 1).Text())
+				out.Methods[method.Name()] = mt
 			}
 		}
 		return out
@@ -806,6 +832,17 @@ func (b *Builder) addVariable(u types.Universe, useName *types.Name, in *tc.Var)
 		name = *useName
 	}
 	out := u.Variable(name)
+	out.Kind = types.DeclarationOf
+	out.Underlying = b.walkType(u, nil, in.Type())
+	return out
+}
+
+func (b *Builder) addConstant(u types.Universe, useName *types.Name, in *tc.Const) *types.Type {
+	name := tcVarNameToName(in.String())
+	if useName != nil {
+		name = *useName
+	}
+	out := u.Constant(name)
 	out.Kind = types.DeclarationOf
 	out.Underlying = b.walkType(u, nil, in.Type())
 	return out

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -924,7 +924,7 @@ k8s.io/code-generator/cmd/set-gen
 k8s.io/code-generator/pkg/namer
 k8s.io/code-generator/pkg/util
 k8s.io/code-generator/third_party/forked/golang/reflect
-# k8s.io/gengo v0.0.0-20200205140755-e0e292d8aa12 => k8s.io/gengo v0.0.0-20190907103519-ebc107f98eab
+# k8s.io/gengo v0.0.0-20200205140755-e0e292d8aa12
 k8s.io/gengo/args
 k8s.io/gengo/examples/deepcopy-gen/generators
 k8s.io/gengo/examples/defaulter-gen/generators


### PR DESCRIPTION
Updates gengo to v0.0.0-20200205140755-e0e292d8aa12.

knative.dev/pkg requires a newer gengo so unpinning the version is necessary to provide consistent codegen results. Unlike other k8s.io packages, gengo should not need to be pinned to a kubernetes version.