### PR TITLE
Register stats in NewStatsReporter instead of init

### DIFF
--- a/cmd/broker/ingress/wire_gen.go
+++ b/cmd/broker/ingress/wire_gen.go
@@ -29,7 +29,10 @@ func InitializeHandler(ctx context.Context, port ingress.Port, projectID ingress
 		return nil, err
 	}
 	multiTopicDecoupleSink := ingress.NewMultiTopicDecoupleSink(ctx, readonlyTargets, clientClient)
-	statsReporter := ingress.NewStatsReporter(podName, containerName2)
+	statsReporter, err := ingress.NewStatsReporter(podName, containerName2)
+	if err != nil {
+		return nil, err
+	}
 	handler := ingress.NewHandler(ctx, httpMessageReceiver, multiTopicDecoupleSink, statsReporter)
 	return handler, nil
 }

--- a/pkg/broker/ingress/handler_test.go
+++ b/pkg/broker/ingress/handler_test.go
@@ -327,7 +327,12 @@ func createAndStartIngress(ctx context.Context, t *testing.T, psSrv *pstest.Serv
 	decouple := NewMultiTopicDecoupleSink(ctx, memory.NewTargets(brokerConfig), client)
 
 	receiver := &testHttpMessageReceiver{urlCh: make(chan string)}
-	h := NewHandler(ctx, receiver, decouple, NewStatsReporter(PodName(pod), ContainerName(container)))
+	statsReporter, err := NewStatsReporter(PodName(pod), ContainerName(container))
+	if err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	h := NewHandler(ctx, receiver, decouple, statsReporter)
 
 	errCh := make(chan error, 1)
 	go func() {

--- a/pkg/broker/ingress/stats_reporter.go
+++ b/pkg/broker/ingress/stats_reporter.go
@@ -19,7 +19,6 @@ package ingress
 import (
 	"context"
 	"fmt"
-	"log"
 	"strconv"
 	"time"
 
@@ -36,14 +35,6 @@ import (
 // - Removed StatsReporter interface and directly use helper methods instead.
 
 var (
-	// dispatchTimeInMsecM records the time spent dispatching an event to
-	// a decouple queue, in milliseconds.
-	dispatchTimeInMsecM = stats.Float64(
-		"event_dispatch_latencies",
-		"The time spent dispatching an event to the decouple topic",
-		stats.UnitMilliseconds,
-	)
-
 	// Create the tag keys that will be used to add tags to our measurements.
 	// Tag keys must conform to the restrictions described in
 	// go.opencensus.io/tag/validate.go. Currently those restrictions are:
@@ -68,11 +59,7 @@ type reportArgs struct {
 	responseCode int
 }
 
-func init() {
-	register()
-}
-
-func register() {
+func (r *StatsReporter) register() error {
 	tagKeys := []tag.Key{
 		namespaceKey,
 		brokerKey,
@@ -84,39 +71,48 @@ func register() {
 	}
 
 	// Create view to see our measurements.
-	err := view.Register(
+	return view.Register(
 		&view.View{
 			Name:        "event_count",
 			Description: "Number of events received by a Broker",
-			Measure:     dispatchTimeInMsecM,
+			Measure:     r.dispatchTimeInMsecM,
 			Aggregation: view.Count(),
 			TagKeys:     tagKeys,
 		},
 		&view.View{
-			Name:        dispatchTimeInMsecM.Name(),
-			Description: dispatchTimeInMsecM.Description(),
-			Measure:     dispatchTimeInMsecM,
+			Name:        r.dispatchTimeInMsecM.Name(),
+			Description: r.dispatchTimeInMsecM.Description(),
+			Measure:     r.dispatchTimeInMsecM,
 			Aggregation: view.Distribution(metrics.Buckets125(1, 10000)...), // 1, 2, 5, 10, 20, 50, 100, 500, 1000, 5000, 10000
 			TagKeys:     tagKeys,
 		},
 	)
-	if err != nil {
-		log.Fatalf("failed to register opencensus views, %s", err)
-	}
 }
 
 // NewStatsReporter creates a new StatsReporter.
-func NewStatsReporter(podName PodName, containerName ContainerName) *StatsReporter {
-	return &StatsReporter{
+func NewStatsReporter(podName PodName, containerName ContainerName) (*StatsReporter, error) {
+	r := &StatsReporter{
 		podName:       podName,
 		containerName: containerName,
+		dispatchTimeInMsecM: stats.Float64(
+			"event_dispatch_latencies",
+			"The time spent dispatching an event to the decouple topic",
+			stats.UnitMilliseconds,
+		),
 	}
+	if err := r.register(); err != nil {
+		return nil, fmt.Errorf("failed to register ingress stats: %w", err)
+	}
+	return r, nil
 }
 
 // StatsReporter reports ingress metrics.
 type StatsReporter struct {
 	podName       PodName
 	containerName ContainerName
+	// dispatchTimeInMsecM records the time spent dispatching an event to a decouple queue, in
+	// milliseconds.
+	dispatchTimeInMsecM *stats.Float64Measure
 }
 
 func (r *StatsReporter) reportEventDispatchTime(ctx context.Context, args reportArgs, d time.Duration) error {
@@ -134,6 +130,6 @@ func (r *StatsReporter) reportEventDispatchTime(ctx context.Context, args report
 		return fmt.Errorf("failed to create metrics tag: %v", err)
 	}
 	// convert time.Duration in nanoseconds to milliseconds.
-	metrics.Record(tag, dispatchTimeInMsecM.M(float64(d/time.Millisecond)))
+	metrics.Record(tag, r.dispatchTimeInMsecM.M(float64(d/time.Millisecond)))
 	return nil
 }

--- a/pkg/broker/ingress/stats_reporter_test.go
+++ b/pkg/broker/ingress/stats_reporter_test.go
@@ -44,7 +44,10 @@ func TestStatsReporter(t *testing.T) {
 		metricskey.PodName:                "testpod",
 	}
 
-	r := NewStatsReporter(PodName("testpod"), ContainerName("testcontainer"))
+	r, err := NewStatsReporter(PodName("testpod"), ContainerName("testcontainer"))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// test ReportDispatchTime
 	expectSuccess(t, func() error {
@@ -59,10 +62,7 @@ func TestStatsReporter(t *testing.T) {
 
 func resetMetrics() {
 	// OpenCensus metrics carry global state that need to be reset between unit tests.
-	metricstest.Unregister(
-		"event_count",
-		"event_dispatch_latencies")
-	register()
+	metricstest.Unregister("event_count", "event_dispatch_latencies")
 }
 
 func expectSuccess(t *testing.T, f func() error) {


### PR DESCRIPTION
Puts the latency measure inside of the stats reporter struct instead of a global variable and registers stats in NewStatsReporter instead of in init().