### PR TITLE
Fixes to performance tests

### DIFF
--- a/test/performance/benchmarks/broker-pubsub/continuous/200-broker-pubsub.yaml
+++ b/test/performance/benchmarks/broker-pubsub/continuous/200-broker-pubsub.yaml
@@ -111,7 +111,7 @@ spec:
                 mountPath: /etc/config-mako
             terminationMessagePolicy: FallbackToLogsOnError
           - name: mako
-            image: gcr.io/knative-performance/mako-microservice:latest
+            image: gcr.io/knative-tests/test-infra/mako-microservice:latest
             env:
               - name: GOOGLE_APPLICATION_CREDENTIALS
                 value: /var/secret/robot.json

--- a/test/performance/benchmarks/channel-pubsub/continuous/200-channel-perf.yaml
+++ b/test/performance/benchmarks/channel-pubsub/continuous/200-channel-perf.yaml
@@ -111,7 +111,7 @@ spec:
                 mountPath: /etc/config-mako
             terminationMessagePolicy: FallbackToLogsOnError
           - name: mako
-            image: gcr.io/knative-performance/mako-microservice:latest
+            image: gcr.io/knative-tests/test-infra/mako-microservice:latest
             env:
               - name: GOOGLE_APPLICATION_CREDENTIALS
                 value: /var/secret/robot.json

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -62,6 +62,12 @@ function update_benchmark() {
   echo ">> Updating benchmark $1"
   ko delete -f "${benchmark_path}"/${TEST_CONFIG_VARIANT} --ignore-not-found=true --wait=false
   sleep 30
+
+  # Add Git info in kodata so the benchmark can show which commit it's running on.
+  local kodata_path="vendor/knative.dev/eventing/test/test_images/performance/kodata"
+  mkdir "${kodata_path}"
+  ln -s "${REPO_ROOT_DIR}/.git/HEAD" "${kodata_path}"
+  ln -s "${REPO_ROOT_DIR}/.git/refs" "${kodata_path}"
   ko apply --strict -f "${benchmark_path}"/${TEST_CONFIG_VARIANT} || abort "failed to apply benchmark $1"
 
   echo "Sleeping 2 min to wait for all resources to setup"


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- Go modules does not allow vendor symlinks, so add symlink for Git info in `kodata` in setup so the benchmark container can find them
- Replace with `gcr.io/knative-tests/test-infra/mako-microservice:latest` so we have a central point to maintain the image.

Note after this change, the benchmark still fails, and the error message in broker and channel is
```
'Failed to reconcile Publisher: Topic "cre-pubsub-kne-trigger-chan" does
      not own publisher service: "cre-pubsub-kne-trigger-chan-publish"'
```
It must be due to some changes that I'm not aware of, so someone that has the context needs to fix it.

/cc @grantr 
