### PR TITLE
Send and receive tracking

### DIFF
--- a/test/test_images/sendtracker/README.md
+++ b/test/test_images/sendtracker/README.md
@@ -1,0 +1,56 @@
+# Overview
+This pod is used to measure unreceived (but accepted) message sends.
+
+# Details
+This pod is designed to be both an event sender and an event receiver.  It
+sends a series of events through a single threaded sender, keeping track of the
+response code for each send.  The receiver maintains a list
+of received events.  When stopped, the receiver than waits several minutes
+for all events to be delivered.
+
+The ranges of events successfully sent and received are then compared, with
+any mismatches seen.  It is expected that no events will have been successfully
+sent, but not received.  These are returned as failures.  It is possible (on
+the other hand) that an event may not have been successfully sent, but will be
+received.  For instance, if the ingress of a broker is killed after it enqueues
+onto pubsub, but before the handler returns).  These are reported as warnings.
+The number of duplicate receive events seen is also reported (no duplicate sends
+are made, but reliable forwarders like the broker may forward some events more than
+once if they are unsure that the previous forward worked)
+
+The yaml's in this directory hard code it to send to the knative GCP
+broker for the default namespace and to receive events via a trigger.
+It must be run as a deployment with a single pod.  They can be deployed with
+  ko apply -f .
+
+This pod then provides a very basic 5 call http "api" to control data taking.
+This API can be reached on the pods port 8070 either via kubectl port forwarding
+or via a curl pod run inside the cluster.
+
+# Control
+- curl sendtracker:8070/ready
+  returns "true" once the sender has successfully sent a startup message to the receiver.
+
+- curl sendtracker:8070/start
+  starts sending events to the receiver.  After this is run, the user should then do whatever
+  perturbations are are desired to test (upgrades, failure injection, etc)
+
+- curl sendtracker:8070/stop
+  stops sending events to the receiver, but waits a configurable time for events to be delivered
+
+- curl sendtracker:8070/resultsready
+  returns "true" once the receiver has finished listening, and results are ready.
+
+- curl sendtracker:8070/ready
+  returns a human readable summary of the run.  The first line is "success" if no errors were seen
+  and "failure" if errors were seen.  The following lines are human readable info about errors, warnings,
+  all send results, all events received, and the number of duplicate events seen.
+
+To run again, delete the pod and let the deployment restart it.
+
+# Tuning
+There are 3 parameters that can be tuned for the deployment.
+
+* K\_SINK - The target for the events.  This target should eventually feed these events back to the pod.
+* DELAY\_MS - The time to wait (in milliseconds) between event sends
+* POST\_STOP\_SECS - The time to wait (in seconds) between the user request to stop and the receiver stopping to record received events.

--- a/test/test_images/sendtracker/README.md
+++ b/test/test_images/sendtracker/README.md
@@ -5,7 +5,7 @@ This pod is used to measure unreceived (but accepted) message sends.
 This pod is designed to be both an event sender and an event receiver.  It
 sends a series of events through a single threaded sender, keeping track of the
 response code for each send.  The receiver maintains a list
-of received events.  When stopped, the receiver than waits several minutes
+of received events.  When stopped, the receiver then waits several minutes
 for all events to be delivered.
 
 The ranges of events successfully sent and received are then compared, with
@@ -19,7 +19,8 @@ are made, but reliable forwarders like the broker may forward some events more t
 once if they are unsure that the previous forward worked)
 
 The yaml's in this directory hard code it to send to the knative GCP
-broker for the default namespace and to receive events via a trigger.
+broker for the default namespace and to receive events via a trigger.  As a
+prerequisite, the broker must already be configured for this namespace.
 It must be run as a deployment with a single pod.  They can be deployed with
   ko apply -f .
 
@@ -33,7 +34,7 @@ or via a curl pod run inside the cluster.
 
 - curl sendtracker:8070/start
   starts sending events to the receiver.  After this is run, the user should then do whatever
-  perturbations are are desired to test (upgrades, failure injection, etc)
+  perturbations are desired to test (upgrades, failure injection, etc)
 
 - curl sendtracker:8070/stop
   stops sending events to the receiver, but waits a configurable time for events to be delivered
@@ -41,7 +42,7 @@ or via a curl pod run inside the cluster.
 - curl sendtracker:8070/resultsready
   returns "true" once the receiver has finished listening, and results are ready.
 
-- curl sendtracker:8070/ready
+- curl sendtracker:8070/results
   returns a human readable summary of the run.  The first line is "success" if no errors were seen
   and "failure" if errors were seen.  The following lines are human readable info about errors, warnings,
   all send results, all events received, and the number of duplicate events seen.

