### PR TITLE
adding test for broker-gcp with steady rps rate

### DIFF
--- a/test/performance/benchmarks/broker-gcp-steady/continuous/100-broker-gcp-setup.yaml
+++ b/test/performance/benchmarks/broker-gcp-steady/continuous/100-broker-gcp-setup.yaml
@@ -1,0 +1,90 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: eventing.knative.dev/v1beta1
+kind: Broker
+metadata:
+  name: gcp
+  namespace: default
+  annotations:
+    eventing.knative.dev/broker.class: googlecloud
+spec: {}
+
+---
+
+apiVersion: eventing.knative.dev/v1beta1
+kind: Trigger
+metadata:
+  name: broker-gcp
+  namespace: default
+spec:
+  broker: gcp
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: broker-gcp-receiver
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: perf-gcpbroker
+  namespace: default
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: perf-gcpbroker
+subjects:
+  - kind: ServiceAccount
+    name: perf-gcpbroker
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: broker-gcp-receiver
+spec:
+  selector:
+    role: broker-gcp-receiver
+  ports:
+    - name: http
+      port: 80
+      targetPort: cloudevents
+      protocol: TCP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: broker-gcp-aggregator
+spec:
+  selector:
+    role: broker-gcp-aggregator
+  ports:
+    - name: grpc
+      port: 10000
+      targetPort: grpc
+      protocol: TCP

--- a/test/performance/benchmarks/broker-gcp-steady/continuous/200-broker-gcp.yaml
+++ b/test/performance/benchmarks/broker-gcp-steady/continuous/200-broker-gcp.yaml
@@ -45,7 +45,7 @@ spec:
               - "--roles=sender,receiver"
               - "--sink=http://broker-ingress.cloud-run-events/default/gcp"
               - "--aggregator=broker-gcp-aggregator:10000"
-              - "--pace=100:10,200:20,400:30,500:60,600:60,700:60,800:60"
+              - "--pace=500:300"
             env:
               - name: POD_NAME
                 valueFrom:

--- a/test/performance/benchmarks/broker-gcp-steady/dev.config
+++ b/test/performance/benchmarks/broker-gcp-steady/dev.config
@@ -1,0 +1,76 @@
+# Create this benchmark with the mako tool: mako create_benchmark dev.config
+# Update this benchmark with the mako tool: mako update_benchmark dev.config
+# Learn more about the mako tool at
+# https://github.com/google/mako/blob/master/docs/CLI.md.
+
+project_name: "Knative"
+benchmark_name: "Development - GCP Broker Latency & Throughput at Steady Pace"
+description: "Measure latency and throughput of the Google Cloud Broker at Steady Pace."
+
+# Human owners for manual benchmark adjustments.
+owner_list: "bkaplan@google.com"
+owner_list: "chizhg@google.com"
+owner_list: "conliu@google.com"
+owner_list: "cshou@google.com"
+owner_list: "danyinggu@google.com"
+owner_list: "elemar@google.com"
+owner_list: "gracegao@google.com"
+owner_list: "grantrodgers@google.com"
+owner_list: "harwayne@google.com"
+owner_list: "ianmi@google.com"
+owner_list: "nachocano@google.com"
+owner_list: "ngiraldo@google.com"
+owner_list: "rustemb@google.com"
+owner_list: "xiyue@google.com"
+owner_list: "zar@google.com"
+
+# Anyone can add their IAM robot here to publish to this benchmark.
+owner_list: "mako-job@knative-performance.iam.gserviceaccount.com"
+# All dev robot accounts go here:
+owner_list: "mako-upload@cshou-playground.iam.gserviceaccount.com"
+owner_list: "mako-upload@grantrodgers-crd.iam.gserviceaccount.com"
+owner_list: "mako-upload@gracegao-knative-gcp-testing.iam.gserviceaccount.com"
+owner_list: "mako-upload@knative-project-228222.iam.gserviceaccount.com"
+owner_list: "mako-upload@ngiraldo-knative-dev.iam.gserviceaccount.com"
+owner_list: "mako-upload@xiyue-knative-project.iam.gserviceaccount.com"
+
+# Define the name and type for x-axis of run charts
+input_value_info: {
+  value_key: "t"
+  label: "time"
+  type: TIMESTAMP
+}
+
+# Note: value_key is stored repeatedly and should be very short (ideally one or two characters).
+metric_info_list: {
+  value_key: "pl"
+  label: "publish-latency"
+}
+metric_info_list: {
+  value_key: "pe"
+  label: "publish-errors"
+}
+metric_info_list: {
+  value_key: "st"
+  label: "send-throughput"
+}
+metric_info_list: {
+  value_key: "dl"
+  label: "deliver-latency"
+}
+metric_info_list: {
+  value_key: "de"
+  label: "deliver-errors"
+}
+metric_info_list: {
+  value_key: "dt"
+  label: "deliver-throughput"
+}
+metric_info_list: {
+  value_key: "pet"
+  label: "publish-failure-throughput"
+}
+metric_info_list: {
+  value_key: "det"
+  label: "deliver-failure-throughput"
+}

