### PR TITLE
Remove TestBrokerTracing.

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -137,22 +137,6 @@ func TestBrokerDeadLetterSink(t *testing.T) {
 	e2ehelpers.BrokerDeadLetterSinkTestHelper(t, "ChannelBasedBroker" /*brokerClass*/, channelTestRunner, lib.DuplicatePubSubSecret)
 }
 
-func TestBrokerTracing(t *testing.T) {
-	t.Skip("Skipping tracing tests due to flakiness. See https://github.com/google/knative-gcp/issues/818.")
-	if authConfig.WorkloadIdentity {
-		t.Skip("Skip broker related test when workloadIdentity is enabled, issue: https://github.com/google/knative-gcp/issues/746")
-	}
-	cancel := logstream.Start(t)
-	defer cancel()
-	conformancehelpers.BrokerTracingTestHelperWithChannelTestRunner(
-		t, "ChannelBasedBroker", channelTestRunner,
-		func(client *eventingtestlib.Client) {
-			lib.GetCredential(client, authConfig.WorkloadIdentity)
-			lib.SetTracingToZipkin(client)
-		},
-	)
-}
-
 func TestChannelTracing(t *testing.T) {
 	if authConfig.WorkloadIdentity {
 		t.Skip("Skip broker related test when workloadIdentity is enabled, issue: https://github.com/google/knative-gcp/issues/746")


### PR DESCRIPTION
Fixes #818.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Remove the `TestBrokerTracing` test. 
    - It was redundant because the Channel was already tested directly, so we do not need to test the Channel based Broker on top of it.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```