### PR TITLE
Remove the brokers event_dispatch_latencies metric

### DIFF
--- a/pkg/broker/ingress/handler_test.go
+++ b/pkg/broker/ingress/handler_test.go
@@ -428,11 +428,10 @@ func createRequest(tc testCase, url string) *nethttp.Request {
 // verifyMetrics verifies broker metrics are properly recorded (or not recorded)
 func verifyMetrics(t *testing.T, tc testCase) {
 	if tc.wantEventCount == 0 {
-		metricstest.CheckStatsNotReported(t, "event_count", "event_dispatch_latencies")
+		metricstest.CheckStatsNotReported(t, "event_count")
 	} else {
-		metricstest.CheckStatsReported(t, "event_count", "event_dispatch_latencies")
+		metricstest.CheckStatsReported(t, "event_count")
 		metricstest.CheckCountData(t, "event_count", tc.wantMetricTags, tc.wantEventCount)
-		metricstest.CheckDistributionCount(t, "event_dispatch_latencies", tc.wantMetricTags, tc.wantEventCount)
 	}
 }
 

--- a/pkg/metrics/ingress_reporter.go
+++ b/pkg/metrics/ingress_reporter.go
@@ -19,11 +19,12 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"strconv"
+
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	"knative.dev/pkg/metrics"
-	"strconv"
 )
 
 // stats_exporter is adapted from knative.dev/eventing/pkg/broker/ingress/stats_reporter.go

--- a/pkg/metrics/ingress_reporter.go
+++ b/pkg/metrics/ingress_reporter.go
@@ -19,13 +19,11 @@ package metrics
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"time"
-
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	"knative.dev/pkg/metrics"
+	"strconv"
 )
 
 // stats_exporter is adapted from knative.dev/eventing/pkg/broker/ingress/stats_reporter.go
@@ -54,17 +52,10 @@ func (r *IngressReporter) register() error {
 	// Create view to see our measurements.
 	return view.Register(
 		&view.View{
-			Name:        "event_count",
-			Description: "Number of events received by a Broker",
-			Measure:     r.dispatchTimeInMsecM,
+			Name:        r.eventCountM.Name(),
+			Description: r.eventCountM.Description(),
+			Measure:     r.eventCountM,
 			Aggregation: view.Count(),
-			TagKeys:     tagKeys,
-		},
-		&view.View{
-			Name:        r.dispatchTimeInMsecM.Name(),
-			Description: r.dispatchTimeInMsecM.Description(),
-			Measure:     r.dispatchTimeInMsecM,
-			Aggregation: view.Distribution(metrics.Buckets125(1, 10000)...), // 1, 2, 5, 10, 20, 50, 100, 500, 1000, 5000, 10000
 			TagKeys:     tagKeys,
 		},
 	)
@@ -75,10 +66,10 @@ func NewIngressReporter(podName PodName, containerName ContainerName) (*IngressR
 	r := &IngressReporter{
 		podName:       podName,
 		containerName: containerName,
-		dispatchTimeInMsecM: stats.Float64(
-			"event_dispatch_latencies",
-			"The time spent dispatching an event to the decouple topic",
-			stats.UnitMilliseconds,
+		eventCountM: stats.Int64(
+			"event_count",
+			"Number of events received by a Broker",
+			stats.UnitDimensionless,
 		),
 	}
 	if err := r.register(); err != nil {
@@ -91,12 +82,10 @@ func NewIngressReporter(podName PodName, containerName ContainerName) (*IngressR
 type IngressReporter struct {
 	podName       PodName
 	containerName ContainerName
-	// dispatchTimeInMsecM records the time spent dispatching an event to a decouple queue, in
-	// milliseconds.
-	dispatchTimeInMsecM *stats.Float64Measure
+	eventCountM *stats.Int64Measure
 }
 
-func (r *IngressReporter) ReportEventDispatchTime(ctx context.Context, args IngressReportArgs, d time.Duration) error {
+func (r *IngressReporter) ReportEventCount(ctx context.Context, args IngressReportArgs) error {
 	tag, err := tag.New(
 		ctx,
 		tag.Insert(PodNameKey, string(r.podName)),
@@ -110,7 +99,6 @@ func (r *IngressReporter) ReportEventDispatchTime(ctx context.Context, args Ingr
 	if err != nil {
 		return fmt.Errorf("failed to create metrics tag: %v", err)
 	}
-	// convert time.Duration in nanoseconds to milliseconds.
-	metrics.Record(tag, r.dispatchTimeInMsecM.M(float64(d/time.Millisecond)))
+	metrics.Record(tag, r.eventCountM.M(1))
 	return nil
 }

--- a/pkg/metrics/ingress_reporter_test.go
+++ b/pkg/metrics/ingress_reporter_test.go
@@ -18,10 +18,8 @@ package metrics
 
 import (
 	"context"
-	"testing"
-	"time"
-
 	_ "knative.dev/pkg/metrics/testing"
+	"testing"
 
 	reportertest "github.com/google/knative-gcp/pkg/metrics/testing"
 	"knative.dev/pkg/metrics/metricskey"
@@ -52,13 +50,12 @@ func TestStatsReporter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// test ReportDispatchTime
+	// test ReportEventCount
 	reportertest.ExpectMetrics(t, func() error {
-		return r.ReportEventDispatchTime(context.Background(), args, 1100*time.Millisecond)
+		return r.ReportEventCount(context.Background(), args)
 	})
 	reportertest.ExpectMetrics(t, func() error {
-		return r.ReportEventDispatchTime(context.Background(), args, 9100*time.Millisecond)
+		return r.ReportEventCount(context.Background(), args)
 	})
 	metricstest.CheckCountData(t, "event_count", wantTags, 2)
-	metricstest.CheckDistributionData(t, "event_dispatch_latencies", wantTags, 2, 1100.0, 9100.0)
 }

--- a/pkg/metrics/ingress_reporter_test.go
+++ b/pkg/metrics/ingress_reporter_test.go
@@ -18,8 +18,9 @@ package metrics
 
 import (
 	"context"
-	_ "knative.dev/pkg/metrics/testing"
 	"testing"
+
+	_ "knative.dev/pkg/metrics/testing"
 
 	reportertest "github.com/google/knative-gcp/pkg/metrics/testing"
 	"knative.dev/pkg/metrics/metricskey"


### PR DESCRIPTION
This isn't one of the existing stackdriver metrics:
- broker/event_count
- trigger/event_count
- trigger/event_dispatch_latencies
- trigger/event_processing_latencies

Which ends up being dropped when attempting to report the metric. Due to
this, the broker/event_count metric isn't able to emit since these
measures are tied together.

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