--- a/test/test_images/sendtracker/compare_test.go
+++ b/test/test_images/sendtracker/compare_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+type testCompareInfo struct {
+	name        string
+	sendInfo    rangeResultArr
+	receiveInfo rangeReceivedArr
+	// This will result in errorString out
+	errIn error
+
+	// These indicate expected error
+	missingElement bool
+	missingRange   bool
+	emptySend      bool
+
+	// These indicate expected warning
+	extraElement bool
+	extraRange   bool
+}
+
+var compTests = []testCompareInfo{
+	{
+		name: "Match",
+		sendInfo: rangeResultArr{
+			{time.Second, true, 202, 1, 100},
+			{time.Second, false, 500, 100, 119},
+			{time.Second, true, 202, 120, 190},
+		},
+		receiveInfo: rangeReceivedArr{
+			{1, 100},
+			{120, 190},
+		},
+	},
+	{
+		name: "ErrorIn",
+		sendInfo: rangeResultArr{
+			{time.Second, true, 202, 1, 100},
+			{time.Second, false, 500, 100, 119},
+			{time.Second, true, 202, 120, 190},
+		},
+		receiveInfo: rangeReceivedArr{
+			{1, 100},
+			{120, 190},
+		},
+		errIn: fmt.Errorf("Inbound error"),
+	},
+	{
+		name:        "EmptySendReceive",
+		sendInfo:    rangeResultArr{},
+		receiveInfo: rangeReceivedArr{},
+		emptySend:   true,
+	},
+	{
+		name:        "EmptySendNonemptyReceive",
+		sendInfo:    rangeResultArr{},
+		receiveInfo: rangeReceivedArr{{1, 10}},
+		emptySend:   true,
+		extraRange:  true,
+	},
+	{
+		name: "MissingRange1",
+		sendInfo: rangeResultArr{
+			{time.Second, true, 202, 1, 100},
+		},
+		receiveInfo:  rangeReceivedArr{},
+		missingRange: true,
+	},
+	{
+		name: "MissingRange2",
+		sendInfo: rangeResultArr{
+			{time.Second, true, 202, 1, 100},
+			{time.Second, false, 500, 100, 119},
+			{time.Second, true, 202, 120, 190},
+		},
+		receiveInfo: rangeReceivedArr{
+			{1, 100},
+		},
+		missingRange: true,
+	},
+	{
+		name: "MissingRange3",
+		sendInfo: rangeResultArr{
+			{time.Second, true, 202, 1, 100},
+			{time.Second, false, 500, 100, 119},
+			{time.Second, true, 202, 120, 190},
+		},
+		receiveInfo: rangeReceivedArr{
+			{120, 190},
+		},
+		missingRange: true,
+	},
+	{
+		name: "MissingElement1",
+		sendInfo: rangeResultArr{
+			{time.Second, true, 202, 1, 100},
+			{time.Second, false, 500, 100, 119},
+			{time.Second, true, 202, 120, 190},
+		},
+		receiveInfo: rangeReceivedArr{
+			{1, 99},
+			{120, 190},
+		},
+		missingElement: true,
+	},
+	{
+		name: "MissingElement2",
+		sendInfo: rangeResultArr{
+			{time.Second, true, 202, 1, 100},
+			{time.Second, false, 500, 100, 119},
+			{time.Second, true, 202, 120, 190},
+		},
+		receiveInfo: rangeReceivedArr{
+			{2, 100},
+			{120, 190},
+		},
+		missingElement: true,
+	},
+	{
+		name: "ExtraElement1",
+		sendInfo: rangeResultArr{
+			{time.Second, true, 202, 1, 100},
+			{time.Second, false, 500, 100, 119},
+			{time.Second, true, 202, 120, 190},
+		},
+		receiveInfo: rangeReceivedArr{
+			{1, 101},
+			{120, 190},
+		},
+		extraElement: true,
+	},
+	{
+		name: "ExtraElement2",
+		sendInfo: rangeResultArr{
+			{time.Second, true, 202, 1, 100},
+			{time.Second, false, 500, 100, 119},
+			{time.Second, true, 202, 120, 190},
+		},
+		receiveInfo: rangeReceivedArr{
+			{1, 100},
+			{119, 190},
+		},
+		extraElement: true,
+	},
+	{
+		name: "ExtraRange",
+		sendInfo: rangeResultArr{
+			{time.Second, true, 202, 1, 100},
+			{time.Second, false, 500, 100, 119},
+			{time.Second, true, 202, 120, 190},
+		},
+		receiveInfo: rangeReceivedArr{
+			{1, 100},
+			{109, 110},
+			{120, 190},
+		},
+		extraRange: true,
+	},
+}
+
+// Test that the sender/receiver range comparison function works
+func TestCompare(t *testing.T) {
+	for _, test := range compTests {
+		t.Run(test.name, func(t *testing.T) {
+			errorString, warningString := compareLogs(test.sendInfo, test.receiveInfo, test.errIn)
+			if test.errIn != nil || test.missingElement || test.missingRange || test.emptySend {
+				if len(errorString) == 0 {
+					t.Fatal("Missing expected error")
+				}
+			} else {
+				if len(errorString) != 0 {
+					t.Fatalf("Saw unexpected error: (%s)", errorString)
+				}
+			}
+
+			if test.extraElement || test.extraRange {
+				if len(warningString) == 0 {
+					t.Fatal("Missing expected warning")
+				}
+			} else {
+				if len(warningString) != 0 {
+					t.Fatalf("Saw unexpected warning: (%s)", warningString)
+				}
+			}
+		})
+	}
+}
+
+type testMapToRange struct {
+	name     string
+	mapIn    map[int]struct{}
+	expected rangeReceivedArr
+}
+
+var mapRangeTests = []testMapToRange{
+	{
+		name:     "empty",
+		mapIn:    map[int]struct{}{},
+		expected: rangeReceivedArr{},
+	},
+	{
+		name: "single entries",
+		mapIn: map[int]struct{}{
+			1: struct{}{},
+			3: struct{}{},
+			5: struct{}{},
+		},
+		expected: rangeReceivedArr{
+			{1, 1},
+			{3, 3},
+			{5, 5},
+		},
+	},
+	{
+		name: "ranges entries",
+		mapIn: map[int]struct{}{
+			1:  struct{}{},
+			2:  struct{}{},
+			3:  struct{}{},
+			7:  struct{}{},
+			9:  struct{}{},
+			10: struct{}{},
+			11: struct{}{},
+			14: struct{}{},
+			15: struct{}{},
+			16: struct{}{},
+			17: struct{}{},
+			18: struct{}{},
+			19: struct{}{},
+		},
+		expected: rangeReceivedArr{
+			{1, 3},
+			{7, 7},
+			{9, 11},
+			{14, 19},
+		},
+	},
+}
+
+// Test that the function that builds ranges in the receiver works.
+func TestMapToRange(t *testing.T) {
+	for _, test := range mapRangeTests {
+		t.Run(test.name, func(t *testing.T) {
+			seen := mapToRange(test.mapIn)
+			if len(seen) != len(test.expected) {
+				t.Fatalf("Length mismatch %d != %d.  Saw %v, expected %+v", len(seen), len(test.expected), seen, test.expected)
+			}
+			for i := range seen {
+				if seen[i] != test.expected[i] {
+					t.Fatalf("Element %d mismatch.  Saw %+v, expected %+v", i, seen[i], test.expected[i])
+				}
+			}
+		})
+	}
+}

