### PR TITLE
Add k8s service account under identity spec

### DIFF
--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -72,6 +72,12 @@ spec:
             spec:
               type: object
               properties:
+                googleServiceAccount:
+                  type: string
+                  description: >
+                    GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service
+                    account must be a valid Google service account. (see
+                    https://cloud.google.com/iam/docs/service-accounts).
                 serviceAccountName:
                   type: string
                   description: >
@@ -209,12 +215,6 @@ spec:
             spec:
               type: object
               properties:
-                googleServiceAccount:
-                  type: string
-                  description: >
-                    GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service
-                    account must be a valid Google service account. (see
-                    https://cloud.google.com/iam/docs/service-accounts).
                 serviceAccountName:
                   type: string
                   description: >

--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -72,12 +72,12 @@ spec:
             spec:
               type: object
               properties:
-                googleServiceAccount:
+                serviceAccountName:
                   type: string
                   description: >
-                    GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service
-                    account must be a valid Google service account (see
-                    https://cloud.google.com/iam/docs/service-accounts).
+                    k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
+                    The value of the k8s service account must be a valid DNS subdomain name.
+                    (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
                 secret:
                   type: object
                   description: >
@@ -209,12 +209,12 @@ spec:
             spec:
               type: object
               properties:
-                googleServiceAccount:
+                serviceAccountName:
                   type: string
                   description: >
-                    GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service
-                    account must be a valid Google service account (see
-                    https://cloud.google.com/iam/docs/service-accounts).
+                    k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
+                    The value of the k8s service account must be a valid DNS subdomain name.
+                    (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
                 secret:
                   type: object
                   description: >

--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -209,11 +209,17 @@ spec:
             spec:
               type: object
               properties:
+                googleServiceAccount:
+                  type: string
+                  description: >
+                    GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service
+                    account must be a valid Google service account. (see
+                    https://cloud.google.com/iam/docs/service-accounts).
                 serviceAccountName:
                   type: string
                   description: >
-                    k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
-                    The value of the k8s service account must be a valid DNS subdomain name.
+                    Kubernetes service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
+                    The value of the Kubernetes service account must be a valid DNS subdomain name.
                     (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
                 secret:
                   type: object

--- a/config/core/resources/cloudauditlogssource.yaml
+++ b/config/core/resources/cloudauditlogssource.yaml
@@ -110,11 +110,17 @@ spec:
                     Extensions specify what attribute are added or overridden on the outbound event. Each
                     `Extensions` key-value pair are set on the event as an attribute extension independently.
                   x-kubernetes-preserve-unknown-fields: true
+            googleServiceAccount:
+              type: string
+              description: >
+                GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service
+                account must be a valid Google service account. (see
+                https://cloud.google.com/iam/docs/service-accounts).
             serviceAccountName:
               type: string
               description: >
-                k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
-                The value of the k8s service account must be a valid DNS subdomain name.
+                Kubernetes service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
+                The value of the Kubernetes service account must be a valid DNS subdomain name.
                 (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
             secret:
               type: object

--- a/config/core/resources/cloudauditlogssource.yaml
+++ b/config/core/resources/cloudauditlogssource.yaml
@@ -110,12 +110,12 @@ spec:
                     Extensions specify what attribute are added or overridden on the outbound event. Each
                     `Extensions` key-value pair are set on the event as an attribute extension independently.
                   x-kubernetes-preserve-unknown-fields: true
-            googleServiceAccount:
+            serviceAccountName:
               type: string
               description: >
-                GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service
-                account must be a valid Google service account (see
-                https://cloud.google.com/iam/docs/service-accounts).
+                k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
+                The value of the k8s service account must be a valid DNS subdomain name.
+                (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
             secret:
               type: object
               description: >

--- a/config/core/resources/cloudbuildsource.yaml
+++ b/config/core/resources/cloudbuildsource.yaml
@@ -100,12 +100,12 @@ spec:
                     Extensions specify what attribute are added or overridden on the outbound event. Each
                     `Extensions` key-value pair are set on the event as an attribute extension independently.
                   x-kubernetes-preserve-unknown-fields: true
-            googleServiceAccount:
+            serviceAccountName:
               type: string
               description: >
-                GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service
-                account must be a valid Google service account (see
-                https://cloud.google.com/iam/docs/service-accounts).
+                k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
+                The value of the k8s service account must be a valid DNS subdomain name.
+                (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
             secret:
               type: object
               description: >

--- a/config/core/resources/cloudbuildsource.yaml
+++ b/config/core/resources/cloudbuildsource.yaml
@@ -100,11 +100,17 @@ spec:
                     Extensions specify what attribute are added or overridden on the outbound event. Each
                     `Extensions` key-value pair are set on the event as an attribute extension independently.
                   x-kubernetes-preserve-unknown-fields: true
+            googleServiceAccount:
+              type: string
+              description: >
+                GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service
+                account must be a valid Google service account. (see
+                https://cloud.google.com/iam/docs/service-accounts).
             serviceAccountName:
               type: string
               description: >
-                k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
-                The value of the k8s service account must be a valid DNS subdomain name.
+                Kubernetes service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
+                The value of the Kubernetes service account must be a valid DNS subdomain name.
                 (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
             secret:
               type: object

--- a/config/core/resources/cloudpubsubsource.yaml
+++ b/config/core/resources/cloudpubsubsource.yaml
@@ -109,12 +109,12 @@ spec:
                     Extensions specify what attribute are added or overridden on the outbound event. Each
                     `Extensions` key-value pair are set on the event as an attribute extension independently.
                   x-kubernetes-preserve-unknown-fields: true
-            googleServiceAccount:
+            serviceAccountName:
               type: string
               description: >
-                GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service
-                account must be a valid Google service account (see
-                https://cloud.google.com/iam/docs/service-accounts).
+                k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
+                The value of the k8s service account must be a valid DNS subdomain name.
+                (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
             secret:
               type: object
               description: >

--- a/config/core/resources/cloudpubsubsource.yaml
+++ b/config/core/resources/cloudpubsubsource.yaml
@@ -109,11 +109,17 @@ spec:
                     Extensions specify what attribute are added or overridden on the outbound event. Each
                     `Extensions` key-value pair are set on the event as an attribute extension independently.
                   x-kubernetes-preserve-unknown-fields: true
+            googleServiceAccount:
+              type: string
+              description: >
+                GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service
+                account must be a valid Google service account. (see
+                https://cloud.google.com/iam/docs/service-accounts).
             serviceAccountName:
               type: string
               description: >
-                k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
-                The value of the k8s service account must be a valid DNS subdomain name.
+                Kubernetes service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
+                The value of the Kubernetes service account must be a valid DNS subdomain name.
                 (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
             secret:
               type: object

--- a/config/core/resources/cloudschedulersource.yaml
+++ b/config/core/resources/cloudschedulersource.yaml
@@ -111,12 +111,12 @@ spec:
                     Extensions specify what attribute are added or overridden on the outbound event. Each
                     `Extensions` key-value pair are set on the event as an attribute extension independently.
                   x-kubernetes-preserve-unknown-fields: true
-            googleServiceAccount:
+            serviceAccountName:
               type: string
               description: >
-                GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service
-                account must be a valid Google service account (see
-                https://cloud.google.com/iam/docs/service-accounts).
+                k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
+                The value of the k8s service account must be a valid DNS subdomain name.
+                (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
             secret:
               type: object
               description: >

--- a/config/core/resources/cloudschedulersource.yaml
+++ b/config/core/resources/cloudschedulersource.yaml
@@ -111,11 +111,17 @@ spec:
                     Extensions specify what attribute are added or overridden on the outbound event. Each
                     `Extensions` key-value pair are set on the event as an attribute extension independently.
                   x-kubernetes-preserve-unknown-fields: true
+            googleServiceAccount:
+              type: string
+              description: >
+                GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service
+                account must be a valid Google service account. (see
+                https://cloud.google.com/iam/docs/service-accounts).
             serviceAccountName:
               type: string
               description: >
-                k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
-                The value of the k8s service account must be a valid DNS subdomain name.
+                Kubernetes service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
+                The value of the Kubernetes service account must be a valid DNS subdomain name.
                 (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
             secret:
               type: object

--- a/config/core/resources/cloudstoragesource.yaml
+++ b/config/core/resources/cloudstoragesource.yaml
@@ -112,12 +112,12 @@ spec:
                     Extensions specify what attribute are added or overridden on the outbound event. Each
                     `Extensions` key-value pair are set on the event as an attribute extension independently.
                   x-kubernetes-preserve-unknown-fields: true
-            googleServiceAccount:
+            serviceAccountName:
               type: string
               description: >
-                GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service
-                account must be a valid Google service account (see
-                https://cloud.google.com/iam/docs/service-accounts).
+                k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
+                The value of the k8s service account must be a valid DNS subdomain name.
+                (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
             secret:
               type: object
               description: >
@@ -137,10 +137,6 @@ spec:
               description: >
                 Google Cloud Project ID of the project into which the topic should be created. If omitted uses
                 the Project ID from the GKE cluster metadata service.
-            serviceAccountName:
-              type: string
-              description: >
-                Service Account to run Receive Adapter as. If omitted, uses 'default'.
             bucket:
               type: string
               description: >

--- a/config/core/resources/cloudstoragesource.yaml
+++ b/config/core/resources/cloudstoragesource.yaml
@@ -112,11 +112,17 @@ spec:
                     Extensions specify what attribute are added or overridden on the outbound event. Each
                     `Extensions` key-value pair are set on the event as an attribute extension independently.
                   x-kubernetes-preserve-unknown-fields: true
+            googleServiceAccount:
+              type: string
+              description: >
+                GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service
+                account must be a valid Google service account. (see
+                https://cloud.google.com/iam/docs/service-accounts).
             serviceAccountName:
               type: string
               description: >
-                k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
-                The value of the k8s service account must be a valid DNS subdomain name.
+                Kubernetes service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
+                The value of the Kubernetes service account must be a valid DNS subdomain name.
                 (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
             secret:
               type: object

--- a/config/core/resources/old_pullsubscription.yaml
+++ b/config/core/resources/old_pullsubscription.yaml
@@ -67,9 +67,12 @@ spec:
             - sink
             - topic
           properties:
+            googleServiceAccount:
+              type: string
+              description: "GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service account must be a valid Google service account (see https://cloud.google.com/iam/docs/service-accounts)."
             serviceAccountName:
               type: string
-              description: "k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription. The value of the k8s service account must be a valid DNS subdomain name. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)"
+              description: "Kubernetes service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription. The value of the Kubernetes service account must be a valid DNS subdomain name. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)"
             secret:
               type: object
               description: "Credential used to poll the Cloud Pub/Sub Subscription. It is not used to create or delete the Subscription, only to poll it. The value of the secret entry must be a service account key in the JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys). Defaults to secret.name of 'google-cloud-key' and secret.key of 'key.json'."

--- a/config/core/resources/old_pullsubscription.yaml
+++ b/config/core/resources/old_pullsubscription.yaml
@@ -67,9 +67,9 @@ spec:
             - sink
             - topic
           properties:
-            googleServiceAccount:
+            serviceAccountName:
               type: string
-              description: "GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service account must be a valid Google service account (see https://cloud.google.com/iam/docs/service-accounts)."
+              description: "k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription. The value of the k8s service account must be a valid DNS subdomain name. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)"
             secret:
               type: object
               description: "Credential used to poll the Cloud Pub/Sub Subscription. It is not used to create or delete the Subscription, only to poll it. The value of the secret entry must be a service account key in the JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys). Defaults to secret.name of 'google-cloud-key' and secret.key of 'key.json'."

--- a/config/core/resources/old_topic.yaml
+++ b/config/core/resources/old_topic.yaml
@@ -69,10 +69,10 @@ spec:
           required:
             - topic
           properties:
-            googleServiceAccount:
+            serviceAccountName:
               type: string
-              description: "GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service account must be a valid Google service account (see https://cloud.google.com/iam/docs/service-accounts)."
-            secret:
+              description: "k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription. The value of the k8s service account must be a valid DNS subdomain name. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)"
+           secret:
               type: object
               description: "Credential used to poll the Cloud Pub/Sub Subscription. It is not used to create or delete the Subscription, only to poll it. The value of the secret entry must be a service account key in the JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys). Defaults to secret.name of 'google-cloud-key' and secret.key of 'key.json'."
               properties:

--- a/config/core/resources/old_topic.yaml
+++ b/config/core/resources/old_topic.yaml
@@ -69,10 +69,13 @@ spec:
           required:
             - topic
           properties:
+            googleServiceAccount:
+              type: string
+              description: "GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service account must be a valid Google service account (see https://cloud.google.com/iam/docs/service-accounts)."
             serviceAccountName:
               type: string
-              description: "k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription. The value of the k8s service account must be a valid DNS subdomain name. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)"
-           secret:
+              description: "Kubernetes service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription. The value of the Kubernetes service account must be a valid DNS subdomain name. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)"
+            secret:
               type: object
               description: "Credential used to poll the Cloud Pub/Sub Subscription. It is not used to create or delete the Subscription, only to poll it. The value of the secret entry must be a service account key in the JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys). Defaults to secret.name of 'google-cloud-key' and secret.key of 'key.json'."
               properties:

--- a/config/core/resources/pullsubscription.yaml
+++ b/config/core/resources/pullsubscription.yaml
@@ -67,9 +67,12 @@ spec:
             - sink
             - topic
           properties:
+            googleServiceAccount:
+              type: string
+              description: "GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service account must be a valid Google service account (see https://cloud.google.com/iam/docs/service-accounts)."
             serviceAccountName:
               type: string
-              description: "k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription. The value of the k8s service account must be a valid DNS subdomain name. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)"
+              description: "Kubernetes service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription. The value of the Kubernetes service account must be a valid DNS subdomain name. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)"
             secret:
               type: object
               description: "Credential used to poll the Cloud Pub/Sub Subscription. It is not used to create or delete the Subscription, only to poll it. The value of the secret entry must be a service account key in the JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys). Defaults to secret.name of 'google-cloud-key' and secret.key of 'key.json'."

--- a/config/core/resources/pullsubscription.yaml
+++ b/config/core/resources/pullsubscription.yaml
@@ -67,9 +67,9 @@ spec:
             - sink
             - topic
           properties:
-            googleServiceAccount:
+            serviceAccountName:
               type: string
-              description: "GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service account must be a valid Google service account (see https://cloud.google.com/iam/docs/service-accounts)."
+              description: "k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription. The value of the k8s service account must be a valid DNS subdomain name. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)"
             secret:
               type: object
               description: "Credential used to poll the Cloud Pub/Sub Subscription. It is not used to create or delete the Subscription, only to poll it. The value of the secret entry must be a service account key in the JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys). Defaults to secret.name of 'google-cloud-key' and secret.key of 'key.json'."

--- a/config/core/resources/topic.yaml
+++ b/config/core/resources/topic.yaml
@@ -69,9 +69,12 @@ spec:
           required:
             - topic
           properties:
+            googleServiceAccount:
+              type: string
+              description: "GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service account must be a valid Google service account (see https://cloud.google.com/iam/docs/service-accounts)."
             serviceAccountName:
               type: string
-              description: "k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription. The value of the k8s service account must be a valid DNS subdomain name. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)"
+              description: "Kubernetes service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription. The value of the Kubernetes service account must be a valid DNS subdomain name. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)"
             secret:
               type: object
               description: "Credential used to poll the Cloud Pub/Sub Subscription. It is not used to create or delete the Subscription, only to poll it. The value of the secret entry must be a service account key in the JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys). Defaults to secret.name of 'google-cloud-key' and secret.key of 'key.json'."

--- a/config/core/resources/topic.yaml
+++ b/config/core/resources/topic.yaml
@@ -69,9 +69,9 @@ spec:
           required:
             - topic
           properties:
-            googleServiceAccount:
+            serviceAccountName:
               type: string
-              description: "GCP service account used to poll the Cloud Pub/Sub Subscription. The value of the service account must be a valid Google service account (see https://cloud.google.com/iam/docs/service-accounts)."
+              description: "k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription. The value of the k8s service account must be a valid DNS subdomain name. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)"
             secret:
               type: object
               description: "Credential used to poll the Cloud Pub/Sub Subscription. It is not used to create or delete the Subscription, only to poll it. The value of the secret entry must be a service account key in the JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys). Defaults to secret.name of 'google-cloud-key' and secret.key of 'key.json'."

--- a/pkg/apis/convert/conversion_helper.go
+++ b/pkg/apis/convert/conversion_helper.go
@@ -46,12 +46,12 @@ func FromV1beta1PubSubSpec(from duckv1beta1.PubSubSpec) duckv1alpha1.PubSubSpec 
 
 func ToV1beta1IdentitySpec(from duckv1alpha1.IdentitySpec) duckv1beta1.IdentitySpec {
 	to := duckv1beta1.IdentitySpec{}
-	to.GoogleServiceAccount = from.GoogleServiceAccount
+	to.ServiceAccountName = from.ServiceAccountName
 	return to
 }
 func FromV1beta1IdentitySpec(from duckv1beta1.IdentitySpec) duckv1alpha1.IdentitySpec {
 	to := duckv1alpha1.IdentitySpec{}
-	to.GoogleServiceAccount = from.GoogleServiceAccount
+	to.ServiceAccountName = from.ServiceAccountName
 	return to
 }
 

--- a/pkg/apis/convert/conversion_helper_test.go
+++ b/pkg/apis/convert/conversion_helper_test.go
@@ -69,7 +69,7 @@ var (
 	}
 
 	completeIdentitySpec = duckv1alpha1.IdentitySpec{
-		GoogleServiceAccount: "googleServiceAccount",
+		ServiceAccountName: "k8sServiceAccount",
 	}
 
 	completeSecret = &v1.SecretKeySelector{

--- a/pkg/apis/duck/v1alpha1/credentials.go
+++ b/pkg/apis/duck/v1alpha1/credentials.go
@@ -55,12 +55,16 @@ func ValidateCredential(secret *corev1.SecretKeySelector, gServiceAccountName st
 		}
 	} else if secret != nil && !equality.Semantic.DeepEqual(secret, &corev1.SecretKeySelector{}) {
 		return validateSecret(secret)
-	} else if gServiceAccountName != "" {
-		return validateGCPServiceAccount(gServiceAccountName)
-	} else if kServiceAccountName != "" {
-		return validateK8sServiceAccount(kServiceAccountName)
+	} else {
+		var errs *apis.FieldError
+		if kServiceAccountName != "" {
+			errs = errs.Also(validateK8sServiceAccount(kServiceAccountName))
+		}
+		if gServiceAccountName != "" {
+			errs = errs.Also(validateGCPServiceAccount(gServiceAccountName))
+		}
+		return errs
 	}
-	return nil
 }
 
 func validateSecret(secret *corev1.SecretKeySelector) *apis.FieldError {

--- a/pkg/apis/duck/v1alpha1/credentials.go
+++ b/pkg/apis/duck/v1alpha1/credentials.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	validation_regexp = regexp.MustCompile(`^[a-z][a-z0-9-]{5,29}@[a-z][a-z0-9-]{5,29}.iam.gserviceaccount.com$`)
+	validation_regexp     = regexp.MustCompile(`^[a-z][a-z0-9-]{5,29}@[a-z][a-z0-9-]{5,29}.iam.gserviceaccount.com$`)
+	validation_regexp_k8s = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?$`)
 )
 
 // DefaultGoogleCloudSecretSelector is the default secret selector used to load
@@ -45,17 +46,19 @@ func DefaultGoogleCloudSecretSelector() *corev1.SecretKeySelector {
 	}
 }
 
-// ValidateCredential checks secret and GCP service account.
-func ValidateCredential(secret *corev1.SecretKeySelector, gServiceAccountName string) *apis.FieldError {
-	if secret != nil && !equality.Semantic.DeepEqual(secret, &corev1.SecretKeySelector{}) && gServiceAccountName != "" {
+// ValidateCredential checks secret and service account.
+func ValidateCredential(secret *corev1.SecretKeySelector, gServiceAccountName string, kServiceAccountName string) *apis.FieldError {
+	if secret != nil && !equality.Semantic.DeepEqual(secret, &corev1.SecretKeySelector{}) && kServiceAccountName != "" {
 		return &apis.FieldError{
-			Message: "Can't have spec.googleServiceAccount and spec.secret at the same time",
+			Message: "Can't have spec.serviceAccountName and spec.secret at the same time",
 			Paths:   []string{""},
 		}
 	} else if secret != nil && !equality.Semantic.DeepEqual(secret, &corev1.SecretKeySelector{}) {
 		return validateSecret(secret)
 	} else if gServiceAccountName != "" {
 		return validateGCPServiceAccount(gServiceAccountName)
+	} else if kServiceAccountName != "" {
+		return validateK8sServiceAccount(kServiceAccountName)
 	}
 	return nil
 }
@@ -85,6 +88,21 @@ func validateGCPServiceAccount(gServiceAccountName string) *apis.FieldError {
 			Message: fmt.Sprintf(`invalid value: %s, googleServiceAccount should have format: ^[a-z][a-z0-9-]{5,29}@[a-z][a-z0-9-]{5,29}.iam.gserviceaccount.com$`,
 				gServiceAccountName),
 			Paths: []string{"googleServiceAccount"},
+		}
+	}
+	return nil
+}
+
+func validateK8sServiceAccount(kServiceAccountName string) *apis.FieldError {
+	// The name of a k8s ServiceAccount object must be a valid DNS subdomain name.
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+
+	match := validation_regexp_k8s.FindStringSubmatch(kServiceAccountName)
+	if len(match) == 0 {
+		return &apis.FieldError{
+			Message: fmt.Sprintf(`invalid value: %s, serviceAccountName should have format: ^[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?$`,
+				kServiceAccountName),
+			Paths: []string{"serviceAccountName"},
 		}
 	}
 	return nil

--- a/pkg/apis/duck/v1alpha1/credentials_test.go
+++ b/pkg/apis/duck/v1alpha1/credentials_test.go
@@ -59,26 +59,26 @@ func TestValidateCredential(t *testing.T) {
 		serviceAccount: "",
 		wantErr:        true,
 	}, {
-		name:           "nil secret, and valid service account",
+		name:           "nil secret, and valid k8s service account",
 		secret:         nil,
-		serviceAccount: "test123@test123.iam.gserviceaccount.com",
+		serviceAccount: "test123",
 		wantErr:        false,
 	}, {
 		name:           "nil secret, and invalid service account",
 		secret:         nil,
-		serviceAccount: "test@test",
+		serviceAccount: "@test",
 		wantErr:        true,
 	}, {
 		name:           "secret and service account exist at the same time",
 		secret:         DefaultGoogleCloudSecretSelector(),
-		serviceAccount: "test@test.iam.gserviceaccount.com",
+		serviceAccount: "test",
 		wantErr:        true,
 	}}
 
 	defer logtesting.ClearAll()
 
 	for _, tc := range testCases {
-		errs := ValidateCredential(tc.secret, tc.serviceAccount)
+		errs := ValidateCredential(tc.secret, "", tc.serviceAccount)
 		got := errs != nil
 		if diff := cmp.Diff(tc.wantErr, got); diff != "" {
 			t.Errorf("unexpected resource (-want, +got) = %v", diff)

--- a/pkg/apis/duck/v1alpha1/identity_types.go
+++ b/pkg/apis/duck/v1alpha1/identity_types.go
@@ -23,6 +23,11 @@ type IdentitySpec struct {
 	// If not specified, defaults to use secret.
 	// +optional
 	GoogleServiceAccount string `json:"googleServiceAccount,omitempty"`
+	// ServiceAccountName is the k8s service account which binds to a google service account.
+	// This google service account has required permissions to poll from a Cloud Pub/Sub subscription.
+	// If not specified, defaults to use secret.
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 // IdentityStatus inherits duck/v1 Status and adds a ServiceAccountName.

--- a/pkg/apis/duck/v1alpha1/pubsub_defaults.go
+++ b/pkg/apis/duck/v1alpha1/pubsub_defaults.go
@@ -22,7 +22,8 @@ import (
 )
 
 func (s *PubSubSpec) SetPubSubDefaults() {
-	if s.GoogleServiceAccount == "" && (s.Secret == nil || equality.Semantic.DeepEqual(s.Secret, &corev1.SecretKeySelector{})) {
+	if s.GoogleServiceAccount == "" && s.ServiceAccountName == "" &&
+		(s.Secret == nil || equality.Semantic.DeepEqual(s.Secret, &corev1.SecretKeySelector{})) {
 		s.Secret = DefaultGoogleCloudSecretSelector()
 	}
 }

--- a/pkg/apis/duck/v1beta1/credentials_test.go
+++ b/pkg/apis/duck/v1beta1/credentials_test.go
@@ -61,17 +61,17 @@ func TestValidateCredential(t *testing.T) {
 	}, {
 		name:           "nil secret, and valid service account",
 		secret:         nil,
-		serviceAccount: "test123@test123.iam.gserviceaccount.com",
+		serviceAccount: "test",
 		wantErr:        false,
 	}, {
 		name:           "nil secret, and invalid service account",
 		secret:         nil,
-		serviceAccount: "test@test",
+		serviceAccount: "@test",
 		wantErr:        true,
 	}, {
 		name:           "secret and service account exist at the same time",
 		secret:         DefaultGoogleCloudSecretSelector(),
-		serviceAccount: "test@test.iam.gserviceaccount.com",
+		serviceAccount: "test",
 		wantErr:        true,
 	}}
 

--- a/pkg/apis/duck/v1beta1/identity_types.go
+++ b/pkg/apis/duck/v1beta1/identity_types.go
@@ -19,10 +19,11 @@ import (
 )
 
 type IdentitySpec struct {
-	// GoogleServiceAccount is the GCP service account which has required permissions to poll from a Cloud Pub/Sub subscription.
+	// ServiceAccountName is the k8s service account which binds to a google service account.
+	// This google service account has required permissions to poll from a Cloud Pub/Sub subscription.
 	// If not specified, defaults to use secret.
 	// +optional
-	GoogleServiceAccount string `json:"googleServiceAccount,omitempty"`
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 // IdentityStatus inherits duck/v1 Status and adds a ServiceAccountName.

--- a/pkg/apis/duck/v1beta1/pubsub_defaults.go
+++ b/pkg/apis/duck/v1beta1/pubsub_defaults.go
@@ -22,7 +22,7 @@ import (
 )
 
 func (s *PubSubSpec) SetPubSubDefaults() {
-	if s.GoogleServiceAccount == "" && (s.Secret == nil || equality.Semantic.DeepEqual(s.Secret, &corev1.SecretKeySelector{})) {
+	if s.ServiceAccountName == "" && (s.Secret == nil || equality.Semantic.DeepEqual(s.Secret, &corev1.SecretKeySelector{})) {
 		s.Secret = DefaultGoogleCloudSecretSelector()
 	}
 }

--- a/pkg/apis/events/v1alpha1/cloudauditlogssource_conversion_test.go
+++ b/pkg/apis/events/v1alpha1/cloudauditlogssource_conversion_test.go
@@ -99,7 +99,7 @@ var (
 	}
 
 	completeIdentitySpec = duckv1alpha1.IdentitySpec{
-		GoogleServiceAccount: "googleServiceAccount",
+		ServiceAccountName: "k8sServiceAccount",
 	}
 
 	completeSecret = &v1.SecretKeySelector{

--- a/pkg/apis/events/v1alpha1/cloudauditlogssource_types_test.go
+++ b/pkg/apis/events/v1alpha1/cloudauditlogssource_types_test.go
@@ -93,13 +93,13 @@ func TestCloudAuditLogsSourceIdentitySpec(t *testing.T) {
 		Spec: CloudAuditLogsSourceSpec{
 			PubSubSpec: duckv1alpha1.PubSubSpec{
 				IdentitySpec: duckv1alpha1.IdentitySpec{
-					GoogleServiceAccount: "test@test",
+					ServiceAccountName: "test",
 				},
 			},
 		},
 	}
-	want := "test@test"
-	got := s.IdentitySpec().GoogleServiceAccount
+	want := "test"
+	got := s.IdentitySpec().ServiceAccountName
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)
 	}

--- a/pkg/apis/events/v1alpha1/cloudauditlogssource_validation.go
+++ b/pkg/apis/events/v1alpha1/cloudauditlogssource_validation.go
@@ -51,7 +51,7 @@ func (current *CloudAuditLogsSourceSpec) Validate(ctx context.Context) *apis.Fie
 		errs = errs.Also(apis.ErrMissingField("methodName"))
 	}
 
-	if err := duckv1alpha1.ValidateCredential(current.Secret, current.GoogleServiceAccount); err != nil {
+	if err := duckv1alpha1.ValidateCredential(current.Secret, current.GoogleServiceAccount, current.ServiceAccountName); err != nil {
 		errs = errs.Also(err)
 	}
 

--- a/pkg/apis/events/v1alpha1/cloudauditlogssource_validation_test.go
+++ b/pkg/apis/events/v1alpha1/cloudauditlogssource_validation_test.go
@@ -54,8 +54,8 @@ var (
 			Project: "my-eventing-project",
 		},
 	}
-	validServiceAccountName   = "test123@test123.iam.gserviceaccount.com"
-	invalidServiceAccountName = "test@test.iam.kserviceaccount.com"
+	validServiceAccountName   = "test"
+	invalidServiceAccountName = "@test"
 )
 
 func TestCloudAuditLogsSourceValidationFields(t *testing.T) {
@@ -116,18 +116,18 @@ func TestCloudAuditLogsSourceValidationFields(t *testing.T) {
 			}(),
 			error: true,
 		},
-		"invalid GCP service account": {
+		"invalid k8s service account": {
 			spec: func() CloudAuditLogsSourceSpec {
 				obj := auditLogsSourceSpec.DeepCopy()
-				obj.GoogleServiceAccount = invalidServiceAccountName
+				obj.ServiceAccountName = invalidServiceAccountName
 				return *obj
 			}(),
 			error: true,
 		},
-		"have GCP service account and secret at the same time": {
+		"have k8s service account and secret at the same time": {
 			spec: func() CloudAuditLogsSourceSpec {
 				obj := auditLogsSourceSpec.DeepCopy()
-				obj.GoogleServiceAccount = invalidServiceAccountName
+				obj.ServiceAccountName = invalidServiceAccountName
 				obj.Secret = duckv1alpha1.DefaultGoogleCloudSecretSelector()
 				return *obj
 			}(),
@@ -221,7 +221,7 @@ func TestCloudAuditLogsSourceCheckImmutableFields(t *testing.T) {
 			updated: CloudAuditLogsSourceSpec{
 				PubSubSpec: duckv1alpha1.PubSubSpec{
 					IdentitySpec: duckv1alpha1.IdentitySpec{
-						GoogleServiceAccount: "new-service-account",
+						ServiceAccountName: "new-service-account",
 					},
 					Secret: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{

--- a/pkg/apis/events/v1alpha1/cloudauditlogssource_validation_test.go
+++ b/pkg/apis/events/v1alpha1/cloudauditlogssource_validation_test.go
@@ -127,7 +127,7 @@ func TestCloudAuditLogsSourceValidationFields(t *testing.T) {
 		"have k8s service account and secret at the same time": {
 			spec: func() CloudAuditLogsSourceSpec {
 				obj := auditLogsSourceSpec.DeepCopy()
-				obj.ServiceAccountName = invalidServiceAccountName
+				obj.ServiceAccountName = validServiceAccountName
 				obj.Secret = duckv1alpha1.DefaultGoogleCloudSecretSelector()
 				return *obj
 			}(),

--- a/pkg/apis/events/v1alpha1/cloudbuildsource_types_test.go
+++ b/pkg/apis/events/v1alpha1/cloudbuildsource_types_test.go
@@ -54,13 +54,13 @@ func TestCloudBuildSourceIdentitySpec(t *testing.T) {
 		Spec: CloudBuildSourceSpec{
 			PubSubSpec: v1alpha1.PubSubSpec{
 				IdentitySpec: v1alpha1.IdentitySpec{
-					GoogleServiceAccount: "test@test",
+					ServiceAccountName: "test",
 				},
 			},
 		},
 	}
-	want := "test@test"
-	got := s.IdentitySpec().GoogleServiceAccount
+	want := "test"
+	got := s.IdentitySpec().ServiceAccountName
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)
 	}

--- a/pkg/apis/events/v1alpha1/cloudbuildsource_validation.go
+++ b/pkg/apis/events/v1alpha1/cloudbuildsource_validation.go
@@ -46,7 +46,7 @@ func (current *CloudBuildSourceSpec) Validate(ctx context.Context) *apis.FieldEr
 		errs = errs.Also(err.ViaField("sink"))
 	}
 
-	if err := duckv1alpha1.ValidateCredential(current.Secret, current.GoogleServiceAccount); err != nil {
+	if err := duckv1alpha1.ValidateCredential(current.Secret, current.GoogleServiceAccount, current.ServiceAccountName); err != nil {
 		errs = errs.Also(err)
 	}
 

--- a/pkg/apis/events/v1alpha1/cloudbuildsource_validation_test.go
+++ b/pkg/apis/events/v1alpha1/cloudbuildsource_validation_test.go
@@ -173,18 +173,18 @@ func TestCloudBuildSourceCheckValidationFields(t *testing.T) {
 			}(),
 			error: false,
 		},
-		"invalid GCP service account": {
+		"invalid k8s service account": {
 			spec: func() CloudBuildSourceSpec {
 				obj := buildSourceSpec.DeepCopy()
-				obj.GoogleServiceAccount = invalidServiceAccountName
+				obj.ServiceAccountName = invalidServiceAccountName
 				return *obj
 			}(),
 			error: true,
 		},
-		"have GCP service account and secret at the same time": {
+		"have k8s service account and secret at the same time": {
 			spec: func() CloudBuildSourceSpec {
 				obj := buildSourceSpec.DeepCopy()
-				obj.GoogleServiceAccount = invalidServiceAccountName
+				obj.ServiceAccountName = invalidServiceAccountName
 				obj.Secret = duckv1alpha1.DefaultGoogleCloudSecretSelector()
 				return *obj
 			}(),

--- a/pkg/apis/events/v1alpha1/cloudbuildsource_validation_test.go
+++ b/pkg/apis/events/v1alpha1/cloudbuildsource_validation_test.go
@@ -184,7 +184,7 @@ func TestCloudBuildSourceCheckValidationFields(t *testing.T) {
 		"have k8s service account and secret at the same time": {
 			spec: func() CloudBuildSourceSpec {
 				obj := buildSourceSpec.DeepCopy()
-				obj.ServiceAccountName = invalidServiceAccountName
+				obj.ServiceAccountName = validServiceAccountName
 				obj.Secret = duckv1alpha1.DefaultGoogleCloudSecretSelector()
 				return *obj
 			}(),

--- a/pkg/apis/events/v1alpha1/cloudpubsubsource_types_test.go
+++ b/pkg/apis/events/v1alpha1/cloudpubsubsource_types_test.go
@@ -100,12 +100,12 @@ func TestCloudPubSubSourceIdentitySpec(t *testing.T) {
 		Spec: CloudPubSubSourceSpec{
 			PubSubSpec: v1alpha1.PubSubSpec{
 				IdentitySpec: v1alpha1.IdentitySpec{
-					GoogleServiceAccount: "test@test",
+					GoogleServiceAccount: "test",
 				},
 			},
 		},
 	}
-	want := "test@test"
+	want := "test"
 	got := s.IdentitySpec().GoogleServiceAccount
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)

--- a/pkg/apis/events/v1alpha1/cloudpubsubsource_validation.go
+++ b/pkg/apis/events/v1alpha1/cloudpubsubsource_validation.go
@@ -77,7 +77,7 @@ func (current *CloudPubSubSourceSpec) Validate(ctx context.Context) *apis.FieldE
 		}
 	}
 
-	if err := duckv1alpha1.ValidateCredential(current.Secret, current.GoogleServiceAccount); err != nil {
+	if err := duckv1alpha1.ValidateCredential(current.Secret, current.GoogleServiceAccount, current.ServiceAccountName); err != nil {
 		errs = errs.Also(err)
 	}
 

--- a/pkg/apis/events/v1alpha1/cloudpubsubsource_validation_test.go
+++ b/pkg/apis/events/v1alpha1/cloudpubsubsource_validation_test.go
@@ -196,18 +196,18 @@ func TestCloudPubSubSourceCheckValidationFields(t *testing.T) {
 			}(),
 			error: false,
 		},
-		"invalid GCP service account": {
+		"invalid k8s service account": {
 			spec: func() CloudPubSubSourceSpec {
 				obj := pubSubSourceSpec.DeepCopy()
-				obj.GoogleServiceAccount = invalidServiceAccountName
+				obj.ServiceAccountName = invalidServiceAccountName
 				return *obj
 			}(),
 			error: true,
 		},
-		"have GCP service account and secret at the same time": {
+		"have k8s service account and secret at the same time": {
 			spec: func() CloudPubSubSourceSpec {
 				obj := pubSubSourceSpec.DeepCopy()
-				obj.GoogleServiceAccount = invalidServiceAccountName
+				obj.ServiceAccountName = invalidServiceAccountName
 				obj.Secret = duckv1alpha1.DefaultGoogleCloudSecretSelector()
 				return *obj
 			}(),

--- a/pkg/apis/events/v1alpha1/cloudpubsubsource_validation_test.go
+++ b/pkg/apis/events/v1alpha1/cloudpubsubsource_validation_test.go
@@ -207,7 +207,7 @@ func TestCloudPubSubSourceCheckValidationFields(t *testing.T) {
 		"have k8s service account and secret at the same time": {
 			spec: func() CloudPubSubSourceSpec {
 				obj := pubSubSourceSpec.DeepCopy()
-				obj.ServiceAccountName = invalidServiceAccountName
+				obj.ServiceAccountName = validServiceAccountName
 				obj.Secret = duckv1alpha1.DefaultGoogleCloudSecretSelector()
 				return *obj
 			}(),

--- a/pkg/apis/events/v1alpha1/cloudschedulersource_types_test.go
+++ b/pkg/apis/events/v1alpha1/cloudschedulersource_types_test.go
@@ -83,12 +83,12 @@ func TestCloudSchedulerSourceIdentitySpec(t *testing.T) {
 		Spec: CloudSchedulerSourceSpec{
 			PubSubSpec: v1alpha1.PubSubSpec{
 				IdentitySpec: v1alpha1.IdentitySpec{
-					GoogleServiceAccount: "test@test",
+					GoogleServiceAccount: "test",
 				},
 			},
 		},
 	}
-	want := "test@test"
+	want := "test"
 	got := s.IdentitySpec().GoogleServiceAccount
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)

--- a/pkg/apis/events/v1alpha1/cloudschedulersource_validation.go
+++ b/pkg/apis/events/v1alpha1/cloudschedulersource_validation.go
@@ -59,7 +59,7 @@ func (current *CloudSchedulerSourceSpec) Validate(ctx context.Context) *apis.Fie
 		errs = errs.Also(apis.ErrMissingField("data"))
 	}
 
-	if err := duckv1alpha1.ValidateCredential(current.Secret, current.GoogleServiceAccount); err != nil {
+	if err := duckv1alpha1.ValidateCredential(current.Secret, current.GoogleServiceAccount, current.ServiceAccountName); err != nil {
 		errs = errs.Also(err)
 	}
 

--- a/pkg/apis/events/v1alpha1/cloudschedulersource_validation_test.go
+++ b/pkg/apis/events/v1alpha1/cloudschedulersource_validation_test.go
@@ -277,14 +277,14 @@ func TestCloudSchedulerSourceSpecValidationFields(t *testing.T) {
 			return fe
 		}(),
 	}, {
-		name: "invalid GCP service account",
+		name: "invalid k8s service account",
 		spec: &CloudSchedulerSourceSpec{
 			Location: "my-test-location",
 			Schedule: "* * * * *",
 			Data:     "data",
 			PubSubSpec: duckv1alpha1.PubSubSpec{
 				IdentitySpec: duckv1alpha1.IdentitySpec{
-					GoogleServiceAccount: invalidServiceAccountName,
+					ServiceAccountName: invalidServiceAccountName,
 				},
 				SourceSpec: duckv1.SourceSpec{
 					Sink: duckv1.Destination{
@@ -300,20 +300,20 @@ func TestCloudSchedulerSourceSpecValidationFields(t *testing.T) {
 		},
 		want: func() *apis.FieldError {
 			fe := &apis.FieldError{
-				Message: `invalid value: test@test.iam.kserviceaccount.com, googleServiceAccount should have format: ^[a-z][a-z0-9-]{5,29}@[a-z][a-z0-9-]{5,29}.iam.gserviceaccount.com$`,
-				Paths:   []string{"googleServiceAccount"},
+				Message: `invalid value: @test, serviceAccountName should have format: ^[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?$`,
+				Paths:   []string{"serviceAccountName"},
 			}
 			return fe
 		}(),
 	}, {
-		name: "have GCP service account and secret at the same time",
+		name: "have k8s service account and secret at the same time",
 		spec: &CloudSchedulerSourceSpec{
 			Location: "my-test-location",
 			Schedule: "* * * * *",
 			Data:     "data",
 			PubSubSpec: duckv1alpha1.PubSubSpec{
 				IdentitySpec: duckv1alpha1.IdentitySpec{
-					GoogleServiceAccount: invalidServiceAccountName,
+					ServiceAccountName: invalidServiceAccountName,
 				},
 				SourceSpec: duckv1.SourceSpec{
 					Sink: duckv1.Destination{
@@ -333,7 +333,7 @@ func TestCloudSchedulerSourceSpecValidationFields(t *testing.T) {
 		},
 		want: func() *apis.FieldError {
 			fe := &apis.FieldError{
-				Message: "Can't have spec.googleServiceAccount and spec.secret at the same time",
+				Message: "Can't have spec.serviceAccountName and spec.secret at the same time",
 				Paths:   []string{""},
 			}
 			return fe

--- a/pkg/apis/events/v1alpha1/cloudschedulersource_validation_test.go
+++ b/pkg/apis/events/v1alpha1/cloudschedulersource_validation_test.go
@@ -313,7 +313,7 @@ func TestCloudSchedulerSourceSpecValidationFields(t *testing.T) {
 			Data:     "data",
 			PubSubSpec: duckv1alpha1.PubSubSpec{
 				IdentitySpec: duckv1alpha1.IdentitySpec{
-					ServiceAccountName: invalidServiceAccountName,
+					ServiceAccountName: validServiceAccountName,
 				},
 				SourceSpec: duckv1.SourceSpec{
 					Sink: duckv1.Destination{

--- a/pkg/apis/events/v1alpha1/cloudstoragesource_conversion_test.go
+++ b/pkg/apis/events/v1alpha1/cloudstoragesource_conversion_test.go
@@ -37,12 +37,11 @@ var (
 	completeCloudStorageSource = &CloudStorageSource{
 		ObjectMeta: completeObjectMeta,
 		Spec: CloudStorageSourceSpec{
-			PubSubSpec:         completePubSubSpec,
-			ServiceAccountName: "serviceAccountName",
-			Bucket:             "bucket",
-			EventTypes:         []string{"event", "types"},
-			ObjectNamePrefix:   "objectNamePrefix",
-			PayloadFormat:      "payloadFormat",
+			PubSubSpec:       completePubSubSpec,
+			Bucket:           "bucket",
+			EventTypes:       []string{"event", "types"},
+			ObjectNamePrefix: "objectNamePrefix",
+			PayloadFormat:    "payloadFormat",
 		},
 		Status: CloudStorageSourceStatus{
 			PubSubStatus:   completePubSubStatus,

--- a/pkg/apis/events/v1alpha1/cloudstoragesource_types.go
+++ b/pkg/apis/events/v1alpha1/cloudstoragesource_types.go
@@ -62,13 +62,6 @@ type CloudStorageSourceSpec struct {
 	// Sink, CloudEventOverrides, Secret, PubSubSecret, and Project
 	duckv1alpha1.PubSubSpec `json:",inline"`
 
-	// ServiceAccountName holds the name of the Kubernetes service account
-	// as which the underlying K8s resources should be run. If unspecified
-	// this will default to the "default" service account for the namespace
-	// in which the GCS exists.
-	// +optional
-	ServiceAccountName string `json:"serviceAccountName,omitempty"`
-
 	// Bucket to subscribe to.
 	Bucket string `json:"bucket"`
 

--- a/pkg/apis/events/v1alpha1/cloudstoragesource_types_test.go
+++ b/pkg/apis/events/v1alpha1/cloudstoragesource_types_test.go
@@ -81,12 +81,12 @@ func TestCloudStorageSourceIdentitySpec(t *testing.T) {
 		Spec: CloudStorageSourceSpec{
 			PubSubSpec: v1alpha1.PubSubSpec{
 				IdentitySpec: v1alpha1.IdentitySpec{
-					GoogleServiceAccount: "test@test",
+					GoogleServiceAccount: "test",
 				},
 			},
 		},
 	}
-	want := "test@test"
+	want := "test"
 	got := s.IdentitySpec().GoogleServiceAccount
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)

--- a/pkg/apis/events/v1alpha1/cloudstoragesource_validation.go
+++ b/pkg/apis/events/v1alpha1/cloudstoragesource_validation.go
@@ -49,7 +49,7 @@ func (current *CloudStorageSourceSpec) Validate(ctx context.Context) *apis.Field
 		errs = errs.Also(apis.ErrMissingField("bucket"))
 	}
 
-	if err := duckv1alpha1.ValidateCredential(current.Secret, current.GoogleServiceAccount); err != nil {
+	if err := duckv1alpha1.ValidateCredential(current.Secret, current.GoogleServiceAccount, current.ServiceAccountName); err != nil {
 		errs = errs.Also(err)
 	}
 

--- a/pkg/apis/events/v1alpha1/cloudstoragesource_validation_test.go
+++ b/pkg/apis/events/v1alpha1/cloudstoragesource_validation_test.go
@@ -256,12 +256,12 @@ func TestSpecValidationFields(t *testing.T) {
 			return fe
 		}(),
 	}, {
-		name: "invalid GCP service account",
+		name: "invalid k8s service account",
 		spec: &CloudStorageSourceSpec{
 			Bucket: "my-test-bucket",
 			PubSubSpec: duckv1alpha1.PubSubSpec{
 				IdentitySpec: duckv1alpha1.IdentitySpec{
-					GoogleServiceAccount: invalidServiceAccountName,
+					ServiceAccountName: invalidServiceAccountName,
 				},
 				SourceSpec: duckv1.SourceSpec{
 					Sink: duckv1.Destination{
@@ -277,18 +277,18 @@ func TestSpecValidationFields(t *testing.T) {
 		},
 		want: func() *apis.FieldError {
 			fe := &apis.FieldError{
-				Message: `invalid value: test@test.iam.kserviceaccount.com, googleServiceAccount should have format: ^[a-z][a-z0-9-]{5,29}@[a-z][a-z0-9-]{5,29}.iam.gserviceaccount.com$`,
-				Paths:   []string{"googleServiceAccount"},
+				Message: `invalid value: @test, serviceAccountName should have format: ^[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?$`,
+				Paths:   []string{"serviceAccountName"},
 			}
 			return fe
 		}(),
 	}, {
-		name: "valid GCP service account",
+		name: "valid k8s service account",
 		spec: &CloudStorageSourceSpec{
 			Bucket: "my-test-bucket",
 			PubSubSpec: duckv1alpha1.PubSubSpec{
 				IdentitySpec: duckv1alpha1.IdentitySpec{
-					GoogleServiceAccount: validServiceAccountName,
+					ServiceAccountName: validServiceAccountName,
 				},
 				SourceSpec: duckv1.SourceSpec{
 					Sink: duckv1.Destination{
@@ -304,12 +304,12 @@ func TestSpecValidationFields(t *testing.T) {
 		},
 		want: nil,
 	}, {
-		name: "have GCP service account and secret at the same time",
+		name: "have k8s service account and secret at the same time",
 		spec: &CloudStorageSourceSpec{
 			Bucket: "my-test-bucket",
 			PubSubSpec: duckv1alpha1.PubSubSpec{
 				IdentitySpec: duckv1alpha1.IdentitySpec{
-					GoogleServiceAccount: invalidServiceAccountName,
+					ServiceAccountName: invalidServiceAccountName,
 				},
 				SourceSpec: duckv1.SourceSpec{
 					Sink: duckv1.Destination{
@@ -329,7 +329,7 @@ func TestSpecValidationFields(t *testing.T) {
 		},
 		want: func() *apis.FieldError {
 			fe := &apis.FieldError{
-				Message: "Can't have spec.googleServiceAccount and spec.secret at the same time",
+				Message: "Can't have spec.serviceAccountName and spec.secret at the same time",
 				Paths:   []string{""},
 			}
 			return fe

--- a/pkg/apis/events/v1alpha1/cloudstoragesource_validation_test.go
+++ b/pkg/apis/events/v1alpha1/cloudstoragesource_validation_test.go
@@ -309,7 +309,7 @@ func TestSpecValidationFields(t *testing.T) {
 			Bucket: "my-test-bucket",
 			PubSubSpec: duckv1alpha1.PubSubSpec{
 				IdentitySpec: duckv1alpha1.IdentitySpec{
-					ServiceAccountName: invalidServiceAccountName,
+					ServiceAccountName: validServiceAccountName,
 				},
 				SourceSpec: duckv1.SourceSpec{
 					Sink: duckv1.Destination{

--- a/pkg/apis/events/v1beta1/cloudauditlogssource_types_test.go
+++ b/pkg/apis/events/v1beta1/cloudauditlogssource_types_test.go
@@ -93,13 +93,13 @@ func TestCloudAuditLogsSourceIdentitySpec(t *testing.T) {
 		Spec: CloudAuditLogsSourceSpec{
 			PubSubSpec: duckv1beta1.PubSubSpec{
 				IdentitySpec: duckv1beta1.IdentitySpec{
-					GoogleServiceAccount: "test@test",
+					ServiceAccountName: "test",
 				},
 			},
 		},
 	}
-	want := "test@test"
-	got := s.IdentitySpec().GoogleServiceAccount
+	want := "test"
+	got := s.IdentitySpec().ServiceAccountName
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)
 	}

--- a/pkg/apis/events/v1beta1/cloudauditlogssource_validation.go
+++ b/pkg/apis/events/v1beta1/cloudauditlogssource_validation.go
@@ -50,7 +50,7 @@ func (current *CloudAuditLogsSourceSpec) Validate(ctx context.Context) *apis.Fie
 		errs = errs.Also(apis.ErrMissingField("methodName"))
 	}
 
-	if err := duckv1beta1.ValidateCredential(current.Secret, current.GoogleServiceAccount); err != nil {
+	if err := duckv1beta1.ValidateCredential(current.Secret, current.ServiceAccountName); err != nil {
 		errs = errs.Also(err)
 	}
 

--- a/pkg/apis/events/v1beta1/cloudauditlogssource_validation_test.go
+++ b/pkg/apis/events/v1beta1/cloudauditlogssource_validation_test.go
@@ -123,7 +123,7 @@ func TestCloudAuditLogsSourceValidationFields(t *testing.T) {
 		"have k8s service account and secret at the same time": {
 			spec: func() CloudAuditLogsSourceSpec {
 				obj := auditLogsSourceSpec.DeepCopy()
-				obj.ServiceAccountName = invalidServiceAccountName
+				obj.ServiceAccountName = validServiceAccountName
 				obj.Secret = duckv1beta1.DefaultGoogleCloudSecretSelector()
 				return *obj
 			}(),

--- a/pkg/apis/events/v1beta1/cloudauditlogssource_validation_test.go
+++ b/pkg/apis/events/v1beta1/cloudauditlogssource_validation_test.go
@@ -50,8 +50,8 @@ var (
 			Project: "my-eventing-project",
 		},
 	}
-	validServiceAccountName   = "test123@test123.iam.gserviceaccount.com"
-	invalidServiceAccountName = "test@test.iam.kserviceaccount.com"
+	validServiceAccountName   = "test"
+	invalidServiceAccountName = "@test"
 )
 
 func TestCloudAuditLogsSourceValidationFields(t *testing.T) {
@@ -112,18 +112,18 @@ func TestCloudAuditLogsSourceValidationFields(t *testing.T) {
 			}(),
 			error: true,
 		},
-		"invalid GCP service account": {
+		"invalid k8s service account": {
 			spec: func() CloudAuditLogsSourceSpec {
 				obj := auditLogsSourceSpec.DeepCopy()
-				obj.GoogleServiceAccount = invalidServiceAccountName
+				obj.ServiceAccountName = invalidServiceAccountName
 				return *obj
 			}(),
 			error: true,
 		},
-		"have GCP service account and secret at the same time": {
+		"have k8s service account and secret at the same time": {
 			spec: func() CloudAuditLogsSourceSpec {
 				obj := auditLogsSourceSpec.DeepCopy()
-				obj.GoogleServiceAccount = invalidServiceAccountName
+				obj.ServiceAccountName = invalidServiceAccountName
 				obj.Secret = duckv1beta1.DefaultGoogleCloudSecretSelector()
 				return *obj
 			}(),
@@ -206,7 +206,7 @@ func TestCloudAuditLogsSourceCheckImmutableFields(t *testing.T) {
 			updated: CloudAuditLogsSourceSpec{
 				PubSubSpec: duckv1beta1.PubSubSpec{
 					IdentitySpec: duckv1beta1.IdentitySpec{
-						GoogleServiceAccount: "new-service-account",
+						ServiceAccountName: "new-service-account",
 					},
 					Secret: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{

--- a/pkg/apis/events/v1beta1/cloudpubsubsource_types_test.go
+++ b/pkg/apis/events/v1beta1/cloudpubsubsource_types_test.go
@@ -100,13 +100,13 @@ func TestCloudPubSubSourceIdentitySpec(t *testing.T) {
 		Spec: CloudPubSubSourceSpec{
 			PubSubSpec: v1beta1.PubSubSpec{
 				IdentitySpec: v1beta1.IdentitySpec{
-					GoogleServiceAccount: "test@test",
+					ServiceAccountName: "test",
 				},
 			},
 		},
 	}
-	want := "test@test"
-	got := s.IdentitySpec().GoogleServiceAccount
+	want := "test"
+	got := s.IdentitySpec().ServiceAccountName
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)
 	}

--- a/pkg/apis/events/v1beta1/cloudpubsubsource_validation.go
+++ b/pkg/apis/events/v1beta1/cloudpubsubsource_validation.go
@@ -76,7 +76,7 @@ func (current *CloudPubSubSourceSpec) Validate(ctx context.Context) *apis.FieldE
 		}
 	}
 
-	if err := duckv1beta1.ValidateCredential(current.Secret, current.GoogleServiceAccount); err != nil {
+	if err := duckv1beta1.ValidateCredential(current.Secret, current.ServiceAccountName); err != nil {
 		errs = errs.Also(err)
 	}
 

--- a/pkg/apis/events/v1beta1/cloudpubsubsource_validation_test.go
+++ b/pkg/apis/events/v1beta1/cloudpubsubsource_validation_test.go
@@ -192,18 +192,18 @@ func TestCloudPubSubSourceCheckValidationFields(t *testing.T) {
 			}(),
 			error: false,
 		},
-		"invalid GCP service account": {
+		"invalid k8s service account": {
 			spec: func() CloudPubSubSourceSpec {
 				obj := pubSubSourceSpec.DeepCopy()
-				obj.GoogleServiceAccount = invalidServiceAccountName
+				obj.ServiceAccountName = invalidServiceAccountName
 				return *obj
 			}(),
 			error: true,
 		},
-		"have GCP service account and secret at the same time": {
+		"have k8s service account and secret at the same time": {
 			spec: func() CloudPubSubSourceSpec {
 				obj := pubSubSourceSpec.DeepCopy()
-				obj.GoogleServiceAccount = invalidServiceAccountName
+				obj.ServiceAccountName = invalidServiceAccountName
 				obj.Secret = duckv1beta1.DefaultGoogleCloudSecretSelector()
 				return *obj
 			}(),
@@ -292,7 +292,7 @@ func TestCloudPubSubSourceCheckImmutableFields(t *testing.T) {
 			updated: CloudPubSubSourceSpec{
 				PubSubSpec: duckv1beta1.PubSubSpec{
 					IdentitySpec: duckv1beta1.IdentitySpec{
-						GoogleServiceAccount: "new-service-account",
+						ServiceAccountName: "new-service-account",
 					},
 					Secret: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{

--- a/pkg/apis/events/v1beta1/cloudpubsubsource_validation_test.go
+++ b/pkg/apis/events/v1beta1/cloudpubsubsource_validation_test.go
@@ -203,7 +203,7 @@ func TestCloudPubSubSourceCheckValidationFields(t *testing.T) {
 		"have k8s service account and secret at the same time": {
 			spec: func() CloudPubSubSourceSpec {
 				obj := pubSubSourceSpec.DeepCopy()
-				obj.ServiceAccountName = invalidServiceAccountName
+				obj.ServiceAccountName = validServiceAccountName
 				obj.Secret = duckv1beta1.DefaultGoogleCloudSecretSelector()
 				return *obj
 			}(),

--- a/pkg/apis/events/v1beta1/cloudschedulersource_types_test.go
+++ b/pkg/apis/events/v1beta1/cloudschedulersource_types_test.go
@@ -83,13 +83,13 @@ func TestCloudSchedulerSourceIdentitySpec(t *testing.T) {
 		Spec: CloudSchedulerSourceSpec{
 			PubSubSpec: v1beta1.PubSubSpec{
 				IdentitySpec: v1beta1.IdentitySpec{
-					GoogleServiceAccount: "test@test",
+					ServiceAccountName: "test",
 				},
 			},
 		},
 	}
-	want := "test@test"
-	got := s.IdentitySpec().GoogleServiceAccount
+	want := "test"
+	got := s.IdentitySpec().ServiceAccountName
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)
 	}

--- a/pkg/apis/events/v1beta1/cloudschedulersource_validation.go
+++ b/pkg/apis/events/v1beta1/cloudschedulersource_validation.go
@@ -57,7 +57,7 @@ func (current *CloudSchedulerSourceSpec) Validate(ctx context.Context) *apis.Fie
 		errs = errs.Also(apis.ErrMissingField("data"))
 	}
 
-	if err := duckv1beta1.ValidateCredential(current.Secret, current.GoogleServiceAccount); err != nil {
+	if err := duckv1beta1.ValidateCredential(current.Secret, current.ServiceAccountName); err != nil {
 		errs = errs.Also(err)
 	}
 

--- a/pkg/apis/events/v1beta1/cloudschedulersource_validation_test.go
+++ b/pkg/apis/events/v1beta1/cloudschedulersource_validation_test.go
@@ -274,14 +274,14 @@ func TestCloudSchedulerSourceSpecValidationFields(t *testing.T) {
 			return fe
 		}(),
 	}, {
-		name: "invalid GCP service account",
+		name: "invalid k8s service account",
 		spec: &CloudSchedulerSourceSpec{
 			Location: "my-test-location",
 			Schedule: "* * * * *",
 			Data:     "data",
 			PubSubSpec: duckv1beta1.PubSubSpec{
 				IdentitySpec: duckv1beta1.IdentitySpec{
-					GoogleServiceAccount: invalidServiceAccountName,
+					ServiceAccountName: invalidServiceAccountName,
 				},
 				SourceSpec: duckv1.SourceSpec{
 					Sink: duckv1.Destination{
@@ -297,20 +297,20 @@ func TestCloudSchedulerSourceSpecValidationFields(t *testing.T) {
 		},
 		want: func() *apis.FieldError {
 			fe := &apis.FieldError{
-				Message: `invalid value: test@test.iam.kserviceaccount.com, googleServiceAccount should have format: ^[a-z][a-z0-9-]{5,29}@[a-z][a-z0-9-]{5,29}.iam.gserviceaccount.com$`,
-				Paths:   []string{"googleServiceAccount"},
+				Message: `invalid value: @test, serviceAccountName should have format: ^[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?$`,
+				Paths:   []string{"serviceAccountName"},
 			}
 			return fe
 		}(),
 	}, {
-		name: "have GCP service account and secret at the same time",
+		name: "have k8s service account and secret at the same time",
 		spec: &CloudSchedulerSourceSpec{
 			Location: "my-test-location",
 			Schedule: "* * * * *",
 			Data:     "data",
 			PubSubSpec: duckv1beta1.PubSubSpec{
 				IdentitySpec: duckv1beta1.IdentitySpec{
-					GoogleServiceAccount: invalidServiceAccountName,
+					ServiceAccountName: invalidServiceAccountName,
 				},
 				SourceSpec: duckv1.SourceSpec{
 					Sink: duckv1.Destination{
@@ -330,7 +330,7 @@ func TestCloudSchedulerSourceSpecValidationFields(t *testing.T) {
 		},
 		want: func() *apis.FieldError {
 			fe := &apis.FieldError{
-				Message: "Can't have spec.googleServiceAccount and spec.secret at the same time",
+				Message: "Can't have spec.serviceAccountName and spec.secret at the same time",
 				Paths:   []string{""},
 			}
 			return fe
@@ -428,7 +428,7 @@ func TestCloudSchedulerSourceSpecCheckImmutableFields(t *testing.T) {
 				Data:     schedulerWithSecret.Data,
 				PubSubSpec: duckv1beta1.PubSubSpec{
 					IdentitySpec: duckv1beta1.IdentitySpec{
-						GoogleServiceAccount: "new-service-account",
+						ServiceAccountName: "new-service-account",
 					},
 					SourceSpec: schedulerWithSecret.SourceSpec,
 					Secret:     schedulerWithSecret.Secret,

--- a/pkg/apis/events/v1beta1/cloudschedulersource_validation_test.go
+++ b/pkg/apis/events/v1beta1/cloudschedulersource_validation_test.go
@@ -310,7 +310,7 @@ func TestCloudSchedulerSourceSpecValidationFields(t *testing.T) {
 			Data:     "data",
 			PubSubSpec: duckv1beta1.PubSubSpec{
 				IdentitySpec: duckv1beta1.IdentitySpec{
-					ServiceAccountName: invalidServiceAccountName,
+					ServiceAccountName: validServiceAccountName,
 				},
 				SourceSpec: duckv1.SourceSpec{
 					Sink: duckv1.Destination{

--- a/pkg/apis/events/v1beta1/cloudstoragesource_types.go
+++ b/pkg/apis/events/v1beta1/cloudstoragesource_types.go
@@ -60,13 +60,6 @@ type CloudStorageSourceSpec struct {
 	// Sink, CloudEventOverrides, Secret, PubSubSecret, and Project
 	duckv1beta1.PubSubSpec `json:",inline"`
 
-	// ServiceAccountName holds the name of the Kubernetes service account
-	// as which the underlying K8s resources should be run. If unspecified
-	// this will default to the "default" service account for the namespace
-	// in which the GCS exists.
-	// +optional
-	ServiceAccountName string `json:"serviceAccountName,omitempty"`
-
 	// Bucket to subscribe to.
 	Bucket string `json:"bucket"`
 

--- a/pkg/apis/events/v1beta1/cloudstoragesource_types_test.go
+++ b/pkg/apis/events/v1beta1/cloudstoragesource_types_test.go
@@ -81,13 +81,13 @@ func TestCloudStorageSourceIdentitySpec(t *testing.T) {
 		Spec: CloudStorageSourceSpec{
 			PubSubSpec: v1beta1.PubSubSpec{
 				IdentitySpec: v1beta1.IdentitySpec{
-					GoogleServiceAccount: "test@test",
+					ServiceAccountName: "test",
 				},
 			},
 		},
 	}
-	want := "test@test"
-	got := s.IdentitySpec().GoogleServiceAccount
+	want := "test"
+	got := s.IdentitySpec().ServiceAccountName
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)
 	}

--- a/pkg/apis/events/v1beta1/cloudstoragesource_validation.go
+++ b/pkg/apis/events/v1beta1/cloudstoragesource_validation.go
@@ -48,7 +48,7 @@ func (current *CloudStorageSourceSpec) Validate(ctx context.Context) *apis.Field
 		errs = errs.Also(apis.ErrMissingField("bucket"))
 	}
 
-	if err := duckv1beta1.ValidateCredential(current.Secret, current.GoogleServiceAccount); err != nil {
+	if err := duckv1beta1.ValidateCredential(current.Secret, current.ServiceAccountName); err != nil {
 		errs = errs.Also(err)
 	}
 

--- a/pkg/apis/events/v1beta1/cloudstoragesource_validation_test.go
+++ b/pkg/apis/events/v1beta1/cloudstoragesource_validation_test.go
@@ -252,12 +252,12 @@ func TestSpecValidationFields(t *testing.T) {
 			return fe
 		}(),
 	}, {
-		name: "invalid GCP service account",
+		name: "invalid k8s service account",
 		spec: &CloudStorageSourceSpec{
 			Bucket: "my-test-bucket",
 			PubSubSpec: duckv1beta1.PubSubSpec{
 				IdentitySpec: duckv1beta1.IdentitySpec{
-					GoogleServiceAccount: invalidServiceAccountName,
+					ServiceAccountName: invalidServiceAccountName,
 				},
 				SourceSpec: duckv1.SourceSpec{
 					Sink: duckv1.Destination{
@@ -273,18 +273,18 @@ func TestSpecValidationFields(t *testing.T) {
 		},
 		want: func() *apis.FieldError {
 			fe := &apis.FieldError{
-				Message: `invalid value: test@test.iam.kserviceaccount.com, googleServiceAccount should have format: ^[a-z][a-z0-9-]{5,29}@[a-z][a-z0-9-]{5,29}.iam.gserviceaccount.com$`,
-				Paths:   []string{"googleServiceAccount"},
+				Message: `invalid value: @test, serviceAccountName should have format: ^[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?$`,
+				Paths:   []string{"serviceAccountName"},
 			}
 			return fe
 		}(),
 	}, {
-		name: "valid GCP service account",
+		name: "valid k8s service account",
 		spec: &CloudStorageSourceSpec{
 			Bucket: "my-test-bucket",
 			PubSubSpec: duckv1beta1.PubSubSpec{
 				IdentitySpec: duckv1beta1.IdentitySpec{
-					GoogleServiceAccount: validServiceAccountName,
+					ServiceAccountName: validServiceAccountName,
 				},
 				SourceSpec: duckv1.SourceSpec{
 					Sink: duckv1.Destination{
@@ -300,12 +300,12 @@ func TestSpecValidationFields(t *testing.T) {
 		},
 		want: nil,
 	}, {
-		name: "have GCP service account and secret at the same time",
+		name: "have k8s service account and secret at the same time",
 		spec: &CloudStorageSourceSpec{
 			Bucket: "my-test-bucket",
 			PubSubSpec: duckv1beta1.PubSubSpec{
 				IdentitySpec: duckv1beta1.IdentitySpec{
-					GoogleServiceAccount: invalidServiceAccountName,
+					ServiceAccountName: invalidServiceAccountName,
 				},
 				SourceSpec: duckv1.SourceSpec{
 					Sink: duckv1.Destination{
@@ -325,7 +325,7 @@ func TestSpecValidationFields(t *testing.T) {
 		},
 		want: func() *apis.FieldError {
 			fe := &apis.FieldError{
-				Message: "Can't have spec.googleServiceAccount and spec.secret at the same time",
+				Message: "Can't have spec.serviceAccountName and spec.secret at the same time",
 				Paths:   []string{""},
 			}
 			return fe
@@ -439,7 +439,7 @@ func TestCheckImmutableFields(t *testing.T) {
 				PayloadFormat:    storageSourceSpec.PayloadFormat,
 				PubSubSpec: duckv1beta1.PubSubSpec{
 					IdentitySpec: duckv1beta1.IdentitySpec{
-						GoogleServiceAccount: "new-service-account",
+						ServiceAccountName: "new-service-account",
 					},
 					SourceSpec: storageSourceSpec.SourceSpec,
 					Secret:     storageSourceSpec.Secret,

--- a/pkg/apis/events/v1beta1/cloudstoragesource_validation_test.go
+++ b/pkg/apis/events/v1beta1/cloudstoragesource_validation_test.go
@@ -305,7 +305,7 @@ func TestSpecValidationFields(t *testing.T) {
 			Bucket: "my-test-bucket",
 			PubSubSpec: duckv1beta1.PubSubSpec{
 				IdentitySpec: duckv1beta1.IdentitySpec{
-					ServiceAccountName: invalidServiceAccountName,
+					ServiceAccountName: validServiceAccountName,
 				},
 				SourceSpec: duckv1.SourceSpec{
 					Sink: duckv1.Destination{

--- a/pkg/apis/intevents/v1alpha1/pullsubscription_conversion_test.go
+++ b/pkg/apis/intevents/v1alpha1/pullsubscription_conversion_test.go
@@ -100,7 +100,7 @@ var (
 	}
 
 	completeIdentitySpec = duckv1alpha1.IdentitySpec{
-		GoogleServiceAccount: "googleServiceAccount",
+		ServiceAccountName: "k8sServiceAccount",
 	}
 
 	completeSecret = &v1.SecretKeySelector{

--- a/pkg/apis/intevents/v1alpha1/pullsubscription_types_test.go
+++ b/pkg/apis/intevents/v1alpha1/pullsubscription_types_test.go
@@ -100,13 +100,13 @@ func TestPullSubscriptionIdentitySpec(t *testing.T) {
 		Spec: PullSubscriptionSpec{
 			PubSubSpec: v1alpha1.PubSubSpec{
 				IdentitySpec: v1alpha1.IdentitySpec{
-					GoogleServiceAccount: "test@test",
+					ServiceAccountName: "test",
 				},
 			},
 		},
 	}
-	want := "test@test"
-	got := s.IdentitySpec().GoogleServiceAccount
+	want := "test"
+	got := s.IdentitySpec().ServiceAccountName
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)
 	}

--- a/pkg/apis/intevents/v1alpha1/topic_types_test.go
+++ b/pkg/apis/intevents/v1alpha1/topic_types_test.go
@@ -46,12 +46,12 @@ func TestTopicIdentitySpec(t *testing.T) {
 	s := &Topic{
 		Spec: TopicSpec{
 			IdentitySpec: v1alpha1.IdentitySpec{
-				GoogleServiceAccount: "test@test",
+				ServiceAccountName: "test",
 			},
 		},
 	}
-	want := "test@test"
-	got := s.IdentitySpec().GoogleServiceAccount
+	want := "test"
+	got := s.IdentitySpec().ServiceAccountName
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)
 	}

--- a/pkg/apis/intevents/v1beta1/pullsubscription_types_test.go
+++ b/pkg/apis/intevents/v1beta1/pullsubscription_types_test.go
@@ -100,13 +100,13 @@ func TestPullSubscriptionIdentitySpec(t *testing.T) {
 		Spec: PullSubscriptionSpec{
 			PubSubSpec: v1beta1.PubSubSpec{
 				IdentitySpec: v1beta1.IdentitySpec{
-					GoogleServiceAccount: "test@test",
+					ServiceAccountName: "test",
 				},
 			},
 		},
 	}
-	want := "test@test"
-	got := s.IdentitySpec().GoogleServiceAccount
+	want := "test"
+	got := s.IdentitySpec().ServiceAccountName
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)
 	}

--- a/pkg/apis/intevents/v1beta1/topic_types_test.go
+++ b/pkg/apis/intevents/v1beta1/topic_types_test.go
@@ -46,12 +46,12 @@ func TestTopicIdentitySpec(t *testing.T) {
 	s := &Topic{
 		Spec: TopicSpec{
 			IdentitySpec: v1beta1.IdentitySpec{
-				GoogleServiceAccount: "test@test",
+				ServiceAccountName: "test",
 			},
 		},
 	}
-	want := "test@test"
-	got := s.IdentitySpec().GoogleServiceAccount
+	want := "test"
+	got := s.IdentitySpec().ServiceAccountName
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)
 	}

--- a/pkg/apis/messaging/v1alpha1/channel_conversion_test.go
+++ b/pkg/apis/messaging/v1alpha1/channel_conversion_test.go
@@ -98,7 +98,7 @@ var (
 	}
 
 	completeIdentitySpec = duckv1alpha1.IdentitySpec{
-		GoogleServiceAccount: "googleServiceAccount",
+		ServiceAccountName: "k8sServiceAccount",
 	}
 
 	completeSecret = &v1.SecretKeySelector{

--- a/pkg/apis/messaging/v1alpha1/channel_defaults.go
+++ b/pkg/apis/messaging/v1alpha1/channel_defaults.go
@@ -66,7 +66,8 @@ func (c *Channel) SetDefaults(ctx context.Context) {
 }
 
 func (cs *ChannelSpec) SetDefaults(ctx context.Context) {
-	if cs.GoogleServiceAccount == "" && (cs.Secret == nil || equality.Semantic.DeepEqual(cs.Secret, &corev1.SecretKeySelector{})) {
+	if cs.GoogleServiceAccount == "" && cs.ServiceAccountName == "" &&
+		(cs.Secret == nil || equality.Semantic.DeepEqual(cs.Secret, &corev1.SecretKeySelector{})) {
 		cs.Secret = defaultSecretSelector()
 	}
 }

--- a/pkg/apis/messaging/v1alpha1/channel_types_test.go
+++ b/pkg/apis/messaging/v1alpha1/channel_types_test.go
@@ -47,11 +47,11 @@ func TestChannelIdentitySpec(t *testing.T) {
 	s := &Channel{
 		Spec: ChannelSpec{
 			IdentitySpec: duckv1alpha1.IdentitySpec{
-				GoogleServiceAccount: "test@test",
+				GoogleServiceAccount: "test",
 			},
 		},
 	}
-	want := "test@test"
+	want := "test"
 	got := s.IdentitySpec().GoogleServiceAccount
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)

--- a/pkg/apis/messaging/v1alpha1/channel_validation.go
+++ b/pkg/apis/messaging/v1alpha1/channel_validation.go
@@ -44,7 +44,7 @@ func (cs *ChannelSpec) Validate(ctx context.Context) *apis.FieldError {
 		}
 	}
 
-	if err := duckv1alpha1.ValidateCredential(cs.Secret, cs.GoogleServiceAccount); err != nil {
+	if err := duckv1alpha1.ValidateCredential(cs.Secret, cs.GoogleServiceAccount, cs.ServiceAccountName); err != nil {
 		errs = errs.Also(err)
 	}
 

--- a/pkg/apis/messaging/v1alpha1/channel_validation_test.go
+++ b/pkg/apis/messaging/v1alpha1/channel_validation_test.go
@@ -32,8 +32,8 @@ import (
 )
 
 var (
-	validServiceAccountName   = "test123@test123.iam.gserviceaccount.com"
-	invalidServiceAccountName = "test@test.iam.kserviceaccount.com"
+	validServiceAccountName   = "test"
+	invalidServiceAccountName = "@test"
 
 	channelSpec = ChannelSpec{
 		Subscribable: &eventingduck.Subscribable{
@@ -141,7 +141,7 @@ func TestChannelValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
-		name: "invalid GCP service account",
+		name: "invalid k8s service account",
 		cr: &Channel{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
@@ -150,7 +150,7 @@ func TestChannelValidation(t *testing.T) {
 			},
 			Spec: ChannelSpec{
 				IdentitySpec: duckv1alpha1.IdentitySpec{
-					GoogleServiceAccount: invalidServiceAccountName,
+					ServiceAccountName: invalidServiceAccountName,
 				},
 				Subscribable: &eventingduck.Subscribable{
 					Subscribers: []eventingduck.SubscriberSpec{{
@@ -161,13 +161,13 @@ func TestChannelValidation(t *testing.T) {
 		},
 		want: func() *apis.FieldError {
 			fe := &apis.FieldError{
-				Message: `invalid value: test@test.iam.kserviceaccount.com, googleServiceAccount should have format: ^[a-z][a-z0-9-]{5,29}@[a-z][a-z0-9-]{5,29}.iam.gserviceaccount.com$`,
-				Paths:   []string{"spec.googleServiceAccount"},
+				Message: `invalid value: @test, serviceAccountName should have format: ^[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?$`,
+				Paths:   []string{"spec.serviceAccountName"},
 			}
 			return fe
 		}(),
 	}, {
-		name: "valid GCP service account",
+		name: "valid k8s service account",
 		cr: &Channel{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
@@ -176,7 +176,7 @@ func TestChannelValidation(t *testing.T) {
 			},
 			Spec: ChannelSpec{
 				IdentitySpec: duckv1alpha1.IdentitySpec{
-					GoogleServiceAccount: validServiceAccountName,
+					ServiceAccountName: validServiceAccountName,
 				},
 				Subscribable: &eventingduck.Subscribable{
 					Subscribers: []eventingduck.SubscriberSpec{{
@@ -187,7 +187,7 @@ func TestChannelValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
-		name: "have GCP service account and secret at the same time",
+		name: "have k8s service account and secret at the same time",
 		cr: &Channel{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
@@ -196,7 +196,7 @@ func TestChannelValidation(t *testing.T) {
 			},
 			Spec: ChannelSpec{
 				IdentitySpec: duckv1alpha1.IdentitySpec{
-					GoogleServiceAccount: validServiceAccountName,
+					ServiceAccountName: validServiceAccountName,
 				},
 				Secret: defaultSecretSelector(),
 				Subscribable: &eventingduck.Subscribable{
@@ -208,7 +208,7 @@ func TestChannelValidation(t *testing.T) {
 		},
 		want: func() *apis.FieldError {
 			fe := &apis.FieldError{
-				Message: "Can't have spec.googleServiceAccount and spec.secret at the same time",
+				Message: "Can't have spec.serviceAccountName and spec.secret at the same time",
 				Paths:   []string{"spec"},
 			}
 			return fe

--- a/pkg/apis/messaging/v1beta1/channel_defaults.go
+++ b/pkg/apis/messaging/v1beta1/channel_defaults.go
@@ -62,7 +62,7 @@ func (c *Channel) SetDefaults(ctx context.Context) {
 }
 
 func (cs *ChannelSpec) SetDefaults(_ context.Context) {
-	if cs.GoogleServiceAccount == "" && (cs.Secret == nil || equality.Semantic.DeepEqual(cs.Secret, &corev1.SecretKeySelector{})) {
+	if cs.ServiceAccountName == "" && (cs.Secret == nil || equality.Semantic.DeepEqual(cs.Secret, &corev1.SecretKeySelector{})) {
 		cs.Secret = defaultSecretSelector()
 	}
 }

--- a/pkg/apis/messaging/v1beta1/channel_types_test.go
+++ b/pkg/apis/messaging/v1beta1/channel_types_test.go
@@ -47,12 +47,12 @@ func TestChannelIdentitySpec(t *testing.T) {
 	s := &Channel{
 		Spec: ChannelSpec{
 			IdentitySpec: duckv1beta1.IdentitySpec{
-				GoogleServiceAccount: "test@test",
+				ServiceAccountName: "test",
 			},
 		},
 	}
-	want := "test@test"
-	got := s.IdentitySpec().GoogleServiceAccount
+	want := "test"
+	got := s.IdentitySpec().ServiceAccountName
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)
 	}

--- a/pkg/apis/messaging/v1beta1/channel_validation.go
+++ b/pkg/apis/messaging/v1beta1/channel_validation.go
@@ -42,7 +42,7 @@ func (cs *ChannelSpec) Validate(ctx context.Context) *apis.FieldError {
 		}
 	}
 
-	if err := duckv1beta1.ValidateCredential(cs.Secret, cs.GoogleServiceAccount); err != nil {
+	if err := duckv1beta1.ValidateCredential(cs.Secret, cs.ServiceAccountName); err != nil {
 		errs = errs.Also(err)
 	}
 
@@ -65,7 +65,7 @@ func (current *Channel) CheckImmutableFields(ctx context.Context, original *Chan
 		}
 	}
 
-	if diff := cmp.Diff(original.Spec.GoogleServiceAccount, current.Spec.GoogleServiceAccount); diff != "" {
+	if diff := cmp.Diff(original.Spec.ServiceAccountName, current.Spec.ServiceAccountName); diff != "" {
 		return &apis.FieldError{
 			Message: "Immutable fields changed (-old +new)",
 			Paths:   []string{"status", "serviceAccount"},

--- a/pkg/apis/messaging/v1beta1/channel_validation_test.go
+++ b/pkg/apis/messaging/v1beta1/channel_validation_test.go
@@ -29,8 +29,8 @@ import (
 )
 
 var (
-	validServiceAccountName   = "test123@test123.iam.gserviceaccount.com"
-	invalidServiceAccountName = "test@test.iam.kserviceaccount.com"
+	validServiceAccountName   = "test"
+	invalidServiceAccountName = "@test"
 
 	channelSpec = ChannelSpec{
 		SubscribableSpec: &eventingduck.SubscribableSpec{
@@ -113,11 +113,11 @@ func TestChannelValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
-		name: "invalid GCP service account",
+		name: "invalid k8s service account",
 		cr: &Channel{
 			Spec: ChannelSpec{
 				IdentitySpec: duckv1beta1.IdentitySpec{
-					GoogleServiceAccount: invalidServiceAccountName,
+					ServiceAccountName: invalidServiceAccountName,
 				},
 				SubscribableSpec: &eventingduck.SubscribableSpec{
 					Subscribers: []eventingduck.SubscriberSpec{{
@@ -128,17 +128,17 @@ func TestChannelValidation(t *testing.T) {
 		},
 		want: func() *apis.FieldError {
 			fe := &apis.FieldError{
-				Message: `invalid value: test@test.iam.kserviceaccount.com, googleServiceAccount should have format: ^[a-z][a-z0-9-]{5,29}@[a-z][a-z0-9-]{5,29}.iam.gserviceaccount.com$`,
-				Paths:   []string{"spec.googleServiceAccount"},
+				Message: `invalid value: @test, serviceAccountName should have format: ^[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?$`,
+				Paths:   []string{"spec.serviceAccountName"},
 			}
 			return fe
 		}(),
 	}, {
-		name: "valid GCP service account",
+		name: "valid k8s service account",
 		cr: &Channel{
 			Spec: ChannelSpec{
 				IdentitySpec: duckv1beta1.IdentitySpec{
-					GoogleServiceAccount: validServiceAccountName,
+					ServiceAccountName: validServiceAccountName,
 				},
 				SubscribableSpec: &eventingduck.SubscribableSpec{
 					Subscribers: []eventingduck.SubscriberSpec{{
@@ -149,11 +149,11 @@ func TestChannelValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
-		name: "have GCP service account and secret at the same time",
+		name: "have k8s service account and secret at the same time",
 		cr: &Channel{
 			Spec: ChannelSpec{
 				IdentitySpec: duckv1beta1.IdentitySpec{
-					GoogleServiceAccount: validServiceAccountName,
+					ServiceAccountName: validServiceAccountName,
 				},
 				Secret: defaultSecretSelector(),
 				SubscribableSpec: &eventingduck.SubscribableSpec{
@@ -165,7 +165,7 @@ func TestChannelValidation(t *testing.T) {
 		},
 		want: func() *apis.FieldError {
 			fe := &apis.FieldError{
-				Message: "Can't have spec.googleServiceAccount and spec.secret at the same time",
+				Message: "Can't have spec.serviceAccountName and spec.secret at the same time",
 				Paths:   []string{"spec"},
 			}
 			return fe
@@ -195,7 +195,7 @@ func TestCheckImmutableFields(t *testing.T) {
 			orig: &channelSpec,
 			updated: ChannelSpec{
 				IdentitySpec: duckv1beta1.IdentitySpec{
-					GoogleServiceAccount: "new-service-account",
+					ServiceAccountName: "new-service-account",
 				},
 			},
 			allowed: false,

--- a/pkg/apis/pubsub/v1alpha1/pullsubscription_conversion_test.go
+++ b/pkg/apis/pubsub/v1alpha1/pullsubscription_conversion_test.go
@@ -100,7 +100,7 @@ var (
 	}
 
 	completeIdentitySpec = duckv1alpha1.IdentitySpec{
-		GoogleServiceAccount: "googleServiceAccount",
+		ServiceAccountName: "k8sServiceAccount",
 	}
 
 	completeSecret = &v1.SecretKeySelector{

--- a/pkg/apis/pubsub/v1alpha1/pullsubscription_types_test.go
+++ b/pkg/apis/pubsub/v1alpha1/pullsubscription_types_test.go
@@ -100,13 +100,13 @@ func TestPullSubscriptionIdentitySpec(t *testing.T) {
 		Spec: PullSubscriptionSpec{
 			PubSubSpec: v1alpha1.PubSubSpec{
 				IdentitySpec: v1alpha1.IdentitySpec{
-					GoogleServiceAccount: "test@test",
+					ServiceAccountName: "test",
 				},
 			},
 		},
 	}
-	want := "test@test"
-	got := s.IdentitySpec().GoogleServiceAccount
+	want := "test"
+	got := s.IdentitySpec().ServiceAccountName
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)
 	}

--- a/pkg/apis/pubsub/v1alpha1/topic_types_test.go
+++ b/pkg/apis/pubsub/v1alpha1/topic_types_test.go
@@ -46,12 +46,12 @@ func TestTopicIdentitySpec(t *testing.T) {
 	s := &Topic{
 		Spec: TopicSpec{
 			IdentitySpec: v1alpha1.IdentitySpec{
-				GoogleServiceAccount: "test@test",
+				ServiceAccountName: "test",
 			},
 		},
 	}
-	want := "test@test"
-	got := s.IdentitySpec().GoogleServiceAccount
+	want := "test"
+	got := s.IdentitySpec().ServiceAccountName
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)
 	}

--- a/pkg/apis/pubsub/v1beta1/pullsubscription_types_test.go
+++ b/pkg/apis/pubsub/v1beta1/pullsubscription_types_test.go
@@ -100,13 +100,13 @@ func TestPullSubscriptionIdentitySpec(t *testing.T) {
 		Spec: PullSubscriptionSpec{
 			PubSubSpec: v1beta1.PubSubSpec{
 				IdentitySpec: v1beta1.IdentitySpec{
-					GoogleServiceAccount: "test@test",
+					ServiceAccountName: "test",
 				},
 			},
 		},
 	}
-	want := "test@test"
-	got := s.IdentitySpec().GoogleServiceAccount
+	want := "test"
+	got := s.IdentitySpec().ServiceAccountName
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)
 	}

--- a/pkg/apis/pubsub/v1beta1/topic_types_test.go
+++ b/pkg/apis/pubsub/v1beta1/topic_types_test.go
@@ -46,12 +46,12 @@ func TestTopicIdentitySpec(t *testing.T) {
 	s := &Topic{
 		Spec: TopicSpec{
 			IdentitySpec: v1beta1.IdentitySpec{
-				GoogleServiceAccount: "test@test",
+				ServiceAccountName: "test",
 			},
 		},
 	}
-	want := "test@test"
-	got := s.IdentitySpec().GoogleServiceAccount
+	want := "test"
+	got := s.IdentitySpec().ServiceAccountName
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)
 	}

--- a/pkg/reconciler/intevents/pullsubscription/resources/receive_adapter.go
+++ b/pkg/reconciler/intevents/pullsubscription/resources/receive_adapter.go
@@ -162,6 +162,17 @@ func makeReceiveAdapterPodSpec(ctx context.Context, args *ReceiveAdapterArgs) *c
 		}
 	}
 
+	// If k8s service account is specified, use that service account as credential.
+	if args.Source.Spec.ServiceAccountName != "" {
+		kServiceAccountName := args.Source.Spec.ServiceAccountName
+		return &corev1.PodSpec{
+			ServiceAccountName: kServiceAccountName,
+			Containers: []corev1.Container{
+				receiveAdapterContainer,
+			},
+		}
+	}
+
 	// Otherwise, use secret as credential.
 	secret := args.Source.Spec.Secret
 	credsFile := fmt.Sprintf("%s/%s", credsMountPath, secret.Key)

--- a/pkg/reconciler/intevents/resources/pullsubscription.go
+++ b/pkg/reconciler/intevents/resources/pullsubscription.go
@@ -52,6 +52,7 @@ func MakePullSubscription(args *PullSubscriptionArgs) *inteventsv1alpha1.PullSub
 			PubSubSpec: duckv1alpha1.PubSubSpec{
 				IdentitySpec: duckv1alpha1.IdentitySpec{
 					GoogleServiceAccount: args.Spec.IdentitySpec.GoogleServiceAccount,
+					ServiceAccountName:   args.Spec.IdentitySpec.ServiceAccountName,
 				},
 				Secret:  args.Spec.Secret,
 				Project: args.Spec.Project,

--- a/pkg/reconciler/intevents/resources/topic.go
+++ b/pkg/reconciler/intevents/resources/topic.go
@@ -48,6 +48,7 @@ func MakeTopic(args *TopicArgs) *inteventsv1alpha1.Topic {
 		Spec: inteventsv1alpha1.TopicSpec{
 			IdentitySpec: duckv1alpha1.IdentitySpec{
 				GoogleServiceAccount: args.Spec.IdentitySpec.GoogleServiceAccount,
+				ServiceAccountName:   args.Spec.IdentitySpec.ServiceAccountName,
 			},
 			Secret:            args.Spec.Secret,
 			Project:           args.Spec.Project,

--- a/pkg/reconciler/intevents/topic/resources/publisher.go
+++ b/pkg/reconciler/intevents/topic/resources/publisher.go
@@ -81,6 +81,17 @@ func makePublisherPodSpec(args *PublisherArgs) *corev1.PodSpec {
 		}
 	}
 
+	// If k8s service account is specified, use that service account as credential.
+	if args.Topic.Spec.ServiceAccountName != "" {
+		kServiceAccountName := args.Topic.Spec.ServiceAccountName
+		return &corev1.PodSpec{
+			ServiceAccountName: kServiceAccountName,
+			Containers: []corev1.Container{
+				publisherContainer,
+			},
+		}
+	}
+
 	// Otherwise, use secret as credential.
 	secret := args.Topic.Spec.Secret
 	if secret == nil {

--- a/pkg/reconciler/messaging/channel/channel.go
+++ b/pkg/reconciler/messaging/channel/channel.go
@@ -159,15 +159,16 @@ func (r *Reconciler) syncSubscribers(ctx context.Context, channel *v1alpha1.Chan
 		genName := resources.GenerateSubscriptionName(s.UID)
 
 		ps := resources.MakePullSubscription(&resources.PullSubscriptionArgs{
-			Owner:          channel,
-			Name:           genName,
-			Project:        channel.Spec.Project,
-			Topic:          channel.Status.TopicID,
-			ServiceAccount: channel.Spec.GoogleServiceAccount,
-			Secret:         channel.Spec.Secret,
-			Labels:         resources.GetPullSubscriptionLabels(controllerAgentName, channel.Name, genName, string(channel.UID)),
-			Annotations:    resources.GetPullSubscriptionAnnotations(channel.Name, clusterName),
-			Subscriber:     s,
+			Owner:              channel,
+			Name:               genName,
+			Project:            channel.Spec.Project,
+			Topic:              channel.Status.TopicID,
+			ServiceAccount:     channel.Spec.GoogleServiceAccount,
+			ServiceAccountName: channel.Spec.ServiceAccountName,
+			Secret:             channel.Spec.Secret,
+			Labels:             resources.GetPullSubscriptionLabels(controllerAgentName, channel.Name, genName, string(channel.UID)),
+			Annotations:        resources.GetPullSubscriptionAnnotations(channel.Name, clusterName),
+			Subscriber:         s,
 		})
 		ps, err := r.RunClientSet.InternalV1alpha1().PullSubscriptions(channel.Namespace).Create(ps)
 		if apierrs.IsAlreadyExists(err) {
@@ -194,15 +195,16 @@ func (r *Reconciler) syncSubscribers(ctx context.Context, channel *v1alpha1.Chan
 		genName := resources.GenerateSubscriptionName(s.UID)
 
 		ps := resources.MakePullSubscription(&resources.PullSubscriptionArgs{
-			Owner:          channel,
-			Name:           genName,
-			Project:        channel.Spec.Project,
-			Topic:          channel.Status.TopicID,
-			ServiceAccount: channel.Spec.GoogleServiceAccount,
-			Secret:         channel.Spec.Secret,
-			Labels:         resources.GetPullSubscriptionLabels(controllerAgentName, channel.Name, genName, string(channel.UID)),
-			Annotations:    resources.GetPullSubscriptionAnnotations(channel.Name, clusterName),
-			Subscriber:     s,
+			Owner:              channel,
+			Name:               genName,
+			Project:            channel.Spec.Project,
+			Topic:              channel.Status.TopicID,
+			ServiceAccount:     channel.Spec.GoogleServiceAccount,
+			ServiceAccountName: channel.Spec.ServiceAccountName,
+			Secret:             channel.Spec.Secret,
+			Labels:             resources.GetPullSubscriptionLabels(controllerAgentName, channel.Name, genName, string(channel.UID)),
+			Annotations:        resources.GetPullSubscriptionAnnotations(channel.Name, clusterName),
+			Subscriber:         s,
 		})
 
 		existingPs, found := pullsubs[genName]
@@ -309,14 +311,15 @@ func (r *Reconciler) reconcileTopic(ctx context.Context, channel *v1alpha1.Chann
 	}
 	clusterName := channel.GetAnnotations()[duckv1alpha1.ClusterNameAnnotation]
 	t := resources.MakeTopic(&resources.TopicArgs{
-		Owner:          channel,
-		Name:           resources.GeneratePublisherName(channel),
-		Project:        channel.Spec.Project,
-		ServiceAccount: channel.Spec.GoogleServiceAccount,
-		Secret:         channel.Spec.Secret,
-		Topic:          resources.GenerateTopicID(channel.UID),
-		Labels:         resources.GetLabels(controllerAgentName, channel.Name, string(channel.UID)),
-		Annotations:    resources.GetTopicAnnotations(clusterName),
+		Owner:              channel,
+		Name:               resources.GeneratePublisherName(channel),
+		Project:            channel.Spec.Project,
+		ServiceAccount:     channel.Spec.GoogleServiceAccount,
+		ServiceAccountName: channel.Spec.ServiceAccountName,
+		Secret:             channel.Spec.Secret,
+		Topic:              resources.GenerateTopicID(channel.UID),
+		Labels:             resources.GetLabels(controllerAgentName, channel.Name, string(channel.UID)),
+		Annotations:        resources.GetTopicAnnotations(clusterName),
 	})
 
 	topic, err = r.RunClientSet.InternalV1alpha1().Topics(channel.Namespace).Create(t)

--- a/pkg/reconciler/messaging/channel/resources/pullsubscription.go
+++ b/pkg/reconciler/messaging/channel/resources/pullsubscription.go
@@ -30,15 +30,16 @@ import (
 // PullSubscriptionArgs are the arguments needed to create a Channel Subscriber.
 // Every field is required.
 type PullSubscriptionArgs struct {
-	Owner          kmeta.OwnerRefable
-	Name           string
-	Project        string
-	Topic          string
-	ServiceAccount string
-	Secret         *corev1.SecretKeySelector
-	Labels         map[string]string
-	Annotations    map[string]string
-	Subscriber     duckv1alpha1.SubscriberSpec
+	Owner              kmeta.OwnerRefable
+	Name               string
+	Project            string
+	Topic              string
+	ServiceAccount     string
+	ServiceAccountName string
+	Secret             *corev1.SecretKeySelector
+	Labels             map[string]string
+	Annotations        map[string]string
+	Subscriber         duckv1alpha1.SubscriberSpec
 }
 
 // MakePullSubscription generates (but does not insert into K8s) the
@@ -50,6 +51,7 @@ func MakePullSubscription(args *PullSubscriptionArgs) *v1alpha1.PullSubscription
 			SourceSpec: duckv1.SourceSpec{},
 			IdentitySpec: gcpduckv1alpha1.IdentitySpec{
 				GoogleServiceAccount: args.ServiceAccount,
+				ServiceAccountName:   args.ServiceAccountName,
 			},
 			Secret:  args.Secret,
 			Project: args.Project,

--- a/pkg/reconciler/messaging/channel/resources/topic.go
+++ b/pkg/reconciler/messaging/channel/resources/topic.go
@@ -29,14 +29,15 @@ import (
 // TopicArgs are the arguments needed to create a Channel Topic.
 // Every field is required.
 type TopicArgs struct {
-	Owner          kmeta.OwnerRefable
-	Name           string
-	Project        string
-	Topic          string
-	ServiceAccount string
-	Secret         *corev1.SecretKeySelector
-	Labels         map[string]string
-	Annotations    map[string]string
+	Owner              kmeta.OwnerRefable
+	Name               string
+	Project            string
+	Topic              string
+	ServiceAccount     string
+	ServiceAccountName string
+	Secret             *corev1.SecretKeySelector
+	Labels             map[string]string
+	Annotations        map[string]string
 }
 
 // MakeInvoker generates (but does not insert into K8s) the Topic for Channels.
@@ -52,6 +53,7 @@ func MakeTopic(args *TopicArgs) *v1alpha1.Topic {
 		Spec: v1alpha1.TopicSpec{
 			IdentitySpec: duckv1alpha1.IdentitySpec{
 				GoogleServiceAccount: args.ServiceAccount,
+				ServiceAccountName:   args.ServiceAccountName,
 			},
 			Secret:            args.Secret,
 			Project:           args.Project,

--- a/pkg/reconciler/pubsub/pullsubscription/resources/receive_adapter.go
+++ b/pkg/reconciler/pubsub/pullsubscription/resources/receive_adapter.go
@@ -163,6 +163,17 @@ func makeReceiveAdapterPodSpec(ctx context.Context, args *ReceiveAdapterArgs) *c
 		}
 	}
 
+	// If k8s service account is specified, use that service account as credential.
+	if args.Source.Spec.ServiceAccountName != "" {
+		kServiceAccountName := args.Source.Spec.ServiceAccountName
+		return &corev1.PodSpec{
+			ServiceAccountName: kServiceAccountName,
+			Containers: []corev1.Container{
+				receiveAdapterContainer,
+			},
+		}
+	}
+
 	// Otherwise, use secret as credential.
 	secret := args.Source.Spec.Secret
 	credsFile := fmt.Sprintf("%s/%s", credsMountPath, secret.Key)

--- a/pkg/reconciler/pubsub/resources/pullsubscription.go
+++ b/pkg/reconciler/pubsub/resources/pullsubscription.go
@@ -52,6 +52,7 @@ func MakePullSubscription(args *PullSubscriptionArgs) *pubsubv1alpha1.PullSubscr
 			PubSubSpec: duckv1alpha1.PubSubSpec{
 				IdentitySpec: duckv1alpha1.IdentitySpec{
 					GoogleServiceAccount: args.Spec.IdentitySpec.GoogleServiceAccount,
+					ServiceAccountName:   args.Spec.IdentitySpec.ServiceAccountName,
 				},
 				Secret:  args.Spec.Secret,
 				Project: args.Spec.Project,

--- a/pkg/reconciler/pubsub/resources/topic.go
+++ b/pkg/reconciler/pubsub/resources/topic.go
@@ -48,6 +48,7 @@ func MakeTopic(args *TopicArgs) *pubsubv1alpha1.Topic {
 		Spec: pubsubv1alpha1.TopicSpec{
 			IdentitySpec: duckv1alpha1.IdentitySpec{
 				GoogleServiceAccount: args.Spec.IdentitySpec.GoogleServiceAccount,
+				ServiceAccountName:   args.Spec.IdentitySpec.ServiceAccountName,
 			},
 			Secret:            args.Spec.Secret,
 			Project:           args.Spec.Project,

--- a/pkg/reconciler/pubsub/topic/resources/publisher.go
+++ b/pkg/reconciler/pubsub/topic/resources/publisher.go
@@ -82,6 +82,17 @@ func makePublisherPodSpec(args *PublisherArgs) *corev1.PodSpec {
 		}
 	}
 
+	// If k8s service account is specified, use that service account as credential.
+	if args.Topic.Spec.ServiceAccountName != "" {
+		kServiceAccountName := args.Topic.Spec.ServiceAccountName
+		return &corev1.PodSpec{
+			ServiceAccountName: kServiceAccountName,
+			Containers: []corev1.Container{
+				publisherContainer,
+			},
+		}
+	}
+
 	// Otherwise, use secret as credential.
 	secret := args.Topic.Spec.Secret
 	if secret == nil {

--- a/test/e2e/test_pullsubscription.go
+++ b/test/e2e/test_pullsubscription.go
@@ -52,7 +52,7 @@ func SmokePullSubscriptionTestImpl(t *testing.T, authConfig lib.AuthConfig) {
 			Topic: topic,
 			PubSubSpec: duckv1alpha1.PubSubSpec{
 				IdentitySpec: duckv1alpha1.IdentitySpec{
-					authConfig.PubsubServiceAccount,
+					GoogleServiceAccount: authConfig.PubsubServiceAccount,
 				},
 			},
 		}),
@@ -87,7 +87,7 @@ func PullSubscriptionWithTargetTestImpl(t *testing.T, authConfig lib.AuthConfig)
 			Topic: topicName,
 			PubSubSpec: duckv1alpha1.PubSubSpec{
 				IdentitySpec: duckv1alpha1.IdentitySpec{
-					authConfig.PubsubServiceAccount,
+					GoogleServiceAccount: authConfig.PubsubServiceAccount,
 				},
 			},
 		}), kngcptesting.WithPullSubscriptionSink(lib.ServiceGVK, targetName))


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- in v1beta1, add .serviceAccountName remove gsa
- in v1alpha1, add .serviceAccountName, keep gsa
- fix some UT

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Add k8s service account and and remove gsa under identity spec in v1beta1.
Add k8s service account and and keep gsa under identity spec in v1alpha1.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
