### PR TITLE
Set HTTP MaxIdleConnsPerHost to runtime.NumCPU() in benchmarks

### DIFF
--- a/pkg/broker/handler/processors/deliver/processor_test.go
+++ b/pkg/broker/handler/processors/deliver/processor_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
 	"time"
 
@@ -318,7 +319,16 @@ func (NoReplyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 func BenchmarkDeliveryNoReply(b *testing.B) {
 	sampleEvent := newSampleEvent()
-	deliverClient, err := ceclient.NewDefault()
+	httpClient := http.Client{
+		Transport: &http.Transport{
+			MaxIdleConnsPerHost: runtime.NumCPU(),
+		},
+	}
+	httpProtocol, err := cehttp.New(cehttp.WithClient(httpClient))
+	if err != nil {
+		b.Fatal(err)
+	}
+	deliverClient, err := ceclient.New(httpProtocol)
 	if err != nil {
 		b.Fatalf("failed to create requester cloudevents client: %v", err)
 	}
@@ -362,7 +372,16 @@ func BenchmarkDeliveryWithReply(b *testing.B) {
 	sampleReply := sampleEvent.Clone()
 	sampleReply.SetID("reply")
 
-	deliverClient, err := ceclient.NewDefault()
+	httpClient := http.Client{
+		Transport: &http.Transport{
+			MaxIdleConnsPerHost: runtime.NumCPU(),
+		},
+	}
+	httpProtocol, err := cehttp.New(cehttp.WithClient(httpClient))
+	if err != nil {
+		b.Fatal(err)
+	}
+	deliverClient, err := ceclient.New(httpProtocol)
 	if err != nil {
 		b.Fatalf("failed to create requester cloudevents client: %v", err)
 	}


### PR DESCRIPTION
This will allow each thread's HTTP connection to be reused when run on multiple processes removing significant benchmarking overhead and making the benchmark less likely to exhaust the number of available sockets.

This results in a significant speedup on my machine:
```
name                  old time/op    new time/op    delta
DeliveryNoReply-16      27.5µs ±11%    15.0µs ± 1%  -45.44%  (p=0.000 n=10+10)
DeliveryWithReply-16    48.4µs ± 4%    25.8µs ± 1%  -46.67%  (p=0.000 n=10+10)

name                  old alloc/op   new alloc/op   delta
DeliveryNoReply-16      16.6kB ± 0%     8.6kB ± 0%  -47.84%  (p=0.000 n=10+9)
DeliveryWithReply-16    33.2kB ± 1%    17.2kB ± 0%  -48.15%  (p=0.000 n=10+10)

name                  old allocs/op  new allocs/op  delta
DeliveryNoReply-16         170 ± 0%       116 ± 0%  -31.92%  (p=0.000 n=10+10)
DeliveryWithReply-16       361 ± 0%       251 ± 0%  -30.53%  (p=0.000 n=10+10)
```

Note that this is not a real speedup, just an improvement to the benchmark.