### PR TITLE
Configure gcp broker test infra to support checking metrics

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -311,5 +311,5 @@ func TestCloudSchedulerSourceWithTargetTestImpl(t *testing.T) {
 func TestGCPBroker(t *testing.T) {
 	cancel := logstream.Start(t)
 	defer cancel()
-	GCPBrokerTestImpl(t, authConfig)
+	GCPBrokerTestImpl(t, false, authConfig)
 }

--- a/test/e2e/test_gcp_broker.go
+++ b/test/e2e/test_gcp_broker.go
@@ -50,12 +50,16 @@ PubSubWithBrokerTestImpl tests the following scenario:
 Note: the number denotes the sequence of the event that flows in this test case.
 */
 
-func GCPBrokerTestImpl(t *testing.T, authConfig lib.AuthConfig) {
+func GCPBrokerTestImpl(t *testing.T, assertMetrics bool, authConfig lib.AuthConfig) {
 	senderName := helpers.AppendRandomString("sender")
 	targetName := helpers.AppendRandomString("target")
 
 	client := lib.Setup(t, true, authConfig.WorkloadIdentity)
 	defer lib.TearDown(client)
+
+	if assertMetrics {
+		client.SetupStackDriverMetrics(t)
+	}
 
 	// Create a target Job to receive the events.
 	makeTargetJobOrDie(client, targetName)
@@ -81,6 +85,10 @@ func GCPBrokerTestImpl(t *testing.T, authConfig lib.AuthConfig) {
 	if done := jobDone(client, targetName, t); !done {
 		t.Error("resp event didn't hit the target pod")
 		t.Failed()
+	}
+	
+	if assertMetrics {
+		lib.AssertBrokerMetrics(t, client)
 	}
 }
 


### PR DESCRIPTION
Progress towards #317

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add flag to GCP Broker test implementation to enable checking metrics. Currently not used in this repo because metrics don't work without patching the implementation. 

