### PR TITLE
Only start the pull handler when its resource is ready

### DIFF
--- a/pkg/broker/handler/pool/fanout.go
+++ b/pkg/broker/handler/pool/fanout.go
@@ -136,6 +136,12 @@ func (p *FanoutPool) SyncOnce(ctx context.Context) error {
 			p.pool.Delete(b.Key())
 		}
 
+		// Don't start the handler if broker is not ready.
+		// The decouple topic/sub might not be ready at this point.
+		if b.State != config.State_READY {
+			return true
+		}
+
 		sub := p.pubsubClient.Subscription(b.DecoupleQueue.Subscription)
 		sub.ReceiveSettings = p.options.PubsubReceiveSettings
 

--- a/pkg/broker/handler/pool/fanout_test.go
+++ b/pkg/broker/handler/pool/fanout_test.go
@@ -55,6 +55,17 @@ func TestFanoutWatchAndSync(t *testing.T) {
 		assertFanoutHandlers(t, syncPool, helper.Targets)
 	})
 
+	t.Run("no handler created for not-ready broker", func(t *testing.T) {
+		b := helper.GenerateBroker(ctx, t, "ns")
+		helper.Targets.MutateBroker(b.Namespace, b.Name, func(bm config.BrokerMutation) {
+			bm.SetState(config.State_UNKNOWN)
+		})
+		signal <- struct{}{}
+		// Wait a short period for the handlers to be updated.
+		<-time.After(time.Second)
+		assertFanoutHandlers(t, syncPool, helper.Targets)
+	})
+
 	bs := make([]*config.Broker, 0, 4)
 
 	t.Run("adding new brokers creates new handlers", func(t *testing.T) {
@@ -344,7 +355,9 @@ func assertFanoutHandlers(t *testing.T, p *FanoutPool, targets config.Targets) {
 	})
 
 	targets.RangeBrokers(func(b *config.Broker) bool {
-		wantHandlers[b.Key()] = true
+		if b.State == config.State_READY {
+			wantHandlers[b.Key()] = true
+		}
 		return true
 	})
 

--- a/pkg/broker/handler/pool/retry.go
+++ b/pkg/broker/handler/pool/retry.go
@@ -113,6 +113,12 @@ func (p *RetryPool) SyncOnce(ctx context.Context) error {
 			p.pool.Delete(t.Key())
 		}
 
+		// Don't start the handler if the target is not ready.
+		// The retry topic/sub might not be ready at this point.
+		if t.State != config.State_READY {
+			return true
+		}
+
 		sub := p.pubsubClient.Subscription(t.RetryQueue.Subscription)
 		sub.ReceiveSettings = p.options.PubsubReceiveSettings
 

--- a/pkg/broker/handler/pool/retry_test.go
+++ b/pkg/broker/handler/pool/retry_test.go
@@ -54,6 +54,19 @@ func TestRetryWatchAndSync(t *testing.T) {
 		assertRetryHandlers(t, syncPool, helper.Targets)
 	})
 
+	t.Run("no handler created for not-ready target", func(t *testing.T) {
+		b := helper.GenerateBroker(ctx, t, "ns")
+		target := helper.GenerateTarget(ctx, t, b.Key(), nil)
+		target.State = config.State_UNKNOWN
+		helper.Targets.MutateBroker(b.Namespace, b.Name, func(bm config.BrokerMutation) {
+			bm.UpsertTargets(target)
+		})
+		signal <- struct{}{}
+		// Wait a short period for the handlers to be updated.
+		<-time.After(time.Second)
+		assertRetryHandlers(t, syncPool, helper.Targets)
+	})
+
 	bs := make([]*config.Broker, 0, 4)
 
 	t.Run("adding some brokers with their targets", func(t *testing.T) {
@@ -276,7 +289,9 @@ func assertRetryHandlers(t *testing.T, p *RetryPool, targets config.Targets) {
 	})
 
 	targets.RangeAllTargets(func(t *config.Target) bool {
-		wantHandlers[t.Key()] = true
+		if t.State == config.State_READY {
+			wantHandlers[t.Key()] = true
+		}
 		return true
 	})
 


### PR DESCRIPTION
Fixes https://github.com/google/knative-gcp/issues/1154

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- fanout/retry pool will not start pull sub when the resource is not ready

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Fanout/retry pool will not start pull sub when the resource is not ready
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