--- a/test/test_images/sendtracker/main.go
+++ b/test/test_images/sendtracker/main.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"time"
 
-	"knative.dev/eventing/pkg/kncloudevents"
+	"github.com/google/knative-gcp/pkg/kncloudevents"
 )
 
 // Compare the ranges in sendResults and receiveResults.

--- a/test/test_images/sendtracker/main.go
+++ b/test/test_images/sendtracker/main.go
@@ -25,7 +25,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/knative-gcp/pkg/kncloudevents"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 )
 
 // Compare the ranges in sendResults and receiveResults.
@@ -82,8 +83,17 @@ func main() {
 		fmt.Printf("Invalid post stop wait seconds (%s)", postStopWaitSecsString)
 		os.Exit(1)
 	}
-	fmt.Printf("Opening connection to %s\n", sinkURI)
-	ceClient, err := kncloudevents.NewDefaultClient(sinkURI)
+	fmt.Printf("Opening client to %s\n", sinkURI)
+	httpOpts := []cehttp.Option{
+		cloudevents.WithTarget(sinkURI),
+	}
+	transport, err := cloudevents.NewHTTP(httpOpts...)
+	if err != nil {
+		fmt.Printf("failed to create transport: %v\n", err)
+		os.Exit(1)
+	}
+
+	ceClient, err := cloudevents.NewClient(transport)
 	if err != nil {
 		fmt.Printf("Unable to create ceClient: %s ", err)
 		os.Exit(1)

--- a/test/test_images/sendtracker/main.go
+++ b/test/test_images/sendtracker/main.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math"
+	"math/big"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"knative.dev/eventing/pkg/kncloudevents"
+)
+
+// Compare the ranges in sendResults and receiveResults.
+// Create error strings for any entries that are successful in sendResults, but not receiveResults.
+// Create warning strings for any entries that are in receiveResults, but not successfull in sendResults.
+// Append an error string if sendError is not nil.
+func compareLogs(sendResults rangeResultArr, receiveResults rangeReceivedArr, sendError error) (errorLogs, warningLogs string) {
+	successSendRangeCount := 0
+	if sendError != nil {
+		errorLogs = sendError.Error()
+	}
+	for _, senderI := range sendResults {
+		if senderI.success {
+			successSendRangeCount++
+			found := false
+			for _, receiverI := range receiveResults {
+				if receiverI.minID <= senderI.minID && receiverI.maxID >= senderI.maxID {
+					found = true
+					if receiverI.minID != senderI.minID || receiverI.maxID != senderI.maxID {
+						warningLogs = fmt.Sprintf("%sExtra elements in received range for sender range %+v\n", warningLogs, senderI)
+					}
+				}
+			}
+			if !found {
+				errorLogs = fmt.Sprintf("%sElements not received from %+v\n", errorLogs, senderI)
+			}
+
+		}
+	}
+	if successSendRangeCount == 0 {
+		errorLogs = fmt.Sprintf("%sNo successful sends\n", errorLogs)
+	}
+	if successSendRangeCount < len(receiveResults) {
+		warningLogs = fmt.Sprintf("%sExtra range in received range set\n", warningLogs)
+	}
+	return errorLogs, warningLogs
+}
+
+func main() {
+	sinkURI := os.Getenv("K_SINK")
+	if len(sinkURI) == 0 {
+		fmt.Printf("No SINK URI specified\n")
+		os.Exit(1)
+	}
+	delayMSString := os.Getenv("DELAY_MS")
+	delayMS, err := strconv.Atoi(delayMSString)
+	if err != nil || delayMS < 0 {
+		fmt.Printf("Invalid delay millisecond (%s)", delayMSString)
+		os.Exit(1)
+	}
+	postStopWaitSecsString := os.Getenv("POST_STOP_SECS")
+	postStopWaitSecs, err := strconv.Atoi(postStopWaitSecsString)
+	if err != nil || postStopWaitSecs < 1 {
+		fmt.Printf("Invalid post stop wait seconds (%s)", postStopWaitSecsString)
+		os.Exit(1)
+	}
+	fmt.Printf("Opening connection to %s\n", sinkURI)
+	ceClient, err := kncloudevents.NewDefaultClient(sinkURI)
+	if err != nil {
+		fmt.Printf("Unable to create ceClient: %s ", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Client created to %s\n", sinkURI)
+
+	bint, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		fmt.Printf("Error creating stracker random source id: %v", bint)
+		os.Exit(1)
+	}
+	source := fmt.Sprintf("stracker_%s", bint)
+	// Start the receive goroutine
+	receiver := StartReceiver(source, time.Duration(postStopWaitSecs)*time.Second)
+	sendPacer := makeSender(ceClient, receiver, source, time.Duration(delayMS))
+
+	http.HandleFunc("/stop", sendPacer.handleStop)
+	http.HandleFunc("/start", sendPacer.handleStart)
+	http.HandleFunc("/ready", sendPacer.handleReady)
+	http.HandleFunc("/resultsready", sendPacer.handleResultsReady)
+	http.HandleFunc("/results", sendPacer.handleResults)
+	go http.ListenAndServe(":8070", nil)
+
+	// Run the send path synchronously
+	sendError := sendPacer.Run()
+	if sendError != nil && sendPacer.getState() < SendStateFinishing {
+		fmt.Printf("Sender saw an error and never made it to finishing: %v\n", sendError)
+	} else {
+		fmt.Printf("Waiting for receiver to drain\n")
+		<-receiver.fullyDone
+		// Get the events the receiver saw
+		results, dups := receiver.GetResults()
+
+		// Compare with the events the sender sent
+		errorString, warningString := compareLogs(sendPacer.results, results, sendError)
+
+		var resultSummary string
+		// If there were no errors seen, it was a success (warnings don't fail this)
+		if len(errorString) == 0 {
+			resultSummary = "success\n"
+		} else {
+			resultSummary = "failure\n"
+		}
+		sendPacer.resultSummary = fmt.Sprintf("%s%s%sAll send intervals = %s\nAll receive intervals = %s\nDuplicates seen %d\n", resultSummary, errorString, warningString, sendPacer.results, results, dups)
+		fmt.Printf("%s", sendPacer.resultSummary)
+		// Allow the result to be retrieved via /results
+		sendPacer.setState(SendStateDone)
+	}
+
+	// loop forever
+	for {
+		time.Sleep(time.Minute)
+	}
+}

--- a/test/test_images/sendtracker/receivetracker.go
+++ b/test/test_images/sendtracker/receivetracker.go
@@ -46,7 +46,7 @@ type Receiver struct {
 	// now only compress the results after taking data.
 	// Revisit if memory is an issue.
 	resultMap map[int]struct{}
-	// Count of duplicates we see whan adding to map
+	// Count of duplicates we see when adding to map
 	resultDuplicates int
 	// sumarized results once we are in Done
 	resultList rangeReceivedArr
@@ -216,5 +216,4 @@ func (r *Receiver) Receive(ctx context.Context, event cloudevents.Event) {
 			return
 		}
 	}
-
 }

