### PR TITLE
Add another dummy.go to make go mod happier

### DIFF
--- a/config/core/deployments/dummy.go
+++ b/config/core/deployments/dummy.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package core is a placeholder that allows us to pull in config files
+// via go mod vendor.
+package deployments


### PR DESCRIPTION
Add a missing dummy.go to a yaml directory.  This lets us pull in this yaml directory.