### PR TITLE
Wait for Fanout Test Helpers in Sync Pool Tests

### DIFF
--- a/pkg/broker/handler/pool/testing/helper.go
+++ b/pkg/broker/handler/pool/testing/helper.go
@@ -361,6 +361,9 @@ func (h *Helper) VerifyNextBrokerIngressEvent(ctx context.Context, t *testing.T,
 	msg, err := bIng.client.Receive(ctx)
 	if err != nil {
 		// In case Receive is stopped.
+		if wantEvent != nil {
+			t.Errorf("Unexpected error receiving event: %v", err)
+		}
 		return
 	}
 	msg.Finish(nil)
@@ -413,6 +416,9 @@ func (h *Helper) VerifyAndRespondNextTargetEvent(ctx context.Context, t *testing
 	msg, respFn, err := consumer.client.Respond(ctx)
 	if err != nil {
 		// In case Receive is stopped.
+		if wantEvent != nil {
+			t.Errorf("Unexpected error receiving event: %v", err)
+		}
 		return
 	}
 	gotEvent, err = binding.ToEvent(ctx, msg)
@@ -463,6 +469,9 @@ func (h *Helper) VerifyNextTargetRetryEvent(ctx context.Context, t *testing.T, t
 	msg, err := psTmp.Receive(ctx)
 	if err != nil {
 		// In case Receive is stopped.
+		if wantEvent != nil {
+			t.Errorf("Unexpected error receiving event: %v", err)
+		}
 		return
 	}
 	msg.Finish(nil)


### PR DESCRIPTION
Fixes #1085. Fixes #1084.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use errgroup to wait for sync pool helpers to finish when running unit tests. This ensures that the helper actually completes, and prevents panics caused by helpers completed after the test has finished.