### PR TITLE
Give the receiver time to shutdown before stopping the knockdown process.

### DIFF
--- a/test/e2e/lib/auditlogs.go
+++ b/test/e2e/lib/auditlogs.go
@@ -69,7 +69,7 @@ func MakeAuditLogsJobOrDie(client *Client, methodName, project, resourceName, se
 		Value: resourceName,
 	}, {
 		Name:  "TIME",
-		Value: "360",
+		Value: "6m",
 	}})
 	client.CreateJobOrFail(job, WithServiceForJob(targetName))
 }

--- a/test/e2e/lib/scheduler.go
+++ b/test/e2e/lib/scheduler.go
@@ -45,7 +45,7 @@ func MakeSchedulerJobOrDie(client *Client, data, targetName string) {
 	job := resources.SchedulerJob(targetName, []v1.EnvVar{
 		{
 			Name:  "TIME",
-			Value: "360",
+			Value: "6m",
 		},
 		{
 			Name:  "SUBJECT_PREFIX",

--- a/test/e2e/lib/storage.go
+++ b/test/e2e/lib/storage.go
@@ -49,7 +49,7 @@ func MakeStorageJobOrDie(client *Client, fileName, targetName string) {
 		Value: fileName,
 	}, {
 		Name:  "TIME",
-		Value: "120",
+		Value: "2m",
 	}})
 	client.CreateJobOrFail(job, WithServiceForJob(targetName))
 }

--- a/test/test_images/auditlogs_target/main.go
+++ b/test/test_images/auditlogs_target/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/google/knative-gcp/test/test_images/internal/knockdown"
@@ -36,6 +37,10 @@ const (
 )
 
 func main() {
+	os.Exit(mainWithExitCode())
+}
+
+func mainWithExitCode() int {
 	r := &auditLogReceiver{}
 	if err := envconfig.Process("", &r); err != nil {
 		panic(err)
@@ -48,7 +53,7 @@ func main() {
 	fmt.Printf("Source to match: %q.\n", r.Source)
 	fmt.Printf("Subject to match: %q.\n", r.Subject)
 
-	knockdown.Main(r.Config, r)
+	return knockdown.Main(r.Config, r)
 }
 
 type auditLogReceiver struct {

--- a/test/test_images/auditlogs_target/main.go
+++ b/test/test_images/auditlogs_target/main.go
@@ -42,7 +42,7 @@ func main() {
 
 func mainWithExitCode() int {
 	r := &auditLogReceiver{}
-	if err := envconfig.Process("", &r); err != nil {
+	if err := envconfig.Process("", r); err != nil {
 		panic(err)
 	}
 

--- a/test/test_images/internal/knockdown/knockdown.go
+++ b/test/test_images/internal/knockdown/knockdown.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go"
@@ -40,9 +39,9 @@ type Config struct {
 	Time time.Duration `envconfig:"TIME" required:"true"`
 }
 
-// Main should be called by the process' main function. It will run the knockdown test. It will not
-// return. Instead, it will call os.Exit.
-func Main(config Config, kdr Receiver) {
+// Main should be called by the process' main function. It will run the knockdown test. The return
+// value MUST be used in os.Exit().
+func Main(config Config, kdr Receiver) int {
 	client, err := cloudevents.NewDefaultClient()
 	if err != nil {
 		panic(err)
@@ -75,7 +74,7 @@ func Main(config Config, kdr Receiver) {
 		log.Fatal(err)
 	}
 
-	os.Exit(0)
+	return 0
 }
 
 type receiver struct {

--- a/test/test_images/internal/knockdown/knockdown.go
+++ b/test/test_images/internal/knockdown/knockdown.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2019 Google LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package knockdown
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go"
+)
+
+// Config is a common envconfig filled struct that includes the common options for knockdown
+// testing. It is expected that knockdown tests will embed this struct in their configuration
+// struct.
+// E.g.
+// type FooKnockdownConfig {
+//     knockdown.Config
+//     FooProperty string `envconfig:...`
+// }
+type Config struct {
+	Time time.Duration `envconfig:"TIME" required:"true"`
+}
+
+// cancel will cancel the main receiver's context. Calling this will cause Main() to become
+// unblocked and call os.Exit(0). In general, write{Successful,Failed}TerminationMessage should be
+// called first.
+var cancel func()
+
+// Main should be called by the process' main function. It will run the knockdown test. It will not
+// return. Instead, it will call os.Exit.
+func Main(config Config, kdr Receiver) {
+	client, err := cloudevents.NewDefaultClient()
+	if err != nil {
+		panic(err)
+	}
+
+	r := receiver{
+		kdr: kdr,
+	}
+
+	var ctx context.Context
+	ctx, cancel = context.WithCancel(context.Background())
+
+	timer := time.NewTimer(config.Time)
+	defer timer.Stop()
+	go func() {
+		<-timer.C
+		// Write the termination message if time out
+		fmt.Printf("Time out waiting for the knock down event(s).")
+		if err := r.writeFailedTerminationMessage(); err != nil {
+			fmt.Printf("Failed to write termination message, %v\n", err)
+		}
+		cancel()
+	}()
+
+	fmt.Printf("Waiting to receive event (timeout in %s)...", config.Time.String())
+
+	// Note, we assume that closing the context will gracefully shutdown the receiver. Having looked
+	// at the current implementation, this is true. But nothing guarantees it in the future.
+	if err := client.StartReceiver(ctx, r.Receive); err != nil {
+		log.Fatal(err)
+	}
+
+	os.Exit(0)
+}
+
+type receiver struct {
+	kdr Receiver
+}
+
+type Receiver interface {
+	Knockdown(event cloudevents.Event) bool
+}
+
+func (r *receiver) Receive(event cloudevents.Event) {
+	done := r.kdr.Knockdown(event)
+	if done {
+		if err := r.writeSuccessfulTerminationMessage(); err != nil {
+			fmt.Printf("Failed to write termination message, %s.\n", err.Error())
+		}
+		cancel()
+		return
+	}
+	fmt.Printf("Event did not knockdown the process.")
+}
+
+// writeSuccessfulTerminationMessage should be called to indicate this knock down process received
+// all the expected events.
+func (r *receiver) writeSuccessfulTerminationMessage() error {
+	return r.writeTerminationMessage(map[string]interface{}{
+		"success": true,
+	})
+}
+
+// writeFailedTerminationMessage should be called to indicate this knock down process did not
+// receive all the expected events.
+func (r *receiver) writeFailedTerminationMessage() error {
+	return r.writeTerminationMessage(map[string]interface{}{
+		"success": false,
+	})
+}
+
+// writeTerminationMessage writes the given result to the termination file, which is read by the e2e
+// test framework to determine if this Pod received all the expected knockdown events.
+func (r *receiver) writeTerminationMessage(result interface{}) error {
+	b, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile("/dev/termination-log", b, 0644)
+}

--- a/test/test_images/scheduler_target/main.go
+++ b/test/test_images/scheduler_target/main.go
@@ -1,17 +1,11 @@
 package main
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"log"
-	"os"
-	"strconv"
 	"strings"
-	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/google/knative-gcp/test/test_images/internal/knockdown"
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -21,50 +15,18 @@ const (
 	eventType    = "type"
 )
 
-var shutDown = make(chan struct{}, 1)
-
 func main() {
-	client, err := cloudevents.NewDefaultClient()
-	if err != nil {
-		panic(err)
-	}
-
-	r := Receiver{}
+	r := &Receiver{}
 	if err := envconfig.Process("", &r); err != nil {
 		panic(err)
 	}
 
-	fmt.Printf("Waiting to receive event (timeout in %s seconds)...", r.Time)
-
-	duration, _ := strconv.Atoi(r.Time)
-	timer := time.NewTimer(time.Second * time.Duration(duration))
-	defer timer.Stop()
-
-	go func() {
-		select {
-		case <-shutDown:
-			// Give the receiver a little time to finish responding.
-			time.Sleep(time.Second)
-			os.Exit(0)
-		case <-timer.C:
-			// Write the termination message if time out occurred
-			fmt.Println("Timed out waiting for event from scheduler")
-			if err := r.writeTerminationMessage(map[string]interface{}{
-				"shutDown": false,
-			}); err != nil {
-				fmt.Println("Failed to write termination message, got error:", err.Error())
-			}
-			os.Exit(0)
-		}
-	}()
-
-	if err := client.StartReceiver(context.Background(), r.Receive); err != nil {
-		log.Fatal(err)
-	}
+	knockdown.Main(r.Config, r)
 }
 
 type Receiver struct {
-	Time          string `envconfig:"TIME" required:"true"`
+	knockdown.Config
+
 	SubjectPrefix string `envconfig:"SUBJECT_PREFIX" required:"true"`
 	Data          string `envconfig:"DATA" required:"true"`
 	EventType     string `envconfig:"TYPE" required:"true"`
@@ -75,7 +37,7 @@ type propPair struct {
 	received string
 }
 
-func (r *Receiver) Receive(event cloudevents.Event) {
+func (r *Receiver) Knockdown(event cloudevents.Event) bool {
 	// Print out event received to log
 	fmt.Printf("Received event\n")
 	fmt.Printf("	Context: %v\n", event.Context.String())
@@ -104,33 +66,14 @@ func (r *Receiver) Receive(event cloudevents.Event) {
 	}
 
 	if len(incorrectAttributes) == 0 {
-		// Write the termination message.
-		if err := r.writeTerminationMessage(map[string]interface{}{
-			"success": true,
-		}); err != nil {
-			fmt.Printf("failed to write termination message, %s.\n", err)
-		}
-	} else {
-		if err := r.writeTerminationMessage(map[string]interface{}{
-			"success": false,
-		}); err != nil {
-			fmt.Printf("failed to write termination message, %s.\n", err)
-		}
-		for k, v := range incorrectAttributes {
-			if k == eventSubject {
-				fmt.Println(v.received, "did not have expected prefix", v.expected)
-			} else {
-				fmt.Println(k, "expected:", v.expected, "got:", v.received)
-			}
+		return true
+	}
+	for k, v := range incorrectAttributes {
+		if k == eventSubject {
+			fmt.Println(v.received, "did not have expected prefix", v.expected)
+		} else {
+			fmt.Println(k, "expected:", v.expected, "got:", v.received)
 		}
 	}
-	shutDown <- struct{}{}
-}
-
-func (r *Receiver) writeTerminationMessage(result interface{}) error {
-	b, err := json.Marshal(result)
-	if err != nil {
-		return err
-	}
-	return ioutil.WriteFile("/dev/termination-log", b, 0644)
+	return false
 }

--- a/test/test_images/scheduler_target/main.go
+++ b/test/test_images/scheduler_target/main.go
@@ -22,7 +22,7 @@ func main() {
 
 func mainWithExitCode() int {
 	r := &Receiver{}
-	if err := envconfig.Process("", &r); err != nil {
+	if err := envconfig.Process("", r); err != nil {
 		panic(err)
 	}
 

--- a/test/test_images/scheduler_target/main.go
+++ b/test/test_images/scheduler_target/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	cloudevents "github.com/cloudevents/sdk-go"
@@ -16,12 +17,16 @@ const (
 )
 
 func main() {
+	os.Exit(mainWithExitCode())
+}
+
+func mainWithExitCode() int {
 	r := &Receiver{}
 	if err := envconfig.Process("", &r); err != nil {
 		panic(err)
 	}
 
-	knockdown.Main(r.Config, r)
+	return knockdown.Main(r.Config, r)
 }
 
 type Receiver struct {

--- a/test/test_images/storage_target/main.go
+++ b/test/test_images/storage_target/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/google/knative-gcp/test/test_images/internal/knockdown"
@@ -9,12 +10,16 @@ import (
 )
 
 func main() {
+	os.Exit(mainWithExitCode())
+}
+
+func mainWithExitCode() int {
 	r := &Receiver{}
 	if err := envconfig.Process("", &r); err != nil {
 		panic(err)
 	}
 
-	knockdown.Main(r.Config, r)
+	return knockdown.Main(r.Config, r)
 }
 
 type Receiver struct {

--- a/test/test_images/storage_target/main.go
+++ b/test/test_images/storage_target/main.go
@@ -1,87 +1,33 @@
 package main
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"log"
-	"os"
-	"strconv"
-	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/google/knative-gcp/test/test_images/internal/knockdown"
 	"github.com/kelseyhightower/envconfig"
 )
 
-var shutDown = make(chan struct{}, 1)
-
 func main() {
-	client, err := cloudevents.NewDefaultClient()
-	if err != nil {
-		panic(err)
-	}
-
-	r := Receiver{}
+	r := &Receiver{}
 	if err := envconfig.Process("", &r); err != nil {
 		panic(err)
 	}
 
-	fmt.Printf("Subject to match: %q.\n", r.Subject)
-
-	// Create a timer
-	duration, _ := strconv.Atoi(r.Time)
-	timer := time.NewTimer(time.Second * time.Duration(duration))
-	defer timer.Stop()
-	go func() {
-		select {
-		case <-shutDown:
-			// Give the reciever a little time to finish.
-			time.Sleep(time.Second)
-			os.Exit(0)
-		case <-timer.C:
-			// Write the termination message if time out
-			fmt.Printf("time out to wait for event with subject %q.\n", r.Subject)
-			if err := r.writeTerminationMessage(map[string]interface{}{
-				"success": false,
-			}); err != nil {
-				fmt.Printf("failed to write termination message, %s.\n", err.Error())
-			}
-			os.Exit(0)
-		}
-	}()
-
-	if err := client.StartReceiver(context.Background(), r.Receive); err != nil {
-		log.Fatal(err)
-	}
+	knockdown.Main(r.Config, r)
 }
 
 type Receiver struct {
+	knockdown.Config
+
 	Subject string `envconfig:"SUBJECT" required:"true"`
-	Time    string `envconfig:"TIME" required:"true"`
 }
 
-func (r *Receiver) Receive(event cloudevents.Event) {
+func (r *Receiver) Knockdown(event cloudevents.Event) bool {
 	eventSubject := event.Context.GetSubject()
 	fmt.Printf(event.Context.String())
 	if eventSubject == r.Subject {
-		fmt.Printf("subject matches, %q.\n", r.Subject)
-		// Write the termination message if the subject successfully matches
-		if err := r.writeTerminationMessage(map[string]interface{}{
-			"success": true,
-		}); err != nil {
-			fmt.Printf("failed to write termination message, %s.\n", err.Error())
-		}
-		shutDown <- struct{}{}
-	} else {
-		fmt.Printf("subject doesn't match, %q != %q.\n", eventSubject, r.Subject)
+		return true
 	}
-}
-
-func (r *Receiver) writeTerminationMessage(result interface{}) error {
-	b, err := json.Marshal(result)
-	if err != nil {
-		return err
-	}
-	return ioutil.WriteFile("/dev/termination-log", b, 0644)
+	return false
 }

--- a/test/test_images/storage_target/main.go
+++ b/test/test_images/storage_target/main.go
@@ -15,7 +15,7 @@ func main() {
 
 func mainWithExitCode() int {
 	r := &Receiver{}
-	if err := envconfig.Process("", &r); err != nil {
+	if err := envconfig.Process("", r); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
## Proposed Changes

- Give the receiver time to shutdown before stopping the knockdown process.
    - Before this change the knockdown job would succeed, but just close its connection to the caller without responding, leading to misleading error logs in tests.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```