--- a/test/test_images/sendtracker/receivetracker.go
+++ b/test/test_images/sendtracker/receivetracker.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go"
+)
+
+const (
+	// Waiting for the sender to send a connect message
+	ReceiveStateConnecting = iota
+	// Receiving messages
+	ReceiveStateReady
+	// Receiving messages, but will stop after timeout
+	ReceiveStateFinishing
+	// Will not record any more messages
+	ReceiveStateDone
+)
+
+type Receiver struct {
+	startTime time.Time
+	client    cloudevents.Client
+	// Hold received message id's as we get them.  For
+	// now only compress the results after taking data.
+	// Revisit if memory is an issue.
+	resultMap map[int]struct{}
+	// Count of duplicates we see whan adding to map
+	resultDuplicates int
+	// sumarized results once we are in Done
+	resultList rangeReceivedArr
+	// Lock for modifying resultMap
+	resultLock sync.Mutex
+	// Lock for modifying state
+	stateLock sync.Mutex
+	// state of the receiver
+	state int
+	// channel closed when we have hit the Done state.
+	fullyDone chan struct{}
+	// name of the source to accept events from
+	receiveSource string
+	// Time to wait between receiving the done message and stopping to listen
+	// for events
+	waitAfterDone time.Duration
+}
+
+func (r *Receiver) GetState() int {
+	r.stateLock.Lock()
+	defer r.stateLock.Unlock()
+	return r.state
+}
+
+// Transitions occur due to event deliveries that can be duplicated, so fail to change
+// but don't error on invalid transitions.
+func (r *Receiver) setState(newState int) bool {
+	r.stateLock.Lock()
+	defer r.stateLock.Unlock()
+	// Transition either in the normal order, or if the done call never succeeded and we are forced
+	// to done.
+	if r.state == newState-1 || newState == ReceiveStateDone && r.state == ReceiveStateReady {
+		r.state = newState
+		return true
+	}
+	return false
+}
+
+func (r *Receiver) GetResults() (rangeReceivedArr, int) {
+	r.resultLock.Lock()
+	defer r.resultLock.Unlock()
+	state := r.GetState()
+	if state != ReceiveStateDone {
+		log.Fatalf("Bad state for get results: %d", state)
+	}
+	return r.resultList, r.resultDuplicates
+}
+
+func StartReceiver(receiveSource string, waitAfterDone time.Duration) *Receiver {
+	client, err := cloudevents.NewDefaultClient()
+	if err != nil {
+		panic(err)
+	}
+	r := &Receiver{
+		client:        client,
+		startTime:     time.Now(),
+		resultMap:     make(map[int]struct{}),
+		fullyDone:     make(chan struct{}),
+		receiveSource: receiveSource,
+		waitAfterDone: waitAfterDone,
+	}
+
+	fmt.Printf("\nReceiver waiting to start\n")
+	go func() {
+		if err := r.client.StartReceiver(context.Background(), r.Receive); err != nil {
+			log.Fatal(err)
+		}
+	}()
+	return r
+}
+
+type rangeReceived struct {
+	minID int
+	maxID int
+}
+
+type rangeReceivedArr []rangeReceived
+
+func (r rangeReceivedArr) String() string {
+	result := fmt.Sprintf("rangeReceived{\n")
+	if len(r) == 0 {
+		result += "  nil\n"
+	}
+	for i := range r {
+		result += fmt.Sprintf("  range: %d-%d\n", r[i].minID, r[i].maxID)
+	}
+	result = result + "}\n"
+	return result
+}
+
+// Convert a map of ints into an ordered list of maximal length range
+// extents for all elements in the map.
+func mapToRange(mapIn map[int]struct{}) rangeReceivedArr {
+	var listOut rangeReceivedArr
+	allKey := make([]int, 0, len(mapIn))
+	for id, _ := range mapIn {
+		allKey = append(allKey, id)
+	}
+	sort.Ints(allKey)
+
+	for _, key := range allKey {
+		if len(listOut) == 0 || listOut[len(listOut)-1].maxID+1 != key {
+			listOut = append(listOut, rangeReceived{minID: key, maxID: key})
+		} else {
+			listOut[len(listOut)-1].maxID = key
+		}
+	}
+	return listOut
+}
+
+// Called when we are fully done receiving events.  This either happens
+// after a delay after we received the finished event, or is called directly
+// by the sender if it never successfully gets a finish event to us.
+func (r *Receiver) Done() {
+	r.resultLock.Lock()
+	changed := r.setState(ReceiveStateDone)
+
+	// Only compute the list on the first Done
+	if !changed {
+		r.resultLock.Unlock()
+		return
+	}
+	r.resultList = mapToRange(r.resultMap)
+	r.resultLock.Unlock()
+	close(r.fullyDone)
+}
+
+func (r *Receiver) Receive(ctx context.Context, event cloudevents.Event, resp *cloudevents.EventResponse) {
+	if event.Source() == r.receiveSource {
+		switch event.Type() {
+		case "event-trace-connect":
+			r.setState(ReceiveStateReady)
+			return
+		case "event-trace-event":
+			id, err := strconv.Atoi(event.ID())
+			if err != nil {
+				fmt.Errorf("Bad ID Decoding: %v %s", err, event)
+			}
+
+			if id <= 0 {
+				fmt.Errorf("Invalid ID %d: %s", id, event)
+			}
+
+			r.resultLock.Lock()
+			state := r.GetState()
+			if state == ReceiveStateReady || state == ReceiveStateFinishing {
+				_, exists := r.resultMap[id]
+				if !exists {
+					r.resultMap[id] = struct{}{}
+				} else {
+					r.resultDuplicates++
+				}
+			}
+			r.resultLock.Unlock()
+
+		case "event-trace-done":
+			change := r.setState(ReceiveStateFinishing)
+			// Only enqueue a wakeup to transition to Done once
+			if change {
+				fmt.Printf("Saw done request\n")
+				// Wait to allow delayed event delivery to come in.
+				time.AfterFunc(r.waitAfterDone, r.Done)
+			}
+			return
+		default:
+			fmt.Errorf("Unexpected event type %s: %s", event.Type(), event)
+			return
+		}
+	}
+
+}

