### PR TITLE
Pubsub converts between Pubsubs, not intevents.

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -26,8 +26,6 @@ KNATIVE_CODEGEN_PKG=${KNATIVE_CODEGEN_PKG:-$(cd "${REPO_ROOT_DIR}"; ls -d -1 ./v
 
 PUBSUBAPICOPY=(
 	"implements_test.go"
-	"pullsubscription_conversion.go"
-	"pullsubscription_conversion_test.go"
 	"pullsubscription_defaults.go"
 	"pullsubscription_defaults_test.go"
 	"pullsubscription_lifecycle.go"
@@ -35,8 +33,6 @@ PUBSUBAPICOPY=(
 	"pullsubscription_types.go"
 	"pullsubscription_validation.go"
 	"pullsubscription_validation_test.go"
-	"topic_conversion.go"
-	"topic_conversion_test.go"
 	"topic_defaults.go"
 	"topic_defaults_test.go"
 	"topic_lifecycle.go"

--- a/pkg/apis/pubsub/v1alpha1/pullsubscription_conversion.go
+++ b/pkg/apis/pubsub/v1alpha1/pullsubscription_conversion.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	convert "github.com/google/knative-gcp/pkg/apis/convert"
-	"github.com/google/knative-gcp/pkg/apis/intevents/v1beta1"
+	"github.com/google/knative-gcp/pkg/apis/pubsub/v1beta1"
 	"knative.dev/pkg/apis"
 )
 

--- a/pkg/apis/pubsub/v1alpha1/pullsubscription_conversion_test.go
+++ b/pkg/apis/pubsub/v1alpha1/pullsubscription_conversion_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	duckv1alpha1 "github.com/google/knative-gcp/pkg/apis/duck/v1alpha1"
-	"github.com/google/knative-gcp/pkg/apis/intevents/v1beta1"
+	"github.com/google/knative-gcp/pkg/apis/pubsub/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"

--- a/pkg/apis/pubsub/v1alpha1/topic_conversion.go
+++ b/pkg/apis/pubsub/v1alpha1/topic_conversion.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	convert "github.com/google/knative-gcp/pkg/apis/convert"
-	"github.com/google/knative-gcp/pkg/apis/intevents/v1beta1"
+	"github.com/google/knative-gcp/pkg/apis/pubsub/v1beta1"
 	"knative.dev/pkg/apis"
 )
 

--- a/pkg/apis/pubsub/v1alpha1/topic_conversion_test.go
+++ b/pkg/apis/pubsub/v1alpha1/topic_conversion_test.go
@@ -25,7 +25,7 @@ import (
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/knative-gcp/pkg/apis/intevents/v1beta1"
+	"github.com/google/knative-gcp/pkg/apis/pubsub/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )


### PR DESCRIPTION
## Proposed Changes

- Pubsub converts between Pubsubs, not intevents.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```