### PR TITLE
Remove unnecessary draining of HTTP request body from benchmark

### DIFF
--- a/pkg/broker/handler/processors/deliver/processor_test.go
+++ b/pkg/broker/handler/processors/deliver/processor_test.go
@@ -19,7 +19,6 @@ package deliver
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -315,9 +314,6 @@ type NoReplyHandler struct{}
 
 func (NoReplyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
-	// Read body to allow the connection to be reused.
-	io.Copy(ioutil.Discard, req.Body)
-	req.Body.Close()
 }
 
 func BenchmarkDeliveryNoReply(b *testing.B) {
@@ -357,9 +353,6 @@ type ReplyHandler struct {
 
 func (h ReplyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	cehttp.WriteResponseWriter(req.Context(), h.msg, http.StatusOK, w)
-	// Read body to allow the connection to be reused.
-	io.Copy(ioutil.Discard, req.Body)
-	req.Body.Close()
 }
 
 func BenchmarkDeliveryWithReply(b *testing.B) {


### PR DESCRIPTION
It is not necessary to close HTTP request bodies, this is only necessary for HTTP response bodies. This has a negligible effect on the benchmark:

> name                  old time/op    new time/op    delta
> DeliveryNoReply-16       114µs ± 0%     123µs ± 0%   ~     (p=1.000 n=1+1)
> DeliveryWithReply-16     253µs ± 0%     240µs ± 0%   ~     (p=1.000 n=1+1)
> 
> name                  old alloc/op   new alloc/op   delta
> DeliveryNoReply-16      10.1kB ± 0%    10.2kB ± 0%   ~     (p=1.000 n=1+1)
> DeliveryWithReply-16    20.2kB ± 0%    20.2kB ± 0%   ~     (p=1.000 n=1+1)
> 
> name                  old allocs/op  new allocs/op  delta
> DeliveryNoReply-16         143 ± 0%       143 ± 0%   ~     (all equal)
> DeliveryWithReply-16       301 ± 0%       301 ± 0%   ~     (all equal)