--- a/test/test_images/sendtracker/receivetracker.go
+++ b/test/test_images/sendtracker/receivetracker.go
@@ -183,11 +183,11 @@ func (r *Receiver) Receive(ctx context.Context, event cloudevents.Event, resp *c
 		case "event-trace-event":
 			id, err := strconv.Atoi(event.ID())
 			if err != nil {
-				fmt.Errorf("Bad ID Decoding: %v %s", err, event)
+				log.Fatalf("Bad ID Decoding: %v %s", err, event)
 			}
 
 			if id <= 0 {
-				fmt.Errorf("Invalid ID %d: %s", id, event)
+				log.Fatalf("Invalid ID %d: %s", id, event)
 			}
 
 			r.resultLock.Lock()
@@ -212,7 +212,7 @@ func (r *Receiver) Receive(ctx context.Context, event cloudevents.Event, resp *c
 			}
 			return
 		default:
-			fmt.Errorf("Unexpected event type %s: %s", event.Type(), event)
+			log.Fatalf("Unexpected event type %s: %s", event.Type(), event)
 			return
 		}
 	}

--- a/test/test_images/sendtracker/receivetracker.go
+++ b/test/test_images/sendtracker/receivetracker.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 	"time"
 
-	cloudevents "github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 )
 
 const (
@@ -174,7 +174,7 @@ func (r *Receiver) Done() {
 	close(r.fullyDone)
 }
 
-func (r *Receiver) Receive(ctx context.Context, event cloudevents.Event, resp *cloudevents.EventResponse) {
+func (r *Receiver) Receive(ctx context.Context, event cloudevents.Event) {
 	if event.Source() == r.receiveSource {
 		switch event.Type() {
 		case "event-trace-connect":

--- a/test/test_images/sendtracker/receivetrigger.yaml
+++ b/test/test_images/sendtracker/receivetrigger.yaml
@@ -1,0 +1,11 @@
+apiVersion: eventing.knative.dev/v1beta1
+kind: Trigger
+metadata:
+  name: tracker-trigger
+spec:
+  filter:
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: sendtracker

--- a/test/test_images/sendtracker/receivetrigger.yaml
+++ b/test/test_images/sendtracker/receivetrigger.yaml
@@ -3,7 +3,6 @@ kind: Trigger
 metadata:
   name: tracker-trigger
 spec:
-  filter:
   subscriber:
     ref:
       apiVersion: v1

--- a/test/test_images/sendtracker/sendbroker.yaml
+++ b/test/test_images/sendtracker/sendbroker.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sendtracker
+  labels:
+    app: sendtracker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sendtracker
+  template:
+    metadata:
+      labels:
+        app: sendtracker
+    spec:
+      containers:
+      - name: sendtracker
+        image: ko://github.com/google/knative-gcp/test/test_images/sendtracker
+        env:
+        - name: K_SINK
+          value: "http://default-brokercell-ingress.cloud-run-events.svc.cluster.local/default/default"
+        - name: DELAY_MS
+          value: "10"
+        - name: POST_STOP_SECS
+          value: "480"
+

--- a/test/test_images/sendtracker/sendtracker.go
+++ b/test/test_images/sendtracker/sendtracker.go
@@ -176,8 +176,6 @@ func (s *sendPacer) runMeasure() error {
 
 		if protocol.IsACK(result) && statusCode >= http.StatusOK && statusCode < http.StatusMultipleChoices {
 			success = true
-		} else {
-			success = false
 		}
 		if len(s.results) > 0 && s.results[len(s.results)-1].success == success && s.results[len(s.results)-1].statusCode == statusCode {
 			s.results[len(s.results)-1].maxID = idNum
@@ -316,9 +314,8 @@ func (s *sendPacer) handleResults(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("%s\n", res)
 		w.Write([]byte(res))
 		return
-	} else {
-		w.Write([]byte(s.resultSummary))
 	}
+	w.Write([]byte(s.resultSummary))
 }
 
 func makeSender(client cloudevents.Client, receiver *Receiver, source string, delay time.Duration) *sendPacer {

--- a/test/test_images/sendtracker/sendtracker.go
+++ b/test/test_images/sendtracker/sendtracker.go
@@ -1,0 +1,319 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go"
+)
+
+const doneSendTimeout = 5 * time.Minute
+
+type rangeResult struct {
+	startElapsed time.Duration
+	success      bool
+	statusCode   int
+	minID        int
+	maxID        int
+}
+
+type rangeResultArr []rangeResult
+
+const (
+	// Waiting for receiver to receive a connect message
+	SendStateConnecting = iota
+	// Waiting for the start request from the user
+	SendStateReady
+	// Sending events, waiting for stop
+	SendStateSending
+	// Sending stop message/waiting for receiver to finish
+	SendStateFinishing
+	// Hack.  Set by main to indicate that the receiver is done, so we can call Results
+	// and ResultsReady will return true.
+	SendStateDone
+)
+
+func (r rangeResultArr) String() string {
+	result := fmt.Sprintf("rangeResults{\n")
+	if len(r) == 0 {
+		result += "  nil\n"
+	}
+	for i := range r {
+		if r[i].success {
+			result += "  success- "
+		} else {
+			result += "  failure- "
+		}
+		result += fmt.Sprintf("range: %d-%d statusCode: %d startElapsed %s\n", r[i].minID, r[i].maxID, r[i].statusCode, r[i].startElapsed)
+	}
+	result = result + "}\n"
+	return result
+}
+
+// Responsibile for sending events
+type sendPacer struct {
+	client cloudevents.Client
+	// Sleep between event sends
+	delay time.Duration
+
+	// Lock for updating state
+	stateLock sync.Mutex
+	// Current state
+	state int
+	// Indicates we have started
+	start chan struct{}
+	// Event ranges for successful and failed sends.
+	// Single threaded, so not locked.
+	results rangeResultArr
+	// The receiver (hack used when seeing if our connect or Done message has made it through.
+	receiver *Receiver
+	// The summary to return through /result
+	resultSummary string
+	// The name of the source to use for the events.
+	source string
+}
+
+func (s *sendPacer) getState() int {
+	s.stateLock.Lock()
+	defer s.stateLock.Unlock()
+	return s.state
+}
+
+// Return true if the state changed, false if it didn't change
+// because the state is the same as the previous state, and error
+// if it's an illegal transition.
+func (s *sendPacer) setState(newstate int) (bool, error) {
+	s.stateLock.Lock()
+	defer s.stateLock.Unlock()
+	if s.state == newstate {
+		return false, nil
+	} else if s.state == newstate-1 {
+		s.state = newstate
+		return true, nil
+	} else {
+		return false, fmt.Errorf("illegal state transition %d -> %d", s.state, newstate)
+	}
+}
+
+// Send connect messages to the receiver
+func (s *sendPacer) runConnect() error {
+	event := cloudevents.NewEvent(cloudevents.VersionV1)
+	event.SetType("event-trace-connect")
+	event.SetSource(s.source)
+	event.SetDataContentType(cloudevents.ApplicationJSON)
+	event.SetData("{}")
+	idNum := 0
+
+	connected := false
+	startConnectTime := time.Now()
+	for !connected {
+		idNum++
+		event.SetID(strconv.Itoa(idNum))
+		rctx, _, err := s.client.Send(context.Background(), event)
+		rtctx := cloudevents.HTTPTransportContextFrom(rctx)
+		time.Sleep(time.Second)
+		state := s.receiver.GetState()
+		if state == ReceiveStateReady {
+			connected = true
+		}
+		if !connected && time.Now().Sub(startConnectTime) > 2*time.Minute {
+			return fmt.Errorf("connection startup failed (timeout), send err %v, code %v", err, rtctx.StatusCode)
+		}
+	}
+	return nil
+}
+
+// Send the measured events to the receiver, recording the results for each.
+func (s *sendPacer) runMeasure() error {
+	event := cloudevents.NewEvent(cloudevents.VersionV1)
+	event.SetType("event-trace-event")
+	event.SetSource(s.source)
+	event.SetDataContentType(cloudevents.ApplicationJSON)
+	event.SetData("{}")
+	idNum := 0
+
+	startTime := time.Now()
+
+	ending := false
+	for !ending {
+		idNum++
+
+		if s.delay > 0 {
+			time.Sleep(s.delay)
+		}
+		success := false
+		event.SetID(strconv.Itoa(idNum))
+		rctx, _, err := s.client.Send(context.Background(), event)
+		rtctx := cloudevents.HTTPTransportContextFrom(rctx)
+		if err == nil && rtctx.StatusCode >= http.StatusOK && rtctx.StatusCode < http.StatusMultipleChoices {
+			success = true
+		} else {
+			success = false
+		}
+		if len(s.results) > 0 && s.results[len(s.results)-1].success == success && s.results[len(s.results)-1].statusCode == rtctx.StatusCode {
+			s.results[len(s.results)-1].maxID = idNum
+		} else {
+			s.results = append(s.results, rangeResult{success: success, statusCode: rtctx.StatusCode, minID: idNum, maxID: idNum, startElapsed: time.Now().Sub(startTime)})
+		}
+		if s.getState() == SendStateFinishing {
+			ending = true
+		}
+	}
+
+	return nil
+}
+
+// Send done messages to the receiver.
+func (s *sendPacer) runDone() error {
+	event := cloudevents.NewEvent(cloudevents.VersionV1)
+	event.SetType("event-trace-done")
+	event.SetSource(s.source)
+	event.SetDataContentType(cloudevents.ApplicationJSON)
+	event.SetData("{}")
+	idNum := 0
+
+	done := false
+	startDoneTime := time.Now()
+	for !done {
+		idNum++
+		event.SetID(strconv.Itoa(idNum))
+		rctx, _, err := s.client.Send(context.Background(), event)
+		rtctx := cloudevents.HTTPTransportContextFrom(rctx)
+		time.Sleep(time.Second)
+		state := s.receiver.GetState()
+		if state >= ReceiveStateFinishing {
+			done = true
+		}
+		if !done && time.Now().Sub(startDoneTime) > 2*time.Minute {
+			s.receiver.Done()
+			return fmt.Errorf("Done send failed (timeout), send err %v, code %v", err, rtctx.StatusCode)
+		}
+	}
+	return nil
+}
+
+// Run the entire send process
+func (s *sendPacer) Run() error {
+	fmt.Printf("Waiting to connect\n")
+	err := s.runConnect()
+	if err != nil {
+		return err
+	}
+	_, err = s.setState(SendStateReady)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Waiting for start\n")
+	<-s.start
+	fmt.Printf("Started\n")
+
+	err = s.runMeasure()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Sending done to receiver\n")
+	err = s.runDone()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *sendPacer) handleStop(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	_, err := s.setState(SendStateFinishing)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		res := fmt.Sprintf("invalid stop call: %v", err)
+		fmt.Printf("%s\n", res)
+		w.Write([]byte(res))
+		return
+
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(""))
+
+}
+
+func (s *sendPacer) handleStart(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	changed, err := s.setState(SendStateSending)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		res := fmt.Sprintf("invalid start call: %v", err)
+		fmt.Printf("%s\n", res)
+		w.Write([]byte(res))
+		return
+	}
+	if changed {
+		close(s.start)
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(""))
+
+}
+
+func (s *sendPacer) handleReady(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	if s.getState() == SendStateReady {
+		w.Write([]byte("true"))
+	} else {
+		w.Write([]byte("false"))
+	}
+}
+
+func (s *sendPacer) handleResultsReady(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	if s.getState() == SendStateDone {
+		w.Write([]byte("true"))
+	} else {
+		w.Write([]byte("false"))
+	}
+}
+
+func (s *sendPacer) handleResults(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	state := s.getState()
+	if state != SendStateDone {
+		w.WriteHeader(http.StatusBadRequest)
+		res := fmt.Sprintf("bad state in get results %d", state)
+		fmt.Printf("%s\n", res)
+		w.Write([]byte(res))
+		return
+	} else {
+		w.Write([]byte(s.resultSummary))
+	}
+}
+
+func makeSender(client cloudevents.Client, receiver *Receiver, source string, delay time.Duration) *sendPacer {
+	return &sendPacer{client: client,
+		delay:    delay,
+		start:    make(chan struct{}),
+		receiver: receiver,
+		source:   source,
+	}
+}

--- a/test/test_images/sendtracker/service.yaml
+++ b/test/test_images/sendtracker/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sendtracker
+  labels:
+    app: sendtracker
+spec:
+  ports:
+  - name: data
+    port: 80
+    targetPort: 8080
+  - name: rest
+    port: 8070
+  selector:
+    app: sendtracker


### PR DESCRIPTION
Fixes #977

Build a sendtracker pod for sending and receivingevents and recording which were successfully received, which weren't, and the http status of the events.  It then reports which events were successfully sent (200 code), but not received.