--- a/test/performance/benchmarks/broker-gcp-steady/prod.config
+++ b/test/performance/benchmarks/broker-gcp-steady/prod.config
@@ -1,0 +1,70 @@
+# Create this benchmark with the mako tool: mako create_benchmark prod.config
+# Update this benchmark with the mako tool: mako update_benchmark prod.config
+# Learn more about the mako tool at
+# https://github.com/google/mako/blob/master/docs/CLI.md.
+
+project_name: "Knative"
+benchmark_name: "GCP Broker Latency & Throughput at Steady Pace"
+description: "Measure latency and throughput of the Google Cloud Broker at Steady Pace"
+
+# Human owners for manual benchmark adjustments.
+owner_list: "bkaplan@google.com"
+owner_list: "chizhg@google.com"
+owner_list: "conliu@google.com"
+owner_list: "cshou@google.com"
+owner_list: "danyinggu@google.com"
+owner_list: "elemar@google.com"
+owner_list: "gracegao@google.com"
+owner_list: "grantrodgers@google.com"
+owner_list: "harwayne@google.com"
+owner_list: "ianmi@google.com"
+owner_list: "nachocano@google.com"
+owner_list: "ngiraldo@google.com"
+owner_list: "rustemb@google.com"
+owner_list: "xiyue@google.com"
+owner_list: "zar@google.com"
+
+# GCP Service Accounts that can publish data to Mako. Since this is a prod
+# benchmark, only the CI account should be listed here.
+owner_list: "mako-job@knative-performance.iam.gserviceaccount.com"
+
+# Define the name and type for x-axis of run charts
+input_value_info: {
+  value_key: "t"
+  label: "time"
+  type: TIMESTAMP
+}
+
+# Note: value_key is stored repeatedly and should be very short (ideally one or two characters).
+metric_info_list: {
+  value_key: "pl"
+  label: "publish-latency"
+}
+metric_info_list: {
+  value_key: "pe"
+  label: "publish-errors"
+}
+metric_info_list: {
+  value_key: "st"
+  label: "send-throughput"
+}
+metric_info_list: {
+  value_key: "dl"
+  label: "deliver-latency"
+}
+metric_info_list: {
+  value_key: "de"
+  label: "deliver-errors"
+}
+metric_info_list: {
+  value_key: "dt"
+  label: "deliver-throughput"
+}
+metric_info_list: {
+  value_key: "pet"
+  label: "publish-failure-throughput"
+}
+metric_info_list: {
+  value_key: "det"
+  label: "deliver-failure-throughput"
+}


### PR DESCRIPTION
Moves forward #876 and #930 

## Proposed Changes

- Adds a new benchmark for broker-gcp that runs at a steady pace for 5 minutes. Steady pace is set at 500 rps which is below the max rps which increasing pace test shows can be safely handled. (this is very much open to discussion, tuning)
- Increases the max rps for the existing broker-gcp tests (increased to 800 max, I want to see it hit the pole)

Reasoning: 
- See [here](http://highscalability.com/blog/2015/10/5/your-load-generator-is-probably-lying-to-you-take-the-red-pi.html) for a conceptual talk about doing performance testing.
- See [here](https://github.com/slinkydeveloper/eventing-bench-results/blob/master/11-14-2019/README.md#results) for a recent performance analysis of knative eventing components.

Key takeaways from these two references (as related to this PR):
- We should not be measuring latencies with a performance test that has an increasing rps pace
- The tests we have (increasing rps pace) are useful, but for a different purpose (to find the breaking point of the SUT). However, it seems to me the current pace does not achieve that goal.

Will update PR with some sample runs (on dev env) once they start coming through on Mako.
