### PR TITLE
Pin knative/pkg and knative/test-infra to release-0.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,9 +32,8 @@ require (
 	k8s.io/apimachinery v0.18.1
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 	knative.dev/eventing v0.14.1-0.20200520223157-166fc6cd13be
-	knative.dev/pkg v0.0.0-20200520073958-94316e20e860
+	knative.dev/pkg v0.0.0-20200519155757-14eb3ae3a5a7
 	knative.dev/serving v0.14.1-0.20200521151457-24ed5a5c7ca2
-	knative.dev/test-infra v0.0.0-20200521070558-cd7a8d4eff9d // indirect
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1522,9 +1522,8 @@ knative.dev/pkg v0.0.0-20200515002500-16d7b963416f h1:kcpAMvYUqftHMA69wZ7g83zEW4
 knative.dev/pkg v0.0.0-20200515002500-16d7b963416f/go.mod h1:tMOHGbxtRz8zYFGEGpV/bpoTEM1o89MwYFC4YJXl3GY=
 knative.dev/pkg v0.0.0-20200518174206-60f4ae1dbe6f h1:f2eK5+z0/l2S431UCezMG9W4FzktuNbD0OB1gezSoMs=
 knative.dev/pkg v0.0.0-20200518174206-60f4ae1dbe6f/go.mod h1:GinFtW8LEi9rzCkzCMHAIlAnZjP1RzauxwhRAI3rimI=
+knative.dev/pkg v0.0.0-20200519155757-14eb3ae3a5a7 h1:9S2r59HZJF9nKvoRLg5zJzx6XpVlVyvVRqz/C/h6h2s=
 knative.dev/pkg v0.0.0-20200519155757-14eb3ae3a5a7/go.mod h1:QgNZTxnwpB/oSpNcfnLVlw+WpEwwyKAvJlvR3hgeltA=
-knative.dev/pkg v0.0.0-20200520073958-94316e20e860 h1:JcN76DOgYvpykb4f6GksDg3mwC5zGnA7nYITw7TEuKo=
-knative.dev/pkg v0.0.0-20200520073958-94316e20e860/go.mod h1:QgNZTxnwpB/oSpNcfnLVlw+WpEwwyKAvJlvR3hgeltA=
 knative.dev/serving v0.14.1-0.20200521151457-24ed5a5c7ca2 h1:CrgEcGrUpOiXHX7cClzvQGyyYmwfaNvJW6H13Iue9Q4=
 knative.dev/serving v0.14.1-0.20200521151457-24ed5a5c7ca2/go.mod h1:jGOPiYDiIwQQJ8XqMe70iFdCf3kfJ4NTD8jUBBWw4xo=
 knative.dev/test-infra v0.0.0-20200407185800-1b88cb3b45a5/go.mod h1:xcdUkMJrLlBswIZqL5zCuBFOC22WIPMQoVX1L35i0vQ=
@@ -1535,9 +1534,8 @@ knative.dev/test-infra v0.0.0-20200514223200-ef4fd3ad398f h1:2j9xK15xMRz5h+yXIHt
 knative.dev/test-infra v0.0.0-20200514223200-ef4fd3ad398f/go.mod h1:+uml4upluwrnWHRSezi4WVcKJ0OJHynF16Ot7fu0ky4=
 knative.dev/test-infra v0.0.0-20200519015156-82551620b0a9 h1:kKfV3QWsxugwXsqgjFd72MjZeAHJ381dWqAxH2KMknc=
 knative.dev/test-infra v0.0.0-20200519015156-82551620b0a9/go.mod h1:A5b2OAXTOeHT3hHhVQm3dmtbuWvIDP7qzgtqxA3/2pE=
+knative.dev/test-infra v0.0.0-20200519161858-554a95a37986 h1:ZDy43jkWPQ75d4l4DGy+ENQIXlNcnHIh4tB6XxgovNc=
 knative.dev/test-infra v0.0.0-20200519161858-554a95a37986/go.mod h1:LeNa1Wvn47efeQUkpkn3XG7Fx9Ga+rhAP13SZyjaEGg=
-knative.dev/test-infra v0.0.0-20200521070558-cd7a8d4eff9d h1:GnPTKmUhFYiTSl9QORLoSxl+6kKXtkBiMfQsNCFEoSc=
-knative.dev/test-infra v0.0.0-20200521070558-cd7a8d4eff9d/go.mod h1:n9eQkzmSNj8BiqNFl1lzoz68D09uMeJfyOjc132Gbik=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -28,10 +28,10 @@ VERSION="master"
 # The list of dependencies that we track at HEAD and periodically
 # float forward in this repository.
 FLOATING_DEPS=(
-  "knative.dev/pkg@$VERSION"
+  "knative.dev/pkg@release-0.15"
   "knative.dev/serving@$VERSION"
   "knative.dev/eventing@$VERSION"
-  "knative.dev/test-infra@$VERSION"
+  "knative.dev/test-infra@release-0.15"
 )
 
 # Parse flags to determine any we should pass to dep.

--- a/vendor/knative.dev/pkg/test/spoof/spoof.go
+++ b/vendor/knative.dev/pkg/test/spoof/spoof.go
@@ -20,9 +20,7 @@ package spoof
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -246,22 +244,18 @@ func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker, error
 // DefaultErrorRetryChecker implements the defaults for retrying on error.
 func DefaultErrorRetryChecker(err error) (bool, error) {
 	if isTCPTimeout(err) {
-		return true, fmt.Errorf("retrying for TCP timeout: %w", err)
+		return true, fmt.Errorf("Retrying for TCP timeout: %w", err)
 	}
 	// Retrying on DNS error, since we may be using xip.io or nip.io in tests.
 	if isDNSError(err) {
-		return true, fmt.Errorf("retrying for DNS error: %w", err)
+		return true, fmt.Errorf("Retrying for DNS error: %w", err)
 	}
 	// Repeat the poll on `connection refused` errors, which are usually transient Istio errors.
 	if isConnectionRefused(err) {
-		return true, fmt.Errorf("retrying for connection refused: %w", err)
+		return true, fmt.Errorf("Retrying for connection refused: %w", err)
 	}
 	if isConnectionReset(err) {
-		return true, fmt.Errorf("retrying for connection reset: %w", err)
-	}
-	// Retry on connection/network errors.
-	if errors.Is(err, io.EOF) {
-		return true, fmt.Errorf("retrying for: %w", err)
+		return true, fmt.Errorf("Retrying for connection reset: %w", err)
 	}
 	return false, err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1106,7 +1106,7 @@ knative.dev/eventing/test/test_images/performance
 knative.dev/eventing/test/test_images/recordevents
 knative.dev/eventing/test/test_images/sendevents
 knative.dev/eventing/test/test_images/transformevents
-# knative.dev/pkg v0.0.0-20200520073958-94316e20e860
+# knative.dev/pkg v0.0.0-20200519155757-14eb3ae3a5a7
 ## explicit
 knative.dev/pkg/apis
 knative.dev/pkg/apis/duck
@@ -1254,8 +1254,7 @@ knative.dev/serving/pkg/client/listers/networking/v1alpha1
 knative.dev/serving/pkg/client/listers/serving/v1
 knative.dev/serving/pkg/client/listers/serving/v1alpha1
 knative.dev/serving/pkg/client/listers/serving/v1beta1
-# knative.dev/test-infra v0.0.0-20200521070558-cd7a8d4eff9d
-## explicit
+# knative.dev/test-infra v0.0.0-20200519161858-554a95a37986
 knative.dev/test-infra/scripts
 # sigs.k8s.io/yaml v1.2.0 => sigs.k8s.io/yaml v1.1.0
 ## explicit


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-  Pin `knative/pkg` and `knative/test-infra` to `release-0.15` in anticipation of the 0.15 release.

This was created by:
1. Manually altering `hack/update-deps.sh`.
1. Running `hack/update-deps.sh --upgrade`.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```