### PR TITLE
Broker tracing conventions

### DIFF
--- a/cmd/broker/fanout/wire_gen.go
+++ b/cmd/broker/fanout/wire_gen.go
@@ -45,6 +45,6 @@ func InitializeSyncPool(ctx context.Context, projectID pool.ProjectID, targetsVo
 }
 
 var (
-	_wireValue  = []http.Option(nil)
+	_wireValue  = pool.DefaultHTTPOpts
 	_wireValue2 = pool.DefaultCEClientOpts
 )

--- a/cmd/broker/retry/wire_gen.go
+++ b/cmd/broker/retry/wire_gen.go
@@ -41,6 +41,6 @@ func InitializeSyncPool(ctx context.Context, projectID pool.ProjectID, targetsVo
 }
 
 var (
-	_wireValue  = []http.Option(nil)
+	_wireValue  = pool.DefaultHTTPOpts
 	_wireValue2 = pool.DefaultCEClientOpts
 )

--- a/pkg/broker/handler/pool/providers.go
+++ b/pkg/broker/handler/pool/providers.go
@@ -24,6 +24,8 @@ import (
 	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	cepubsub "github.com/cloudevents/sdk-go/v2/protocol/pubsub"
 	"github.com/google/wire"
+	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
 )
 
 var (
@@ -31,6 +33,10 @@ var (
 		ceclient.WithUUIDs(),
 		ceclient.WithTimeNow(),
 		ceclient.WithTracePropagation(),
+	}
+
+	DefaultHTTPOpts = []cehttp.Option{
+		cehttp.WithRoundTripper(&ochttp.Transport{Propagation: &tracecontext.HTTPFormat{}}),
 	}
 
 	// ProviderSet provides the fanout and retry sync pools using the default client options. In
@@ -43,7 +49,7 @@ var (
 		NewDeliverClient,
 		NewPubsubClient,
 		NewRetryClient,
-		wire.Value([]cehttp.Option(nil)),
+		wire.Value(DefaultHTTPOpts),
 		wire.Value(DefaultCEClientOpts),
 	)
 )

--- a/pkg/broker/handler/processors/filter/processor.go
+++ b/pkg/broker/handler/processors/filter/processor.go
@@ -18,17 +18,19 @@ package filter
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/cloudevents/sdk-go/v2/extensions"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/eventing/pkg/logging"
+	kntracing "knative.dev/eventing/pkg/tracing"
 
 	"github.com/google/knative-gcp/pkg/broker/config"
 	handlerctx "github.com/google/knative-gcp/pkg/broker/handler/context"
 	"github.com/google/knative-gcp/pkg/broker/handler/processors"
+	"github.com/google/knative-gcp/pkg/tracing"
 )
 
 // Processor is the processor to filter events based on trigger filters.
@@ -55,10 +57,24 @@ func (p *Processor) Process(ctx context.Context, event *event.Event) error {
 		return nil
 	}
 
+	trigger := types.NamespacedName{
+		Namespace: target.Namespace,
+		Name:      target.Name,
+	}
+	var span *trace.Span
 	if dt, ok := extensions.GetDistributedTracingExtension(*event); ok {
-		var span *trace.Span
-		ctx, span = dt.StartChildSpan(ctx, fmt.Sprintf("trigger:%s.%s", target.Name, target.Namespace))
-		defer span.End()
+		ctx, span = dt.StartChildSpan(ctx, kntracing.TriggerMessagingDestination(trigger))
+	} else {
+		ctx, span = trace.StartSpan(ctx, kntracing.TriggerMessagingDestination(trigger))
+	}
+	defer span.End()
+	if span.IsRecordingEvents() {
+		span.AddAttributes(
+			kntracing.MessagingSystemAttribute,
+			tracing.PubSubProtocolAttribute,
+			kntracing.TriggerMessagingDestinationAttribute(trigger),
+			kntracing.MessagingMessageIDAttribute(event.ID()),
+		)
 	}
 
 	if target.FilterAttributes == nil {

--- a/pkg/broker/ingress/handler.go
+++ b/pkg/broker/ingress/handler.go
@@ -38,8 +38,6 @@ import (
 	"knative.dev/eventing/pkg/kncloudevents"
 	"knative.dev/eventing/pkg/logging"
 	kntracing "knative.dev/eventing/pkg/tracing"
-
-	_ "knative.dev/pkg/metrics/testing"
 )
 
 const (

--- a/pkg/broker/ingress/handler_test.go
+++ b/pkg/broker/ingress/handler_test.go
@@ -45,6 +45,8 @@ import (
 	logtest "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/metrics/metricskey"
 	"knative.dev/pkg/metrics/metricstest"
+
+	_ "knative.dev/pkg/metrics/testing"
 )
 
 const (

--- a/pkg/tracing/attributes.go
+++ b/pkg/tracing/attributes.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 Google LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import "knative.dev/eventing/pkg/tracing"
+
+const (
+	PubSubProtocol = "Pub/Sub"
+)
+
+var (
+	PubSubProtocolAttribute = tracing.MessagingProtocolAttribute(PubSubProtocol)
+)


### PR DESCRIPTION
Fixes #1063

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Emit Broker Ingress and Trigger Spans.
- Add the messaging.system, messaging.protocol, messaging.destination, and messaging.id attributes as specified in https://github.com/knative/eventing/blob/master/docs/spec/broker.md.

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🎁 The GCP Broker now emits broker and trigger trace spans named broker:<name>.<namespace> and trigger:<name>.<namespace> respectively.
```

