### PR TITLE
Use HTTP Client + CE SDK v2 Bindings in Deliver Processor

### DIFF
--- a/cmd/broker/fanout/wire_gen.go
+++ b/cmd/broker/fanout/wire_gen.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"context"
-	"github.com/cloudevents/sdk-go/v2/protocol/http"
 	"github.com/google/knative-gcp/pkg/broker/config/volume"
 	"github.com/google/knative-gcp/pkg/broker/handler/pool"
 )
@@ -23,21 +22,13 @@ func InitializeSyncPool(ctx context.Context, projectID pool.ProjectID, targetsVo
 	if err != nil {
 		return nil, err
 	}
+	httpClient := _wireClientValue
 	v := _wireValue
-	protocol, err := http.New(v...)
+	retryClient, err := pool.NewRetryClient(ctx, client, v...)
 	if err != nil {
 		return nil, err
 	}
-	v2 := _wireValue2
-	deliverClient, err := pool.NewDeliverClient(protocol, v2...)
-	if err != nil {
-		return nil, err
-	}
-	retryClient, err := pool.NewRetryClient(ctx, client, v2...)
-	if err != nil {
-		return nil, err
-	}
-	fanoutPool, err := pool.NewFanoutPool(readonlyTargets, client, deliverClient, retryClient, opts...)
+	fanoutPool, err := pool.NewFanoutPool(readonlyTargets, client, httpClient, retryClient, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -45,6 +36,6 @@ func InitializeSyncPool(ctx context.Context, projectID pool.ProjectID, targetsVo
 }
 
 var (
-	_wireValue  = pool.DefaultHTTPOpts
-	_wireValue2 = pool.DefaultCEClientOpts
+	_wireClientValue = pool.DefaultHTTPClient
+	_wireValue       = pool.DefaultCEClientOpts
 )

--- a/cmd/broker/retry/wire_gen.go
+++ b/cmd/broker/retry/wire_gen.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"context"
-	"github.com/cloudevents/sdk-go/v2/protocol/http"
 	"github.com/google/knative-gcp/pkg/broker/config/volume"
 	"github.com/google/knative-gcp/pkg/broker/handler/pool"
 )
@@ -23,17 +22,8 @@ func InitializeSyncPool(ctx context.Context, projectID pool.ProjectID, targetsVo
 	if err != nil {
 		return nil, err
 	}
-	v := _wireValue
-	protocol, err := http.New(v...)
-	if err != nil {
-		return nil, err
-	}
-	v2 := _wireValue2
-	deliverClient, err := pool.NewDeliverClient(protocol, v2...)
-	if err != nil {
-		return nil, err
-	}
-	retryPool, err := pool.NewRetryPool(readonlyTargets, client, deliverClient, opts...)
+	httpClient := _wireClientValue
+	retryPool, err := pool.NewRetryPool(readonlyTargets, client, httpClient, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -41,6 +31,5 @@ func InitializeSyncPool(ctx context.Context, projectID pool.ProjectID, targetsVo
 }
 
 var (
-	_wireValue  = pool.DefaultHTTPOpts
-	_wireValue2 = pool.DefaultCEClientOpts
+	_wireClientValue = pool.DefaultHTTPClient
 )

--- a/pkg/broker/eventutil/hops.go
+++ b/pkg/broker/eventutil/hops.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	cetypes "github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/event"
 	"go.uber.org/zap"
 	"knative.dev/eventing/pkg/logging"
@@ -59,6 +60,13 @@ func UpdateRemainingHops(ctx context.Context, event *event.Event, preemptiveHops
 // It ignores any existing hops value.
 func SetRemainingHops(ctx context.Context, event *event.Event, hops int32) {
 	event.SetExtension(hopsAttribute, hops)
+}
+
+type SetRemainingHopsTransformer int32
+
+func (h SetRemainingHopsTransformer) Transform(_ binding.MessageMetadataReader, out binding.MessageMetadataWriter) error {
+	out.SetExtension(hopsAttribute, int32(h))
+	return nil
 }
 
 // GetRemainingHops returns the remaining hops of the event if it presents.

--- a/pkg/broker/handler/pool/fanout.go
+++ b/pkg/broker/handler/pool/fanout.go
@@ -19,6 +19,7 @@ package pool
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync"
 	"time"
 
@@ -52,7 +53,7 @@ type FanoutPool struct {
 	deliverRetryClient ceclient.Client
 	// For initial events delivery. We only need a shared client.
 	// And we can set target address dynamically.
-	deliverClient ceclient.Client
+	deliverClient *http.Client
 }
 
 type fanoutHandlerCache struct {
@@ -82,7 +83,7 @@ func (hc *fanoutHandlerCache) shouldRenew(b *config.Broker) bool {
 func NewFanoutPool(
 	targets config.ReadonlyTargets,
 	pubsubClient *pubsub.Client,
-	deliverClient DeliverClient,
+	deliverClient *http.Client,
 	retryClient RetryClient,
 	opts ...Option,
 ) (*FanoutPool, error) {

--- a/pkg/broker/handler/pool/retry.go
+++ b/pkg/broker/handler/pool/retry.go
@@ -19,9 +19,9 @@ package pool
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync"
 
-	ceclient "github.com/cloudevents/sdk-go/v2/client"
 	"go.uber.org/zap"
 	"knative.dev/eventing/pkg/logging"
 
@@ -47,7 +47,7 @@ type RetryPool struct {
 	pubsubClient *pubsub.Client
 	// For initial events delivery. We only need a shared client.
 	// And we can set target address dynamically.
-	deliverClient ceclient.Client
+	deliverClient *http.Client
 }
 
 type retryHandlerCache struct {
@@ -74,7 +74,7 @@ func (hc *retryHandlerCache) shouldRenew(t *config.Target) bool {
 }
 
 // NewRetryPool creates a new retry handler pool.
-func NewRetryPool(targets config.ReadonlyTargets, pubsubClient *pubsub.Client, deliverClient DeliverClient, opts ...Option) (*RetryPool, error) {
+func NewRetryPool(targets config.ReadonlyTargets, pubsubClient *pubsub.Client, deliverClient *http.Client, opts ...Option) (*RetryPool, error) {
 	options, err := NewOptions(opts...)
 	if err != nil {
 		return nil, err

--- a/pkg/broker/handler/pool/testing/helper.go
+++ b/pkg/broker/handler/pool/testing/helper.go
@@ -366,7 +366,7 @@ func (h *Helper) VerifyNextBrokerIngressEvent(ctx context.Context, t *testing.T,
 		}
 		return
 	}
-	msg.Finish(nil)
+	defer msg.Finish(nil)
 	gotEvent, err = binding.ToEvent(ctx, msg)
 	if err != nil {
 		t.Errorf("broker (key=%q) received invalid cloudevent: %v", brokerKey, err)

--- a/pkg/broker/handler/pool/wire.go
+++ b/pkg/broker/handler/pool/wire.go
@@ -22,7 +22,6 @@ import (
 	"context"
 
 	"cloud.google.com/go/pubsub"
-	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	"github.com/google/knative-gcp/pkg/broker/config"
 	"github.com/google/wire"
 )
@@ -35,10 +34,8 @@ func InitializeTestFanoutPool(
 ) (*FanoutPool, error) {
 	panic(wire.Build(
 		NewFanoutPool,
-		NewDeliverClient,
 		NewRetryClient,
-		cehttp.New,
-		wire.Value([]cehttp.Option(nil)),
+		wire.Value(DefaultHTTPClient),
 		wire.Value(DefaultCEClientOpts),
 	))
 }
@@ -50,9 +47,6 @@ func InitializeTestRetryPool(
 ) (*RetryPool, error) {
 	panic(wire.Build(
 		NewRetryPool,
-		NewDeliverClient,
-		cehttp.New,
-		wire.Value([]cehttp.Option(nil)),
-		wire.Value(DefaultCEClientOpts),
+		wire.Value(DefaultHTTPClient),
 	))
 }

--- a/pkg/broker/handler/pool/wire_gen.go
+++ b/pkg/broker/handler/pool/wire_gen.go
@@ -8,28 +8,19 @@ package pool
 import (
 	"cloud.google.com/go/pubsub"
 	"context"
-	"github.com/cloudevents/sdk-go/v2/protocol/http"
 	"github.com/google/knative-gcp/pkg/broker/config"
 )
 
 // Injectors from wire.go:
 
 func InitializeTestFanoutPool(ctx context.Context, targets config.ReadonlyTargets, pubsubClient *pubsub.Client, opts ...Option) (*FanoutPool, error) {
+	client := _wireClientValue
 	v := _wireValue
-	protocol, err := http.New(v...)
+	retryClient, err := NewRetryClient(ctx, pubsubClient, v...)
 	if err != nil {
 		return nil, err
 	}
-	v2 := _wireValue2
-	deliverClient, err := NewDeliverClient(protocol, v2...)
-	if err != nil {
-		return nil, err
-	}
-	retryClient, err := NewRetryClient(ctx, pubsubClient, v2...)
-	if err != nil {
-		return nil, err
-	}
-	fanoutPool, err := NewFanoutPool(targets, pubsubClient, deliverClient, retryClient, opts...)
+	fanoutPool, err := NewFanoutPool(targets, pubsubClient, client, retryClient, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -37,22 +28,13 @@ func InitializeTestFanoutPool(ctx context.Context, targets config.ReadonlyTarget
 }
 
 var (
-	_wireValue  = []http.Option(nil)
-	_wireValue2 = DefaultCEClientOpts
+	_wireClientValue = DefaultHTTPClient
+	_wireValue       = DefaultCEClientOpts
 )
 
 func InitializeTestRetryPool(targets config.ReadonlyTargets, pubsubClient *pubsub.Client, opts ...Option) (*RetryPool, error) {
-	v := _wireValue3
-	protocol, err := http.New(v...)
-	if err != nil {
-		return nil, err
-	}
-	v2 := _wireValue4
-	deliverClient, err := NewDeliverClient(protocol, v2...)
-	if err != nil {
-		return nil, err
-	}
-	retryPool, err := NewRetryPool(targets, pubsubClient, deliverClient, opts...)
+	client := _wireHttpClientValue
+	retryPool, err := NewRetryPool(targets, pubsubClient, client, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -60,6 +42,5 @@ func InitializeTestRetryPool(targets config.ReadonlyTargets, pubsubClient *pubsu
 }
 
 var (
-	_wireValue3 = []http.Option(nil)
-	_wireValue4 = DefaultCEClientOpts
+	_wireHttpClientValue = DefaultHTTPClient
 )

--- a/pkg/broker/handler/processors/deliver/processor.go
+++ b/pkg/broker/handler/processors/deliver/processor.go
@@ -129,7 +129,7 @@ func (p *Processor) deliver(ctx context.Context, target *config.Target, broker *
 	}()
 
 	if resp.StatusCode/100 != 2 {
-		return fmt.Errorf("event delivery failed: HTTP status code %d.", resp.StatusCode)
+		return fmt.Errorf("event delivery failed: HTTP status code %d", resp.StatusCode)
 	}
 
 	respMsg := cehttp.NewMessageFromHttpResponse(resp)
@@ -159,7 +159,7 @@ func (p *Processor) deliver(ctx context.Context, target *config.Target, broker *
 }
 
 func (p *Processor) sendMsg(ctx context.Context, address string, msg binding.Message, transformers ...binding.Transformer) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, "POST", address, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, address, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/broker/handler/processors/deliver/processor.go
+++ b/pkg/broker/handler/processors/deliver/processor.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cloudevents/sdk-go/v2/event"
 	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	"go.uber.org/zap"
-	"knative.dev/pkg/logging"
+	"knative.dev/eventing/pkg/logging"
 
 	"github.com/google/knative-gcp/pkg/broker/config"
 	"github.com/google/knative-gcp/pkg/broker/eventutil"

--- a/pkg/broker/handler/processors/deliver/processor_test.go
+++ b/pkg/broker/handler/processors/deliver/processor_test.go
@@ -36,8 +36,11 @@ import (
 	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	cepubsub "github.com/cloudevents/sdk-go/v2/protocol/pubsub"
 	"github.com/google/go-cmp/cmp"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"knative.dev/pkg/logging"
 	logtest "knative.dev/pkg/logging/testing"
 
 	"github.com/google/knative-gcp/pkg/broker/config"
@@ -432,7 +435,8 @@ func benchmarkNoReply(b *testing.B, httpClient http.Client, targetAddress string
 	testTargets.MutateBroker("ns", "broker", func(bm config.BrokerMutation) {
 		bm.UpsertTargets(target)
 	})
-	ctx := handlerctx.WithBrokerKey(context.Background(), broker.Key())
+	ctx := logging.WithLogger(context.Background(), zaptest.NewLogger(b, zaptest.Level(zap.InfoLevel)).Sugar())
+	ctx = handlerctx.WithBrokerKey(ctx, broker.Key())
 	ctx = handlerctx.WithTargetKey(ctx, target.Key())
 
 	p := &Processor{
@@ -464,7 +468,8 @@ func benchmarkWithReply(b *testing.B, ingressAddress string, makeTarget func(*te
 		bm.SetAddress(ingressAddress)
 		bm.UpsertTargets(target)
 	})
-	ctx := handlerctx.WithBrokerKey(context.Background(), broker.Key())
+	ctx := logging.WithLogger(context.Background(), zaptest.NewLogger(b, zaptest.Level(zap.InfoLevel)).Sugar())
+	ctx = handlerctx.WithBrokerKey(ctx, broker.Key())
 	ctx = handlerctx.WithTargetKey(ctx, target.Key())
 
 	p := &Processor{


### PR DESCRIPTION
Directly use the HTTP client in the deliver processor using the cloudevents SDK v2 bindings. This significantly improves the performance of fanout delivery:

```
name                            old time/op    new time/op    delta
DeliveryNoReply-16                15.0µs ± 1%    11.8µs ± 1%  -21.28%  (p=0.000 n=19+19)
DeliveryWithReply-16              25.8µs ± 1%    23.4µs ± 1%   -9.39%  (p=0.000 n=20+20)
DeliveryNoReplyFakeClient-16      3.03µs ± 1%    1.96µs ± 2%  -35.20%  (p=0.000 n=20+20)
DeliveryWithReplyFakeClient-16    4.88µs ± 2%    3.04µs ± 2%  -37.78%  (p=0.000 n=19+16)

name                            old alloc/op   new alloc/op   delta
DeliveryNoReply-16                8.64kB ± 0%    7.40kB ± 0%  -14.33%  (p=0.000 n=19+18)
DeliveryWithReply-16              17.2kB ± 0%    14.7kB ± 0%  -14.81%  (p=0.000 n=20+20)
DeliveryNoReplyFakeClient-16      4.35kB ± 0%    3.23kB ± 0%  -25.82%  (p=0.000 n=20+20)
DeliveryWithReplyFakeClient-16    7.33kB ± 0%    4.84kB ± 0%  -34.00%  (p=0.000 n=20+16)

name                            old allocs/op  new allocs/op  delta
DeliveryNoReply-16                   116 ± 0%        94 ± 0%  -18.97%  (p=0.000 n=19+20)
DeliveryWithReply-16                 251 ± 0%       210 ± 0%  -16.33%  (p=0.000 n=20+20)
DeliveryNoReplyFakeClient-16        62.0 ± 0%      41.0 ± 0%  -33.87%  (p=0.000 n=20+20)
DeliveryWithReplyFakeClient-16       109 ± 0%        69 ± 0%  -36.70%  (p=0.000 n=20+20)
```