### PR TITLE
Use config-gcp-auth for WI manipulation of GSAs

### DIFF
--- a/pkg/reconciler/events/auditlogs/auditlogs.go
+++ b/pkg/reconciler/events/auditlogs/auditlogs.go
@@ -73,7 +73,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, s *v1alpha1.CloudAuditLo
 	s.Status.ObservedGeneration = s.Generation
 
 	// If GCP ServiceAccount is provided, reconcile workload identity.
-	if s.Spec.GoogleServiceAccount != "" {
+	if s.Spec.ServiceAccountName != "" || s.Spec.GoogleServiceAccount != "" {
 		if _, err := c.Identity.ReconcileWorkloadIdentity(ctx, s.Spec.Project, s); err != nil {
 			return reconciler.NewEvent(corev1.EventTypeWarning, workloadIdentityFailed, "Failed to reconcile CloudAuditLogsSource workload identity: %s", err.Error())
 		}
@@ -187,7 +187,7 @@ func (c *Reconciler) deleteSink(ctx context.Context, s *v1alpha1.CloudAuditLogsS
 func (c *Reconciler) FinalizeKind(ctx context.Context, s *v1alpha1.CloudAuditLogsSource) reconciler.Event {
 	// If k8s ServiceAccount exists and it only has one ownerReference, remove the corresponding GCP ServiceAccount iam policy binding.
 	// No need to delete k8s ServiceAccount, it will be automatically handled by k8s Garbage Collection.
-	if s.Spec.GoogleServiceAccount != "" {
+	if s.Spec.ServiceAccountName != "" || s.Spec.GoogleServiceAccount != "" {
 		if err := c.Identity.DeleteWorkloadIdentity(ctx, s.Spec.Project, s); err != nil {
 			return reconciler.NewEvent(corev1.EventTypeWarning, deleteWorkloadIdentityFailed, "Failed to delete CloudAuditLogsSource workload identity: %s", err.Error())
 		}

--- a/pkg/reconciler/events/auditlogs/auditlogs_test.go
+++ b/pkg/reconciler/events/auditlogs/auditlogs_test.go
@@ -414,7 +414,7 @@ func TestAllCases(t *testing.T) {
 				WithCloudAuditLogsSourceAnnotations(map[string]string{
 					duckv1alpha1.ClusterNameAnnotation: testingMetadataClient.FakeClusterName,
 				}),
-				WithCloudAuditLogsSourceDefaultAuthorization(),
+				WithCloudAuditLogsSourceDefaultGCPAuth(),
 			),
 			NewTopic(sourceName, testNS,
 				WithTopicSpec(inteventsv1alpha1.TopicSpec{
@@ -424,7 +424,7 @@ func TestAllCases(t *testing.T) {
 				WithTopicReady(testTopicID),
 				WithTopicAddress(testTopicURI),
 				WithTopicProjectID(testProject),
-				WithTopicDefaultAuthorization(),
+				WithTopicDefaultGCPAuth(),
 			),
 		},
 		Key: testNS + "/" + sourceName,
@@ -439,7 +439,7 @@ func TestAllCases(t *testing.T) {
 				WithCloudAuditLogsSourceAnnotations(map[string]string{
 					duckv1alpha1.ClusterNameAnnotation: testingMetadataClient.FakeClusterName,
 				}),
-				WithCloudAuditLogsSourceDefaultAuthorization(),
+				WithCloudAuditLogsSourceDefaultGCPAuth(),
 				WithCloudAuditLogsSourcePullSubscriptionUnknown("PullSubscriptionNotConfigured", failedToReconcilePullSubscriptionMsg),
 			),
 		}},
@@ -462,7 +462,7 @@ func TestAllCases(t *testing.T) {
 					duckv1alpha1.ClusterNameAnnotation: testingMetadataClient.FakeClusterName,
 				}),
 				WithPullSubscriptionOwnerReferences([]metav1.OwnerReference{sourceOwnerRef(sourceName, sourceUID)}),
-				WithPullSubscriptionDefaultAuthorization(),
+				WithPullSubscriptionDefaultGCPAuth(),
 			),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{

--- a/pkg/reconciler/events/auditlogs/auditlogs_test.go
+++ b/pkg/reconciler/events/auditlogs/auditlogs_test.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	clientgotesting "k8s.io/client-go/testing"
-
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/configmap"
@@ -1315,7 +1314,7 @@ func TestAllCases(t *testing.T) {
 				func(ctx context.Context, listers *Listers, cmw configmap.Watcher, testData map[string]interface{}) controller.Reconciler {
 					r := &Reconciler{
 						PubSubBase:             intevents.NewPubSubBaseWithAdapter(ctx, controllerAgentName, receiveAdapterName, converters.CloudAuditLogsConverter, cmw),
-						Identity:               identity.NewIdentity(ctx, NoopIAMPolicyManager),
+						Identity:               identity.NewIdentity(ctx, NoopIAMPolicyManager, NewGCPAuthTestStore(t, nil)),
 						auditLogsSourceLister:  listers.GetCloudAuditLogsSourceLister(),
 						logadminClientProvider: logadminClientProvider,
 						pubsubClientProvider:   gpubsub.TestClientCreator(testData["pubsub"]),

--- a/pkg/reconciler/events/auditlogs/controller.go
+++ b/pkg/reconciler/events/auditlogs/controller.go
@@ -20,6 +20,7 @@ package auditlogs
 import (
 	"context"
 
+	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
 	"github.com/google/knative-gcp/pkg/apis/events/v1alpha1"
 	"github.com/google/knative-gcp/pkg/pubsub/adapter/converters"
 	"github.com/google/knative-gcp/pkg/reconciler"
@@ -30,6 +31,7 @@ import (
 	serviceaccountinformers "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
 
 	cloudauditlogssourceinformers "github.com/google/knative-gcp/pkg/client/injection/informers/events/v1alpha1/cloudauditlogssource"
 	pullsubscriptioninformers "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1alpha1/pullsubscription"

--- a/pkg/reconciler/events/auditlogs/controller.go
+++ b/pkg/reconciler/events/auditlogs/controller.go
@@ -20,6 +20,11 @@ package auditlogs
 import (
 	"context"
 
+	"k8s.io/client-go/tools/cache"
+	serviceaccountinformers "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+
 	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
 	"github.com/google/knative-gcp/pkg/apis/events/v1alpha1"
 	"github.com/google/knative-gcp/pkg/pubsub/adapter/converters"
@@ -27,11 +32,6 @@ import (
 	"github.com/google/knative-gcp/pkg/reconciler/identity"
 	"github.com/google/knative-gcp/pkg/reconciler/identity/iam"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents"
-	"k8s.io/client-go/tools/cache"
-	serviceaccountinformers "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount"
-	"knative.dev/pkg/configmap"
-	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
 
 	cloudauditlogssourceinformers "github.com/google/knative-gcp/pkg/client/injection/informers/events/v1alpha1/cloudauditlogssource"
 	pullsubscriptioninformers "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1alpha1/pullsubscription"
@@ -62,13 +62,15 @@ func NewController(
 	return newControllerWithIAMPolicyManager(
 		ctx,
 		cmw,
-		iam.DefaultIAMPolicyManager())
+		iam.DefaultIAMPolicyManager(),
+		identity.NewGCPAuthStore(ctx, cmw))
 }
 
 func newControllerWithIAMPolicyManager(
 	ctx context.Context,
 	cmw configmap.Watcher,
 	ipm iam.IAMPolicyManager,
+	gcpas *gcpauth.Store,
 ) *controller.Impl {
 	pullsubscriptionInformer := pullsubscriptioninformers.Get(ctx)
 	topicInformer := topicinformers.Get(ctx)
@@ -77,7 +79,7 @@ func newControllerWithIAMPolicyManager(
 
 	r := &Reconciler{
 		PubSubBase:             intevents.NewPubSubBaseWithAdapter(ctx, controllerAgentName, receiveAdapterName, converters.CloudAuditLogsConverter, cmw),
-		Identity:               identity.NewIdentity(ctx, ipm),
+		Identity:               identity.NewIdentity(ctx, ipm, gcpas),
 		auditLogsSourceLister:  cloudauditlogssourceInformer.Lister(),
 		logadminClientProvider: glogadmin.NewClient,
 		pubsubClientProvider:   gpubsub.NewClient,

--- a/pkg/reconciler/events/auditlogs/controller_test.go
+++ b/pkg/reconciler/events/auditlogs/controller_test.go
@@ -37,8 +37,8 @@ import (
 func TestNew(t *testing.T) {
 	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
-
-	c := newControllerWithIAMPolicyManager(ctx, configmap.NewStaticWatcher(), iamtesting.NoopIAMPolicyManager)
+	cmw := configmap.NewStaticWatcher()
+	c := newControllerWithIAMPolicyManager(ctx, cmw, iamtesting.NoopIAMPolicyManager, iamtesting.NewGCPAuthTestStore(t, nil))
 
 	if c == nil {
 		t.Fatal("Expected newControllerWithIAMPolicyManager to return a non-nil value")

--- a/pkg/reconciler/events/build/build.go
+++ b/pkg/reconciler/events/build/build.go
@@ -66,7 +66,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, build *v1alpha1.CloudBui
 	build.Status.InitializeConditions()
 	build.Status.ObservedGeneration = build.Generation
 	// If GCP ServiceAccount is provided, reconcile workload identity.
-	if build.Spec.GoogleServiceAccount != "" {
+	if build.Spec.ServiceAccountName != "" || build.Spec.GoogleServiceAccount != "" {
 		if _, err := r.Identity.ReconcileWorkloadIdentity(ctx, build.Spec.Project, build); err != nil {
 			return pkgreconciler.NewEvent(corev1.EventTypeWarning, workloadIdentityFailed, "Failed to reconcile CloudBuildSource workload identity: %s", err.Error())
 		}
@@ -82,7 +82,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, build *v1alpha1.CloudBui
 func (r *Reconciler) FinalizeKind(ctx context.Context, build *v1alpha1.CloudBuildSource) pkgreconciler.Event {
 	// If k8s ServiceAccount exists and it only has one ownerReference, remove the corresponding GCP ServiceAccount iam policy binding.
 	// No need to delete k8s ServiceAccount, it will be automatically handled by k8s Garbage Collection.
-	if build.Spec.GoogleServiceAccount != "" {
+	if build.Spec.ServiceAccountName != "" || build.Spec.GoogleServiceAccount != "" {
 		if err := r.Identity.DeleteWorkloadIdentity(ctx, build.Spec.Project, build); err != nil {
 			return pkgreconciler.NewEvent(corev1.EventTypeWarning, deleteWorkloadIdentityFailed, "Failed to delete CloudBuildSource workload identity: %s", err.Error())
 		}

--- a/pkg/reconciler/events/build/build_test.go
+++ b/pkg/reconciler/events/build/build_test.go
@@ -166,7 +166,7 @@ func TestAllCases(t *testing.T) {
 					WithCloudBuildSourceAnnotations(map[string]string{
 						duckv1alpha1.ClusterNameAnnotation: testingMetadataClient.FakeClusterName,
 					}),
-					WithCloudBuildSourceDefaultAuthorization(),
+					WithCloudBuildSourceDefaultGCPAuth(),
 				),
 				newSink(),
 			},
@@ -182,7 +182,7 @@ func TestAllCases(t *testing.T) {
 					WithCloudBuildSourceAnnotations(map[string]string{
 						duckv1alpha1.ClusterNameAnnotation: testingMetadataClient.FakeClusterName,
 					}),
-					WithCloudBuildSourceDefaultAuthorization(),
+					WithCloudBuildSourceDefaultGCPAuth(),
 					WithCloudBuildSourcePullSubscriptionUnknown("PullSubscriptionNotConfigured", "PullSubscription has not yet been reconciled"),
 				),
 			}},
@@ -207,7 +207,7 @@ func TestAllCases(t *testing.T) {
 						duckv1alpha1.ClusterNameAnnotation: testingMetadataClient.FakeClusterName,
 					}),
 					WithPullSubscriptionOwnerReferences([]metav1.OwnerReference{ownerRef()}),
-					WithPullSubscriptionDefaultAuthorization(),
+					WithPullSubscriptionDefaultGCPAuth(),
 				),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{

--- a/pkg/reconciler/events/build/build_test.go
+++ b/pkg/reconciler/events/build/build_test.go
@@ -401,7 +401,7 @@ func TestAllCases(t *testing.T) {
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher, _ map[string]interface{}) controller.Reconciler {
 		r := &Reconciler{
 			PubSubBase:           intevents.NewPubSubBase(ctx, controllerAgentName, receiveAdapterName, cmw),
-			Identity:             identity.NewIdentity(ctx, NoopIAMPolicyManager),
+			Identity:             identity.NewIdentity(ctx, NoopIAMPolicyManager, NewGCPAuthTestStore(t, nil)),
 			buildLister:          listers.GetCloudBuildSourceLister(),
 			serviceAccountLister: listers.GetServiceAccountLister(),
 		}

--- a/pkg/reconciler/events/build/controller_test.go
+++ b/pkg/reconciler/events/build/controller_test.go
@@ -37,8 +37,8 @@ import (
 func TestNew(t *testing.T) {
 	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
-
-	c := newControllerWithIAMPolicyManager(ctx, configmap.NewStaticWatcher(), iamtesting.NoopIAMPolicyManager)
+	cmw := configmap.NewStaticWatcher()
+	c := newControllerWithIAMPolicyManager(ctx, cmw, iamtesting.NoopIAMPolicyManager, iamtesting.NewGCPAuthTestStore(t, nil))
 
 	if c == nil {
 		t.Fatal("Expected newControllerWithIAMPolicyManager to return a non-nil value")

--- a/pkg/reconciler/events/pubsub/controller.go
+++ b/pkg/reconciler/events/pubsub/controller.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 
+	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
 	"github.com/google/knative-gcp/pkg/apis/events/v1alpha1"
 	cloudpubsubsourceinformers "github.com/google/knative-gcp/pkg/client/injection/informers/events/v1alpha1/cloudpubsubsource"
 	pullsubscriptioninformers "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1alpha1/pullsubscription"
@@ -55,13 +56,15 @@ func NewController(
 	return newControllerWithIAMPolicyManager(
 		ctx,
 		cmw,
-		iam.DefaultIAMPolicyManager())
+		iam.DefaultIAMPolicyManager(),
+		identity.NewGCPAuthStore(ctx, cmw))
 }
 
 func newControllerWithIAMPolicyManager(
 	ctx context.Context,
 	cmw configmap.Watcher,
 	ipm iam.IAMPolicyManager,
+	gcpas *gcpauth.Store,
 ) *controller.Impl {
 	pullsubscriptionInformer := pullsubscriptioninformers.Get(ctx)
 	cloudpubsubsourceInformer := cloudpubsubsourceinformers.Get(ctx)
@@ -69,7 +72,7 @@ func newControllerWithIAMPolicyManager(
 
 	r := &Reconciler{
 		PubSubBase:   intevents.NewPubSubBase(ctx, controllerAgentName, receiveAdapterName, cmw),
-		Identity:     identity.NewIdentity(ctx, ipm),
+		Identity:     identity.NewIdentity(ctx, ipm, gcpas),
 		pubsubLister: cloudpubsubsourceInformer.Lister(),
 	}
 	impl := cloudpubsubsourcereconciler.NewImpl(ctx, r)

--- a/pkg/reconciler/events/pubsub/controller_test.go
+++ b/pkg/reconciler/events/pubsub/controller_test.go
@@ -37,8 +37,8 @@ import (
 func TestNew(t *testing.T) {
 	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
-
-	c := newControllerWithIAMPolicyManager(ctx, configmap.NewStaticWatcher(), iamtesting.NoopIAMPolicyManager)
+	cmw := configmap.NewStaticWatcher()
+	c := newControllerWithIAMPolicyManager(ctx, cmw, iamtesting.NoopIAMPolicyManager, iamtesting.NewGCPAuthTestStore(t, nil))
 
 	if c == nil {
 		t.Fatal("Expected newControllerWithIAMPolicyManager to return a non-nil value")

--- a/pkg/reconciler/events/pubsub/pubsub.go
+++ b/pkg/reconciler/events/pubsub/pubsub.go
@@ -58,7 +58,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, pubsub *v1alpha1.CloudPu
 	pubsub.Status.ObservedGeneration = pubsub.Generation
 
 	// If GCP ServiceAccount is provided, reconcile workload identity.
-	if pubsub.Spec.GoogleServiceAccount != "" {
+	if pubsub.Spec.ServiceAccountName != "" || pubsub.Spec.GoogleServiceAccount != "" {
 		if _, err := r.Identity.ReconcileWorkloadIdentity(ctx, pubsub.Spec.Project, pubsub); err != nil {
 			return pkgreconciler.NewEvent(corev1.EventTypeWarning, workloadIdentityFailed, "Failed to reconcile CloudPubSubSource workload identity: %s", err.Error())
 		}
@@ -74,7 +74,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, pubsub *v1alpha1.CloudPu
 func (r *Reconciler) FinalizeKind(ctx context.Context, pubsub *v1alpha1.CloudPubSubSource) pkgreconciler.Event {
 	// If k8s ServiceAccount exists and it only has one ownerReference, remove the corresponding GCP ServiceAccount iam policy binding.
 	// No need to delete k8s ServiceAccount, it will be automatically handled by k8s Garbage Collection.
-	if pubsub.Spec.GoogleServiceAccount != "" {
+	if pubsub.Spec.ServiceAccountName != "" || pubsub.Spec.GoogleServiceAccount != "" {
 		if err := r.Identity.DeleteWorkloadIdentity(ctx, pubsub.Spec.Project, pubsub); err != nil {
 			return pkgreconciler.NewEvent(corev1.EventTypeWarning, deleteWorkloadIdentityFailed, "Failed to delete CloudPubSubSource workload identity: %s", err.Error())
 		}

--- a/pkg/reconciler/events/pubsub/pubsub_test.go
+++ b/pkg/reconciler/events/pubsub/pubsub_test.go
@@ -164,7 +164,7 @@ func TestAllCases(t *testing.T) {
 				WithCloudPubSubSourceAnnotations(map[string]string{
 					duckv1alpha1.ClusterNameAnnotation: testingMetadataClient.FakeClusterName,
 				}),
-				WithCloudPubSubSourceDefaultAuthorization(),
+				WithCloudPubSubSourceDefaultGCPAuth(),
 			),
 			newSink(),
 		},
@@ -180,7 +180,7 @@ func TestAllCases(t *testing.T) {
 				WithCloudPubSubSourceAnnotations(map[string]string{
 					duckv1alpha1.ClusterNameAnnotation: testingMetadataClient.FakeClusterName,
 				}),
-				WithCloudPubSubSourceDefaultAuthorization(),
+				WithCloudPubSubSourceDefaultGCPAuth(),
 				WithCloudPubSubSourcePullSubscriptionUnknown("PullSubscriptionNotConfigured", "PullSubscription has not yet been reconciled"),
 			),
 		}},
@@ -203,7 +203,7 @@ func TestAllCases(t *testing.T) {
 					duckv1alpha1.ClusterNameAnnotation: testingMetadataClient.FakeClusterName,
 				}),
 				WithPullSubscriptionOwnerReferences([]metav1.OwnerReference{ownerRef()}),
-				WithPullSubscriptionDefaultAuthorization(),
+				WithPullSubscriptionDefaultGCPAuth(),
 			),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{

--- a/pkg/reconciler/events/pubsub/pubsub_test.go
+++ b/pkg/reconciler/events/pubsub/pubsub_test.go
@@ -400,7 +400,7 @@ func TestAllCases(t *testing.T) {
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher, _ map[string]interface{}) controller.Reconciler {
 		r := &Reconciler{
 			PubSubBase:   intevents.NewPubSubBase(ctx, controllerAgentName, receiveAdapterName, cmw),
-			Identity:     identity.NewIdentity(ctx, NoopIAMPolicyManager),
+			Identity:     identity.NewIdentity(ctx, NoopIAMPolicyManager, NewGCPAuthTestStore(t, nil)),
 			pubsubLister: listers.GetCloudPubSubSourceLister(),
 		}
 		return cloudpubsubsource.NewReconciler(ctx, r.Logger, r.RunClientSet, listers.GetCloudPubSubSourceLister(), r.Recorder, r)

--- a/pkg/reconciler/events/scheduler/controller_test.go
+++ b/pkg/reconciler/events/scheduler/controller_test.go
@@ -19,10 +19,14 @@ package scheduler
 import (
 	"testing"
 
-	iamtesting "github.com/google/knative-gcp/pkg/reconciler/testing"
 	"knative.dev/pkg/configmap"
 	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
+
+	iamtesting "github.com/google/knative-gcp/pkg/reconciler/testing"
+
+	_ "knative.dev/pkg/client/injection/kube/informers/batch/v1/job/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 
 	// Fake injection informers
 	_ "github.com/google/knative-gcp/pkg/client/clientset/versioned/typed/intevents/v1alpha1/fake"
@@ -31,15 +35,13 @@ import (
 	_ "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1alpha1/pullsubscription/fake"
 	_ "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1alpha1/topic/fake"
 	_ "github.com/google/knative-gcp/pkg/reconciler/testing"
-	_ "knative.dev/pkg/client/injection/kube/informers/batch/v1/job/fake"
-	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 )
 
 func TestNew(t *testing.T) {
 	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
-
-	c := newControllerWithIAMPolicyManager(ctx, configmap.NewStaticWatcher(), iamtesting.NoopIAMPolicyManager)
+	cmw := configmap.NewStaticWatcher()
+	c := newControllerWithIAMPolicyManager(ctx, cmw, iamtesting.NoopIAMPolicyManager, iamtesting.NewGCPAuthTestStore(t, nil))
 
 	if c == nil {
 		t.Fatal("Expected newControllerWithIAMPolicyManager to return a non-nil value")

--- a/pkg/reconciler/events/scheduler/scheduler.go
+++ b/pkg/reconciler/events/scheduler/scheduler.go
@@ -73,7 +73,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, scheduler *v1alpha1.Clou
 	scheduler.Status.ObservedGeneration = scheduler.Generation
 
 	// If GCP ServiceAccount is provided, reconcile workload identity.
-	if scheduler.Spec.GoogleServiceAccount != "" {
+	if scheduler.Spec.ServiceAccountName != "" || scheduler.Spec.GoogleServiceAccount != "" {
 		if _, err := r.Identity.ReconcileWorkloadIdentity(ctx, scheduler.Spec.Project, scheduler); err != nil {
 			return reconciler.NewEvent(corev1.EventTypeWarning, workloadIdentityFailed, "Failed to reconcile CloudSchedulerSource workload identity: %s", err.Error())
 		}
@@ -187,7 +187,7 @@ func (r *Reconciler) deleteJob(ctx context.Context, scheduler *v1alpha1.CloudSch
 func (r *Reconciler) FinalizeKind(ctx context.Context, scheduler *v1alpha1.CloudSchedulerSource) reconciler.Event {
 	// If k8s ServiceAccount exists and it only has one ownerReference, remove the corresponding GCP ServiceAccount iam policy binding.
 	// No need to delete k8s ServiceAccount, it will be automatically handled by k8s Garbage Collection.
-	if scheduler.Spec.GoogleServiceAccount != "" {
+	if scheduler.Spec.ServiceAccountName != "" || scheduler.Spec.GoogleServiceAccount != "" {
 		if err := r.Identity.DeleteWorkloadIdentity(ctx, scheduler.Spec.Project, scheduler); err != nil {
 			return reconciler.NewEvent(corev1.EventTypeWarning, deleteWorkloadIdentityFailed, "Failed to delete CloudSchedulerSource workload identity: %s", err.Error())
 		}

--- a/pkg/reconciler/events/scheduler/scheduler_test.go
+++ b/pkg/reconciler/events/scheduler/scheduler_test.go
@@ -454,7 +454,7 @@ func TestAllCases(t *testing.T) {
 					WithCloudSchedulerSourceAnnotations(map[string]string{
 						duckv1alpha1.ClusterNameAnnotation: testingMetadataClient.FakeClusterName,
 					}),
-					WithCloudSchedulerSourceDefaultAuthorization(),
+					WithCloudSchedulerSourceDefaultGCPAuth(),
 				),
 				NewTopic(schedulerName, testNS,
 					WithTopicSpec(inteventsv1alpha1.TopicSpec{
@@ -464,7 +464,7 @@ func TestAllCases(t *testing.T) {
 					WithTopicReady(testTopicID),
 					WithTopicAddress(testTopicURI),
 					WithTopicProjectID(testProject),
-					WithTopicDefaultAuthorization(),
+					WithTopicDefaultGCPAuth(),
 				),
 				newSink(),
 			},
@@ -480,7 +480,7 @@ func TestAllCases(t *testing.T) {
 					WithCloudSchedulerSourceAnnotations(map[string]string{
 						duckv1alpha1.ClusterNameAnnotation: testingMetadataClient.FakeClusterName,
 					}),
-					WithCloudSchedulerSourceDefaultAuthorization(),
+					WithCloudSchedulerSourceDefaultGCPAuth(),
 					WithCloudSchedulerSourcePullSubscriptionUnknown("PullSubscriptionNotConfigured", failedToReconcilePullSubscriptionMsg),
 				),
 			}},

--- a/pkg/reconciler/events/scheduler/scheduler_test.go
+++ b/pkg/reconciler/events/scheduler/scheduler_test.go
@@ -1206,7 +1206,7 @@ func TestAllCases(t *testing.T) {
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher, testData map[string]interface{}) controller.Reconciler {
 		r := &Reconciler{
 			PubSubBase:      intevents.NewPubSubBase(ctx, controllerAgentName, receiveAdapterName, cmw),
-			Identity:        identity.NewIdentity(ctx, NoopIAMPolicyManager),
+			Identity:        identity.NewIdentity(ctx, NoopIAMPolicyManager, NewGCPAuthTestStore(t, nil)),
 			schedulerLister: listers.GetCloudSchedulerSourceLister(),
 			createClientFn:  gscheduler.TestClientCreator(testData["scheduler"]),
 		}

--- a/pkg/reconciler/events/storage/controller.go
+++ b/pkg/reconciler/events/storage/controller.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 
+	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
 	"github.com/google/knative-gcp/pkg/apis/events/v1alpha1"
 	cloudstoragesourceinformers "github.com/google/knative-gcp/pkg/client/injection/informers/events/v1alpha1/cloudstoragesource"
 	pullsubscriptioninformers "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1alpha1/pullsubscription"
@@ -57,13 +58,15 @@ func NewController(
 	return newControllerWithIAMPolicyManager(
 		ctx,
 		cmw,
-		iam.DefaultIAMPolicyManager())
+		iam.DefaultIAMPolicyManager(),
+		identity.NewGCPAuthStore(ctx, cmw))
 }
 
 func newControllerWithIAMPolicyManager(
 	ctx context.Context,
 	cmw configmap.Watcher,
 	ipm iam.IAMPolicyManager,
+	gcpas *gcpauth.Store,
 ) *controller.Impl {
 	pullsubscriptionInformer := pullsubscriptioninformers.Get(ctx)
 	topicInformer := topicinformers.Get(ctx)
@@ -72,7 +75,7 @@ func newControllerWithIAMPolicyManager(
 
 	r := &Reconciler{
 		PubSubBase:     intevents.NewPubSubBase(ctx, controllerAgentName, receiveAdapterName, cmw),
-		Identity:       identity.NewIdentity(ctx, ipm),
+		Identity:       identity.NewIdentity(ctx, ipm, gcpas),
 		storageLister:  cloudstoragesourceInformer.Lister(),
 		createClientFn: gstorage.NewClient,
 	}

--- a/pkg/reconciler/events/storage/controller_test.go
+++ b/pkg/reconciler/events/storage/controller_test.go
@@ -19,10 +19,14 @@ package storage
 import (
 	"testing"
 
-	iamtesting "github.com/google/knative-gcp/pkg/reconciler/testing"
 	"knative.dev/pkg/configmap"
 	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
+
+	iamtesting "github.com/google/knative-gcp/pkg/reconciler/testing"
+
+	_ "knative.dev/pkg/client/injection/kube/informers/batch/v1/job/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 
 	// Fake injection informers
 	_ "github.com/google/knative-gcp/pkg/client/clientset/versioned/typed/intevents/v1alpha1/fake"
@@ -31,15 +35,13 @@ import (
 	_ "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1alpha1/pullsubscription/fake"
 	_ "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1alpha1/topic/fake"
 	_ "github.com/google/knative-gcp/pkg/reconciler/testing"
-	_ "knative.dev/pkg/client/injection/kube/informers/batch/v1/job/fake"
-	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 )
 
 func TestNew(t *testing.T) {
 	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
-
-	c := newControllerWithIAMPolicyManager(ctx, configmap.NewStaticWatcher(), iamtesting.NoopIAMPolicyManager)
+	cmw := configmap.NewStaticWatcher()
+	c := newControllerWithIAMPolicyManager(ctx, cmw, iamtesting.NoopIAMPolicyManager, iamtesting.NewGCPAuthTestStore(t, nil))
 
 	if c == nil {
 		t.Fatal("Expected newControllerWithIAMPolicyManager to return a non-nil value")

--- a/pkg/reconciler/events/storage/storage.go
+++ b/pkg/reconciler/events/storage/storage.go
@@ -86,7 +86,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, storage *v1alpha1.CloudS
 	storage.Status.ObservedGeneration = storage.Generation
 
 	// If GCP ServiceAccount is provided, reconcile workload identity.
-	if storage.Spec.GoogleServiceAccount != "" {
+	if storage.Spec.ServiceAccountName != "" || storage.Spec.GoogleServiceAccount != "" {
 		if _, err := r.Identity.ReconcileWorkloadIdentity(ctx, storage.Spec.Project, storage); err != nil {
 			return reconciler.NewEvent(corev1.EventTypeWarning, workloadIdentityFailed, "Failed to reconcile CloudStorageSource workload identity: %s", err.Error())
 		}
@@ -137,7 +137,6 @@ func (r *Reconciler) reconcileNotification(ctx context.Context, storage *v1alpha
 		logging.FromContext(ctx).Desugar().Error("Failed to fetch attrs of bucket", zap.String("bucketName", storage.Spec.Bucket), zap.Error(err))
 		return "", err
 	}
-
 
 	notifications, err := bucket.Notifications(ctx)
 	if err != nil {
@@ -243,7 +242,7 @@ func (r *Reconciler) deleteNotification(ctx context.Context, storage *v1alpha1.C
 func (r *Reconciler) FinalizeKind(ctx context.Context, storage *v1alpha1.CloudStorageSource) reconciler.Event {
 	// If k8s ServiceAccount exists and it only has one ownerReference, remove the corresponding GCP ServiceAccount iam policy binding.
 	// No need to delete k8s ServiceAccount, it will be automatically handled by k8s Garbage Collection.
-	if storage.Spec.GoogleServiceAccount != "" {
+	if storage.Spec.ServiceAccountName != "" || storage.Spec.GoogleServiceAccount != "" {
 		if err := r.Identity.DeleteWorkloadIdentity(ctx, storage.Spec.Project, storage); err != nil {
 			return reconciler.NewEvent(corev1.EventTypeWarning, deleteWorkloadIdentityFailed, "Failed to delete CloudStorageSource workload identity: %s", err.Error())
 		}

--- a/pkg/reconciler/events/storage/storage_test.go
+++ b/pkg/reconciler/events/storage/storage_test.go
@@ -1227,7 +1227,7 @@ func TestAllCases(t *testing.T) {
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher, testData map[string]interface{}) controller.Reconciler {
 		r := &Reconciler{
 			PubSubBase:     intevents.NewPubSubBase(ctx, controllerAgentName, receiveAdapterName, cmw),
-			Identity:       identity.NewIdentity(ctx, NoopIAMPolicyManager),
+			Identity:       identity.NewIdentity(ctx, NoopIAMPolicyManager, NewGCPAuthTestStore(t, nil)),
 			storageLister:  listers.GetCloudStorageSourceLister(),
 			createClientFn: gstorage.TestClientCreator(testData["storage"]),
 		}

--- a/pkg/reconciler/events/storage/storage_test.go
+++ b/pkg/reconciler/events/storage/storage_test.go
@@ -444,7 +444,7 @@ func TestAllCases(t *testing.T) {
 				WithCloudStorageSourceAnnotations(map[string]string{
 					duckv1alpha1.ClusterNameAnnotation: testingMetadataClient.FakeClusterName,
 				}),
-				WithCloudStorageSourceDefaultAuthorization(),
+				WithCloudStorageSourceDefaultGCPAuth(),
 			),
 			NewTopic(storageName, testNS,
 				WithTopicSpec(inteventsv1alpha1.TopicSpec{
@@ -454,7 +454,7 @@ func TestAllCases(t *testing.T) {
 				WithTopicReady(testTopicID),
 				WithTopicAddress(testTopicURI),
 				WithTopicProjectID(testProject),
-				WithTopicDefaultAuthorization(),
+				WithTopicDefaultGCPAuth(),
 			),
 			newSink(),
 		},
@@ -471,7 +471,7 @@ func TestAllCases(t *testing.T) {
 				WithCloudStorageSourceAnnotations(map[string]string{
 					duckv1alpha1.ClusterNameAnnotation: testingMetadataClient.FakeClusterName,
 				}),
-				WithCloudStorageSourceDefaultAuthorization(),
+				WithCloudStorageSourceDefaultGCPAuth(),
 				WithCloudStorageSourcePullSubscriptionUnknown("PullSubscriptionNotConfigured", failedToReconcilepullSubscriptionMsg),
 			),
 		}},
@@ -1163,7 +1163,7 @@ func TestAllCases(t *testing.T) {
 					WithDeletionTimestamp()),
 			}},
 		},
-			{
+		{
 			Name: "successfully deleted storage",
 			Objects: []runtime.Object{
 				NewCloudStorageSource(storageName, testNS,

--- a/pkg/reconciler/identity/reconciler_test.go
+++ b/pkg/reconciler/identity/reconciler_test.go
@@ -72,7 +72,7 @@ var (
   clusterDefaults: 
     serviceAccountName: test
     workloadIdentityMapping:
-      test: test@test
+      test-fake-cluster-name: test@test
 `,
 	}
 
@@ -158,7 +158,7 @@ func TestKSACreates(t *testing.T) {
 				policyManager: m,
 			}
 			identifiable := NewCloudPubSubSource(identifiableName, testNS)
-			identifiable.Spec.ServiceAccountName = "test"
+			identifiable.Spec.ServiceAccountName = kServiceAccountName
 			identifiable.SetAnnotations(map[string]string{
 				duckv1alpha1.ClusterNameAnnotation: testingMetadataClient.FakeClusterName,
 			})

--- a/pkg/reconciler/identity/resources/service_account.go
+++ b/pkg/reconciler/identity/resources/service_account.go
@@ -18,7 +18,6 @@ package resources
 
 import (
 	"fmt"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,16 +28,16 @@ const (
 )
 
 // GenerateServiceAccountName generates a k8s ServiceAccount name according to GCP ServiceAccount
-func GenerateServiceAccountName(gServiceAccount, clusterName string) string {
-	return fmt.Sprintf("%s-%s", strings.Split(gServiceAccount, "@")[0], clusterName)
+func GenerateServiceAccountName(kServiceAccount, clusterName string) string {
+	return fmt.Sprintf("%s-%s", kServiceAccount, clusterName)
 }
 
 // MakeServiceAccount creates a K8s ServiceAccount object for the Namespace.
-func MakeServiceAccount(namespace string, gServiceAccount, clusterName string) *corev1.ServiceAccount {
+func MakeServiceAccount(namespace string, kServiceAccount, gServiceAccount, clusterName string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      GenerateServiceAccountName(gServiceAccount, clusterName),
+			Name:      GenerateServiceAccountName(kServiceAccount, clusterName),
 			Annotations: map[string]string{
 				WorkloadIdentityKey: gServiceAccount,
 			},

--- a/pkg/reconciler/identity/resources/service_account.go
+++ b/pkg/reconciler/identity/resources/service_account.go
@@ -28,19 +28,26 @@ const (
 	WorkloadIdentityKey = "iam.gke.io/gcp-service-account"
 )
 
+type IdentityNames struct {
+	KServiceAccountName      string
+	GoogleServiceAccountName string
+	Namespace                string
+	ClusterName              string
+}
+
 // GenerateServiceAccountName generates a k8s ServiceAccount name according to GCP ServiceAccount
 func GenerateServiceAccountName(gServiceAccount, clusterName string) string {
 	return fmt.Sprintf("%s-%s", strings.Split(gServiceAccount, "@")[0], clusterName)
 }
 
 // MakeServiceAccount creates a K8s ServiceAccount object for the Namespace.
-func MakeServiceAccount(namespace string, kServiceAccount, gServiceAccount, clusterName string) *corev1.ServiceAccount {
+func MakeServiceAccount(identityNames IdentityNames) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      kServiceAccount,
+			Namespace: identityNames.Namespace,
+			Name:      identityNames.KServiceAccountName,
 			Annotations: map[string]string{
-				WorkloadIdentityKey: gServiceAccount,
+				WorkloadIdentityKey: identityNames.GoogleServiceAccountName,
 			},
 		},
 	}

--- a/pkg/reconciler/identity/resources/service_account.go
+++ b/pkg/reconciler/identity/resources/service_account.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,8 +29,8 @@ const (
 )
 
 // GenerateServiceAccountName generates a k8s ServiceAccount name according to GCP ServiceAccount
-func GenerateServiceAccountName(kServiceAccount, clusterName string) string {
-	return fmt.Sprintf("%s-%s", kServiceAccount, clusterName)
+func GenerateServiceAccountName(gServiceAccount, clusterName string) string {
+	return fmt.Sprintf("%s-%s", strings.Split(gServiceAccount, "@")[0], clusterName)
 }
 
 // MakeServiceAccount creates a K8s ServiceAccount object for the Namespace.
@@ -37,7 +38,7 @@ func MakeServiceAccount(namespace string, kServiceAccount, gServiceAccount, clus
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      GenerateServiceAccountName(kServiceAccount, clusterName),
+			Name:      kServiceAccount,
 			Annotations: map[string]string{
 				WorkloadIdentityKey: gServiceAccount,
 			},

--- a/pkg/reconciler/identity/resources/service_account_test.go
+++ b/pkg/reconciler/identity/resources/service_account_test.go
@@ -49,7 +49,11 @@ func TestMakeServiceAccount(t *testing.T) {
 			},
 		},
 	}
-	got := MakeServiceAccount("default", kServiceAccountName, gServiceAccountName, clusterName)
+	got := MakeServiceAccount(IdentityNames{
+		KServiceAccountName:      kServiceAccountName,
+		GoogleServiceAccountName: gServiceAccountName,
+		Namespace:                "default",
+		ClusterName:              clusterName})
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unexpected (-want, +got) = %v", diff)
 	}

--- a/pkg/reconciler/identity/resources/service_account_test.go
+++ b/pkg/reconciler/identity/resources/service_account_test.go
@@ -32,7 +32,7 @@ var (
 
 func TestGenerateServiceAccountName(t *testing.T) {
 	want := kServiceAccountName
-	got := GenerateServiceAccountName(gServiceAccountName, clusterName)
+	got := GenerateServiceAccountName("test", clusterName)
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unexpected (-want, +got) = %v", diff)
@@ -49,7 +49,7 @@ func TestMakeServiceAccount(t *testing.T) {
 			},
 		},
 	}
-	got := MakeServiceAccount("default", gServiceAccountName, clusterName)
+	got := MakeServiceAccount("default", "test", gServiceAccountName, clusterName)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unexpected (-want, +got) = %v", diff)
 	}

--- a/pkg/reconciler/identity/resources/service_account_test.go
+++ b/pkg/reconciler/identity/resources/service_account_test.go
@@ -32,7 +32,7 @@ var (
 
 func TestGenerateServiceAccountName(t *testing.T) {
 	want := kServiceAccountName
-	got := GenerateServiceAccountName("test", clusterName)
+	got := GenerateServiceAccountName(gServiceAccountName, clusterName)
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unexpected (-want, +got) = %v", diff)
@@ -49,7 +49,7 @@ func TestMakeServiceAccount(t *testing.T) {
 			},
 		},
 	}
-	got := MakeServiceAccount("default", "test", gServiceAccountName, clusterName)
+	got := MakeServiceAccount("default", kServiceAccountName, gServiceAccountName, clusterName)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unexpected (-want, +got) = %v", diff)
 	}

--- a/pkg/reconciler/identity/testdata/config-gcp-auth-empty.yaml
+++ b/pkg/reconciler/identity/testdata/config-gcp-auth-empty.yaml
@@ -1,0 +1,90 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-gcp-auth
+  namespace: cloud-run-events
+  labels:
+    events.cloud.google.com/release: devel
+
+data:
+  default-auth-config: |
+    clusterDefaults:
+      serviceAccountName: empty
+      workloadIdentityMapping:
+        empty: empty@empty
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # default-auth-config is the configuration for determining the default
+    # GCP auth to apply to all objects that require GCP auth but,
+    # do not specify it. This is expected to be Channels and Sources.
+    #
+    # When determing the defaults to use for a custom object in a specific
+    # namespace, the precedence rules are:
+    # If the custom object's spec specifies the GCP auth to use, use that.
+    # If not and that namespace is in the `namespaceDefaults` key, then use the
+    # defaults specified there. If not, then use the defaults specified in
+    # `clusterDefaults`.
+    default-auth-config: |
+      # clusterDefaults are the defaults to apply to every namespace in the
+      # cluster, except those in the `namespaceDefaults` sibling key.
+      clusterDefaults:
+        # The Kubernetes Service Account to use for all data plane pieces. This
+        # is expected to be used for Workload Identity workloads. If omitted or
+        # left blank, then Kubernetes will choose the default Service Account.
+        serviceAccountName: cluster-default-ksa
+        # The Kubernetes SecretKeySelector pointing to the Secret to use. Note
+        # that this secret must exist in the namespace of the custom object
+        # being created.
+        secret:
+          name: google-cloud-key
+          key: key.json
+        # Mapping from Kubernetes Service Account to Google IAM Service Account.
+        # If a custom object's Kubernetes Service Account is in this map, then
+        # the controller will attempt to setup Workload Identity between the
+        # two accounts. If the controller is unable to, then the custom object
+        # will not become ready.
+        workloadIdentityMapping:
+          cluster-wi-ksa1: ns-wi-gsa1@PROJECT.iam.gserviceaccount.com
+          cluster-wi-ksa2: cluster-wi-gsa2@PROJECT.iam.gserviceaccount.com
+      # namespaceDefaults is a map from namespace name to default configuration.
+      # The default configuration is exactly the same as the one defined in
+      # the `clusterDefaults` sibling key.
+      namespaceDefaults:
+        # It is acceptable to turn off defaulting for any namespace.
+        empty-ns: {}
+        customized-ns:
+          serviceAccountName: ns-default-ksa
+          secret:
+            name: some-other-name
+            key: some-other-key
+          workloadIdentityMapping:
+            ns-wi-ksa1: ns-wi-gsa1@PROJECT.iam.gserviceaccount.com
+            ns-wi-ksa2: ns-wi-gsa2@PROJECT.iam.gserviceaccount.com

--- a/pkg/reconciler/identity/testdata/config-gcp-auth.yaml
+++ b/pkg/reconciler/identity/testdata/config-gcp-auth.yaml
@@ -1,0 +1,90 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-gcp-auth
+  namespace: cloud-run-events
+  labels:
+    events.cloud.google.com/release: devel
+
+data:
+  default-auth-config: |
+    clusterDefaults:
+      serviceAccountName: test-fake-cluster-name
+      workloadIdentityMapping:
+        test-fake-cluster-name: test@test
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # default-auth-config is the configuration for determining the default
+    # GCP auth to apply to all objects that require GCP auth but,
+    # do not specify it. This is expected to be Channels and Sources.
+    #
+    # When determing the defaults to use for a custom object in a specific
+    # namespace, the precedence rules are:
+    # If the custom object's spec specifies the GCP auth to use, use that.
+    # If not and that namespace is in the `namespaceDefaults` key, then use the
+    # defaults specified there. If not, then use the defaults specified in
+    # `clusterDefaults`.
+    default-auth-config: |
+      # clusterDefaults are the defaults to apply to every namespace in the
+      # cluster, except those in the `namespaceDefaults` sibling key.
+      clusterDefaults:
+        # The Kubernetes Service Account to use for all data plane pieces. This
+        # is expected to be used for Workload Identity workloads. If omitted or
+        # left blank, then Kubernetes will choose the default Service Account.
+        serviceAccountName: cluster-default-ksa
+        # The Kubernetes SecretKeySelector pointing to the Secret to use. Note
+        # that this secret must exist in the namespace of the custom object
+        # being created.
+        secret:
+          name: google-cloud-key
+          key: key.json
+        # Mapping from Kubernetes Service Account to Google IAM Service Account.
+        # If a custom object's Kubernetes Service Account is in this map, then
+        # the controller will attempt to setup Workload Identity between the
+        # two accounts. If the controller is unable to, then the custom object
+        # will not become ready.
+        workloadIdentityMapping:
+          cluster-wi-ksa1: ns-wi-gsa1@PROJECT.iam.gserviceaccount.com
+          cluster-wi-ksa2: cluster-wi-gsa2@PROJECT.iam.gserviceaccount.com
+      # namespaceDefaults is a map from namespace name to default configuration.
+      # The default configuration is exactly the same as the one defined in
+      # the `clusterDefaults` sibling key.
+      namespaceDefaults:
+        # It is acceptable to turn off defaulting for any namespace.
+        empty-ns: {}
+        customized-ns:
+          serviceAccountName: ns-default-ksa
+          secret:
+            name: some-other-name
+            key: some-other-key
+          workloadIdentityMapping:
+            ns-wi-ksa1: ns-wi-gsa1@PROJECT.iam.gserviceaccount.com
+            ns-wi-ksa2: ns-wi-gsa2@PROJECT.iam.gserviceaccount.com

--- a/pkg/reconciler/intevents/pullsubscription/keda/controller_test.go
+++ b/pkg/reconciler/intevents/pullsubscription/keda/controller_test.go
@@ -49,8 +49,7 @@ func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
 	_ = os.Setenv("PUBSUB_RA_IMAGE", "PUBSUB_RA_IMAGE")
-
-	c := newControllerWithIAMPolicyManager(ctx, configmap.NewStaticWatcher(
+	cmw := configmap.NewStaticWatcher(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      logging.ConfigMapName(),
@@ -72,8 +71,8 @@ func TestNew(t *testing.T) {
 			},
 			Data: map[string]string{},
 		},
-	),
-		iamtesting.NoopIAMPolicyManager)
+	)
+	c := newControllerWithIAMPolicyManager(ctx, cmw, iamtesting.NoopIAMPolicyManager, iamtesting.NewGCPAuthTestStore(t, nil))
 
 	if c == nil {
 		t.Fatal("Expected newControllerWithIAMPolicyManager to return a non-nil value")

--- a/pkg/reconciler/intevents/pullsubscription/reconciler.go
+++ b/pkg/reconciler/intevents/pullsubscription/reconciler.go
@@ -105,7 +105,7 @@ func (r *Base) ReconcileKind(ctx context.Context, ps *v1alpha1.PullSubscription)
 
 	// If pullsubscription doesn't have ownerReference and GCP ServiceAccount is provided, reconcile workload identity.
 	// Otherwise, its owner will reconcile workload identity.
-	if (ps.OwnerReferences == nil || len(ps.OwnerReferences) == 0) && ps.Spec.GoogleServiceAccount != "" {
+	if (ps.OwnerReferences == nil || len(ps.OwnerReferences) == 0) && (ps.Spec.ServiceAccountName != "" || ps.Spec.GoogleServiceAccount != "") {
 		if _, err := r.Identity.ReconcileWorkloadIdentity(ctx, ps.Spec.Project, ps); err != nil {
 			return reconciler.NewEvent(corev1.EventTypeWarning, workloadIdentityFailed, "Failed to reconcile Pub/Sub subscription workload identity: %s", err.Error())
 		}
@@ -404,7 +404,7 @@ func (r *Base) resolveDestination(ctx context.Context, destination duckv1.Destin
 func (r *Base) FinalizeKind(ctx context.Context, ps *v1alpha1.PullSubscription) reconciler.Event {
 	// If pullsubscription doesn't have ownerReference, k8s ServiceAccount exists and it only has one ownerReference, remove the corresponding GCP ServiceAccount iam policy binding.
 	// No need to delete k8s ServiceAccount, it will be automatically handled by k8s Garbage Collection.
-	if (ps.OwnerReferences == nil || len(ps.OwnerReferences) == 0) && ps.Spec.GoogleServiceAccount != "" {
+	if (ps.OwnerReferences == nil || len(ps.OwnerReferences) == 0) && (ps.Spec.ServiceAccountName != "" || ps.Spec.GoogleServiceAccount != "") {
 		if err := r.Identity.DeleteWorkloadIdentity(ctx, ps.Spec.Project, ps); err != nil {
 			return reconciler.NewEvent(corev1.EventTypeWarning, deleteWorkloadIdentityFailed, "Failed to delete delete Pub/Sub subscription workload identity: %s", err.Error())
 		}

--- a/pkg/reconciler/intevents/pullsubscription/resources/receive_adapter.go
+++ b/pkg/reconciler/intevents/pullsubscription/resources/receive_adapter.go
@@ -19,7 +19,6 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"go.uber.org/zap"
 
@@ -154,9 +153,7 @@ func makeReceiveAdapterPodSpec(ctx context.Context, args *ReceiveAdapterArgs) *c
 
 	// If GCP service account is specified, use that service account as credential.
 	if args.Source.Spec.GoogleServiceAccount != "" {
-		ksa := strings.Split(args.Source.Spec.GoogleServiceAccount, "@")[0]
-		kServiceAccountName := resources.GenerateServiceAccountName(ksa,
-			args.Source.Annotations[duckv1alpha1.ClusterNameAnnotation])
+		kServiceAccountName := resources.GenerateServiceAccountName(args.Source.Spec.GoogleServiceAccount, args.Source.Annotations[duckv1alpha1.ClusterNameAnnotation])
 		return &corev1.PodSpec{
 			ServiceAccountName: kServiceAccountName,
 			Containers: []corev1.Container{
@@ -167,10 +164,8 @@ func makeReceiveAdapterPodSpec(ctx context.Context, args *ReceiveAdapterArgs) *c
 
 	// If there is no secret to embed, return what we have.
 	if args.Source.Spec.Secret == nil {
-		kServiceAccountName := resources.GenerateServiceAccountName(args.Source.Spec.ServiceAccountName,
-			args.Source.Annotations[duckv1alpha1.ClusterNameAnnotation])
 		return &corev1.PodSpec{
-			ServiceAccountName: kServiceAccountName,
+			ServiceAccountName: args.Source.Spec.ServiceAccountName,
 			Containers: []corev1.Container{
 				receiveAdapterContainer,
 			},

--- a/pkg/reconciler/intevents/pullsubscription/static/controller.go
+++ b/pkg/reconciler/intevents/pullsubscription/static/controller.go
@@ -19,6 +19,7 @@ package static
 import (
 	"context"
 
+	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
 	duckv1alpha1 "github.com/google/knative-gcp/pkg/apis/duck/v1alpha1"
 	"github.com/google/knative-gcp/pkg/apis/intevents/v1alpha1"
 	pullsubscriptioninformers "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1alpha1/pullsubscription"
@@ -69,13 +70,15 @@ func NewController(
 	return newControllerWithIAMPolicyManager(
 		ctx,
 		cmw,
-		iam.DefaultIAMPolicyManager())
+		iam.DefaultIAMPolicyManager(),
+		identity.NewGCPAuthStore(ctx, cmw))
 }
 
 func newControllerWithIAMPolicyManager(
 	ctx context.Context,
 	cmw configmap.Watcher,
 	ipm iam.IAMPolicyManager,
+	gcpas *gcpauth.Store,
 ) *controller.Impl {
 	deploymentInformer := deploymentinformer.Get(ctx)
 	pullSubscriptionInformer := pullsubscriptioninformers.Get(ctx)
@@ -95,7 +98,7 @@ func newControllerWithIAMPolicyManager(
 	r := &Reconciler{
 		Base: &psreconciler.Base{
 			PubSubBase:             pubsubBase,
-			Identity:               identity.NewIdentity(ctx, ipm),
+			Identity:               identity.NewIdentity(ctx, ipm, gcpas),
 			DeploymentLister:       deploymentInformer.Lister(),
 			PullSubscriptionLister: pullSubscriptionInformer.Lister(),
 			ReceiveAdapterImage:    env.ReceiveAdapter,

--- a/pkg/reconciler/intevents/pullsubscription/static/controller_test.go
+++ b/pkg/reconciler/intevents/pullsubscription/static/controller_test.go
@@ -20,7 +20,12 @@ import (
 	"os"
 	"testing"
 
-	iamtesting "github.com/google/knative-gcp/pkg/reconciler/testing"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/batch/v1/job/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/logging"
 	logtesting "knative.dev/pkg/logging/testing"
@@ -30,13 +35,7 @@ import (
 	"knative.dev/pkg/system"
 	tracingconfig "knative.dev/pkg/tracing/config"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
-	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
-	_ "knative.dev/pkg/client/injection/kube/informers/batch/v1/job/fake"
-	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
+	iamtesting "github.com/google/knative-gcp/pkg/reconciler/testing"
 
 	// Fake injection informers
 	_ "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1alpha1/pullsubscription/fake"
@@ -48,7 +47,7 @@ func TestNew(t *testing.T) {
 
 	_ = os.Setenv("PUBSUB_RA_IMAGE", "PUBSUB_RA_IMAGE")
 
-	c := newControllerWithIAMPolicyManager(ctx, configmap.NewStaticWatcher(
+	cmw := configmap.NewStaticWatcher(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      logging.ConfigMapName(),
@@ -70,8 +69,8 @@ func TestNew(t *testing.T) {
 			},
 			Data: map[string]string{},
 		},
-	),
-		iamtesting.NoopIAMPolicyManager)
+	)
+	c := newControllerWithIAMPolicyManager(ctx, cmw, iamtesting.NoopIAMPolicyManager, iamtesting.NewGCPAuthTestStore(t, nil))
 
 	if c == nil {
 		t.Fatal("Expected newControllerWithIAMPolicyManager to return a non-nil value")

--- a/pkg/reconciler/intevents/reconciler_test.go
+++ b/pkg/reconciler/intevents/reconciler_test.go
@@ -87,7 +87,7 @@ var (
 
 	pubsubable = rectesting.NewCloudStorageSource(name, testNS,
 		rectesting.WithCloudStorageSourceSinkDestination(sink),
-		rectesting.WithCloudStorageSourceDefaultAuthorization())
+		rectesting.WithCloudStorageSourceDefaultGCPAuth())
 
 	ignoreLastTransitionTime = cmp.FilterPath(func(p cmp.Path) bool {
 		return strings.HasSuffix(p.String(), "LastTransitionTime.Inner.Time")

--- a/pkg/reconciler/intevents/topic/controller_test.go
+++ b/pkg/reconciler/intevents/topic/controller_test.go
@@ -44,18 +44,15 @@ func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
 	_ = os.Setenv("PUBSUB_PUBLISHER_IMAGE", "PUBSUB_PUBLISHER_IMAGE")
-
-	c := newControllerWithIAMPolicyManager(
-		ctx,
-		configmap.NewStaticWatcher(
-			&corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      tracingconfig.ConfigName,
-					Namespace: system.Namespace(),
-				},
-				Data: map[string]string{},
-			}),
-		iamtesting.NoopIAMPolicyManager)
+	cmw := configmap.NewStaticWatcher(
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      tracingconfig.ConfigName,
+				Namespace: system.Namespace(),
+			},
+			Data: map[string]string{},
+		})
+	c := newControllerWithIAMPolicyManager(ctx, cmw, iamtesting.NoopIAMPolicyManager, iamtesting.NewGCPAuthTestStore(t, nil))
 
 	if c == nil {
 		t.Fatal("Expected newControllerWithIAMPolicyManager to return a non-nil value")

--- a/pkg/reconciler/intevents/topic/resources/publisher.go
+++ b/pkg/reconciler/intevents/topic/resources/publisher.go
@@ -18,7 +18,6 @@ package resources
 
 import (
 	"fmt"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,9 +72,7 @@ func makePublisherPodSpec(args *PublisherArgs) *corev1.PodSpec {
 
 	// If GCP service account is specified, use that service account as credential.
 	if args.Topic.Spec.GoogleServiceAccount != "" {
-		ksa := strings.Split(args.Topic.Spec.GoogleServiceAccount, "@")[0]
-		kServiceAccountName := resources.GenerateServiceAccountName(ksa,
-			args.Topic.Annotations[duckv1alpha1.ClusterNameAnnotation])
+		kServiceAccountName := resources.GenerateServiceAccountName(args.Topic.Spec.GoogleServiceAccount, args.Topic.Annotations[duckv1alpha1.ClusterNameAnnotation])
 		return &corev1.PodSpec{
 			ServiceAccountName: kServiceAccountName,
 			Containers: []corev1.Container{
@@ -86,10 +83,8 @@ func makePublisherPodSpec(args *PublisherArgs) *corev1.PodSpec {
 
 	// If k8s service account is specified, use that service account as credential.
 	if args.Topic.Spec.ServiceAccountName != "" {
-		kServiceAccountName := resources.GenerateServiceAccountName(args.Topic.Spec.ServiceAccountName,
-			args.Topic.Annotations[duckv1alpha1.ClusterNameAnnotation])
 		return &corev1.PodSpec{
-			ServiceAccountName: kServiceAccountName,
+			ServiceAccountName: args.Topic.Spec.ServiceAccountName,
 			Containers: []corev1.Container{
 				publisherContainer,
 			},

--- a/pkg/reconciler/intevents/topic/resources/publisher.go
+++ b/pkg/reconciler/intevents/topic/resources/publisher.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,7 +73,9 @@ func makePublisherPodSpec(args *PublisherArgs) *corev1.PodSpec {
 
 	// If GCP service account is specified, use that service account as credential.
 	if args.Topic.Spec.GoogleServiceAccount != "" {
-		kServiceAccountName := resources.GenerateServiceAccountName(args.Topic.Spec.GoogleServiceAccount, args.Topic.Annotations[duckv1alpha1.ClusterNameAnnotation])
+		ksa := strings.Split(args.Topic.Spec.GoogleServiceAccount, "@")[0]
+		kServiceAccountName := resources.GenerateServiceAccountName(ksa,
+			args.Topic.Annotations[duckv1alpha1.ClusterNameAnnotation])
 		return &corev1.PodSpec{
 			ServiceAccountName: kServiceAccountName,
 			Containers: []corev1.Container{
@@ -83,7 +86,8 @@ func makePublisherPodSpec(args *PublisherArgs) *corev1.PodSpec {
 
 	// If k8s service account is specified, use that service account as credential.
 	if args.Topic.Spec.ServiceAccountName != "" {
-		kServiceAccountName := args.Topic.Spec.ServiceAccountName
+		kServiceAccountName := resources.GenerateServiceAccountName(args.Topic.Spec.ServiceAccountName,
+			args.Topic.Annotations[duckv1alpha1.ClusterNameAnnotation])
 		return &corev1.PodSpec{
 			ServiceAccountName: kServiceAccountName,
 			Containers: []corev1.Container{

--- a/pkg/reconciler/intevents/topic/topic.go
+++ b/pkg/reconciler/intevents/topic/topic.go
@@ -93,7 +93,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, topic *v1alpha1.Topic) r
 
 	// If topic doesn't have ownerReference and GCP ServiceAccount is provided, reconcile workload identity.
 	// Otherwise, its owner will reconcile workload identity.
-	if (topic.OwnerReferences == nil || len(topic.OwnerReferences) == 0) && topic.Spec.GoogleServiceAccount != "" {
+	if (topic.OwnerReferences == nil || len(topic.OwnerReferences) == 0) && (topic.Spec.ServiceAccountName != "" || topic.Spec.GoogleServiceAccount != "") {
 		if _, err := r.Identity.ReconcileWorkloadIdentity(ctx, topic.Spec.Project, topic); err != nil {
 			return reconciler.NewEvent(corev1.EventTypeWarning, workloadIdentityFailed, "Failed to reconcile Pub/Sub topic workload identity: %s", err.Error())
 		}
@@ -272,7 +272,7 @@ func (r *Reconciler) UpdateFromTracingConfigMap(cfg *corev1.ConfigMap) {
 func (r *Reconciler) FinalizeKind(ctx context.Context, topic *v1alpha1.Topic) reconciler.Event {
 	// If topic doesn't have ownerReference, k8s ServiceAccount exists and it only has one ownerReference, remove the corresponding GCP ServiceAccount iam policy binding.
 	// No need to delete k8s ServiceAccount, it will be automatically handled by k8s Garbage Collection.
-	if (topic.OwnerReferences == nil || len(topic.OwnerReferences) == 0) && topic.Spec.GoogleServiceAccount != "" {
+	if (topic.OwnerReferences == nil || len(topic.OwnerReferences) == 0) && (topic.Spec.ServiceAccountName != "" || topic.Spec.GoogleServiceAccount != "") {
 		if err := r.Identity.DeleteWorkloadIdentity(ctx, topic.Spec.Project, topic); err != nil {
 			return reconciler.NewEvent(corev1.EventTypeWarning, deleteWorkloadIdentityFailed, "Failed to delete delete Pub/Sub topic workload identity: %s", err.Error())
 		}

--- a/pkg/reconciler/messaging/channel/channel.go
+++ b/pkg/reconciler/messaging/channel/channel.go
@@ -74,7 +74,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, channel *v1alpha1.Channe
 	channel.Status.ObservedGeneration = channel.Generation
 
 	// If GCP ServiceAccount is provided, reconcile workload identity.
-	if channel.Spec.GoogleServiceAccount != "" {
+	if channel.Spec.ServiceAccountName != "" || channel.Spec.GoogleServiceAccount != "" {
 		if _, err := r.Identity.ReconcileWorkloadIdentity(ctx, channel.Spec.Project, channel); err != nil {
 			return pkgreconciler.NewEvent(corev1.EventTypeWarning, workloadIdentityFailed, "Failed to reconcile Channel workload identity: %s", err.Error())
 		}
@@ -381,7 +381,7 @@ func (r *Reconciler) getPullSubscriptionStatus(ps *inteventsv1alpha1.PullSubscri
 func (r *Reconciler) FinalizeKind(ctx context.Context, channel *v1alpha1.Channel) pkgreconciler.Event {
 	// If k8s ServiceAccount exists and it only has one ownerReference, remove the corresponding GCP ServiceAccount iam policy binding.
 	// No need to delete k8s ServiceAccount, it will be automatically handled by k8s Garbage Collection.
-	if channel.Spec.GoogleServiceAccount != "" {
+	if channel.Spec.ServiceAccountName != "" || channel.Spec.GoogleServiceAccount != "" {
 		if err := r.Identity.DeleteWorkloadIdentity(ctx, channel.Spec.Project, channel); err != nil {
 			return pkgreconciler.NewEvent(corev1.EventTypeWarning, deleteWorkloadIdentityFailed, "Failed to delete Channel workload identity: %s", err.Error())
 		}

--- a/pkg/reconciler/messaging/channel/channel_test.go
+++ b/pkg/reconciler/messaging/channel/channel_test.go
@@ -548,7 +548,7 @@ func TestAllCases(t *testing.T) {
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher, _ map[string]interface{}) controller.Reconciler {
 		r := &Reconciler{
 			Base:          reconciler.NewBase(ctx, controllerAgentName, cmw),
-			Identity:      identity.NewIdentity(ctx, NoopIAMPolicyManager),
+			Identity:      identity.NewIdentity(ctx, NoopIAMPolicyManager, NewGCPAuthTestStore(t, nil)),
 			channelLister: listers.GetChannelLister(),
 			topicLister:   listers.GetTopicLister(),
 		}

--- a/pkg/reconciler/messaging/channel/controller.go
+++ b/pkg/reconciler/messaging/channel/controller.go
@@ -23,6 +23,7 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 
+	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
 	"github.com/google/knative-gcp/pkg/apis/messaging/v1alpha1"
 	pullsubscriptioninformer "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1alpha1/pullsubscription"
 	topicinformer "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1alpha1/topic"
@@ -52,13 +53,15 @@ func NewController(
 	return newControllerWithIAMPolicyManager(
 		ctx,
 		cmw,
-		iam.DefaultIAMPolicyManager())
+		iam.DefaultIAMPolicyManager(),
+		identity.NewGCPAuthStore(ctx, cmw))
 }
 
 func newControllerWithIAMPolicyManager(
 	ctx context.Context,
 	cmw configmap.Watcher,
 	ipm iam.IAMPolicyManager,
+	gcpas *gcpauth.Store,
 ) *controller.Impl {
 	channelInformer := channelinformer.Get(ctx)
 
@@ -68,7 +71,7 @@ func newControllerWithIAMPolicyManager(
 
 	r := &Reconciler{
 		Base:          reconciler.NewBase(ctx, controllerAgentName, cmw),
-		Identity:      identity.NewIdentity(ctx, ipm),
+		Identity:      identity.NewIdentity(ctx, ipm, gcpas),
 		channelLister: channelInformer.Lister(),
 		topicLister:   topicInformer.Lister(),
 	}

--- a/pkg/reconciler/messaging/channel/controller_test.go
+++ b/pkg/reconciler/messaging/channel/controller_test.go
@@ -35,8 +35,8 @@ import (
 func TestNew(t *testing.T) {
 	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
-
-	c := newControllerWithIAMPolicyManager(ctx, configmap.NewStaticWatcher(), iamtesting.NoopIAMPolicyManager)
+	cmw := configmap.NewStaticWatcher()
+	c := newControllerWithIAMPolicyManager(ctx, cmw, iamtesting.NoopIAMPolicyManager, iamtesting.NewGCPAuthTestStore(t, nil))
 
 	if c == nil {
 		t.Fatal("Expected newControllerWithIAMPolicyManager to return a non-nil value")

--- a/pkg/reconciler/testing/auditlogs.go
+++ b/pkg/reconciler/testing/auditlogs.go
@@ -194,7 +194,7 @@ func WithCloudAuditLogsSourceAnnotations(Annotations map[string]string) CloudAud
 	}
 }
 
-func WithCloudAuditLogsSourceDefaultAuthorization() CloudAuditLogsSourceOption {
+func WithCloudAuditLogsSourceDefaultGCPAuth() CloudAuditLogsSourceOption {
 	return func(s *v1alpha1.CloudAuditLogsSource) {
 		s.Spec.PubSubSpec.SetPubSubDefaults(gcpauthtesthelper.ContextWithDefaults())
 	}

--- a/pkg/reconciler/testing/build.go
+++ b/pkg/reconciler/testing/build.go
@@ -165,7 +165,7 @@ func WithCloudBuildSourceAnnotations(Annotations map[string]string) CloudBuildSo
 	}
 }
 
-func WithCloudBuildSourceDefaultAuthorization() CloudBuildSourceOption {
+func WithCloudBuildSourceDefaultGCPAuth() CloudBuildSourceOption {
 	return func(s *v1alpha1.CloudBuildSource) {
 		s.Spec.PubSubSpec.SetPubSubDefaults(gcpauthtesthelper.ContextWithDefaults())
 	}

--- a/pkg/reconciler/testing/pubsub.go
+++ b/pkg/reconciler/testing/pubsub.go
@@ -163,7 +163,7 @@ func WithCloudPubSubSourceAnnotations(Annotations map[string]string) CloudPubSub
 	}
 }
 
-func WithCloudPubSubSourceDefaultAuthorization() CloudPubSubSourceOption {
+func WithCloudPubSubSourceDefaultGCPAuth() CloudPubSubSourceOption {
 	return func(s *v1alpha1.CloudPubSubSource) {
 		s.Spec.PubSubSpec.SetPubSubDefaults(gcpauthtesthelper.ContextWithDefaults())
 	}

--- a/pkg/reconciler/testing/pullsubscription.go
+++ b/pkg/reconciler/testing/pullsubscription.go
@@ -286,7 +286,7 @@ func WithPullSubscriptionMode(mode v1alpha1.ModeType) PullSubscriptionOption {
 	}
 }
 
-func WithPullSubscriptionDefaultAuthorization() PullSubscriptionOption {
+func WithPullSubscriptionDefaultGCPAuth() PullSubscriptionOption {
 	return func(s *v1alpha1.PullSubscription) {
 		s.Spec.PubSubSpec.SetPubSubDefaults(gcpauthtesthelper.ContextWithDefaults())
 	}

--- a/pkg/reconciler/testing/scheduler.go
+++ b/pkg/reconciler/testing/scheduler.go
@@ -212,7 +212,7 @@ func WithCloudSchedulerSourceAnnotations(Annotations map[string]string) CloudSch
 	}
 }
 
-func WithCloudSchedulerSourceDefaultAuthorization() CloudSchedulerSourceOption {
+func WithCloudSchedulerSourceDefaultGCPAuth() CloudSchedulerSourceOption {
 	return func(s *v1alpha1.CloudSchedulerSource) {
 		s.Spec.PubSubSpec.SetPubSubDefaults(gcpauthtesthelper.ContextWithDefaults())
 	}

--- a/pkg/reconciler/testing/storage.go
+++ b/pkg/reconciler/testing/storage.go
@@ -237,7 +237,7 @@ func WithCloudStorageSourceAnnotations(Annotations map[string]string) CloudStora
 	}
 }
 
-func WithCloudStorageSourceDefaultAuthorization() CloudStorageSourceOption {
+func WithCloudStorageSourceDefaultGCPAuth() CloudStorageSourceOption {
 	return func(s *v1alpha1.CloudStorageSource) {
 		s.Spec.PubSubSpec.SetPubSubDefaults(gcpauthtesthelper.ContextWithDefaults())
 	}

--- a/pkg/reconciler/testing/store.go
+++ b/pkg/reconciler/testing/store.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 Google LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	logtesting "knative.dev/pkg/logging/testing"
+
+	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
+)
+
+func NewGCPAuthTestStore(t *testing.T, config *corev1.ConfigMap) *gcpauth.Store {
+	gcpAuthTestStore := gcpauth.NewStore(logtesting.TestLogger(t))
+	if config != nil {
+		gcpAuthTestStore.OnConfigChanged(config)
+	}
+	return gcpAuthTestStore
+}

--- a/pkg/reconciler/testing/topic.go
+++ b/pkg/reconciler/testing/topic.go
@@ -188,7 +188,7 @@ func WithTopicAnnotations(annotations map[string]string) TopicOption {
 	}
 }
 
-func WithTopicDefaultAuthorization() TopicOption {
+func WithTopicDefaultGCPAuth() TopicOption {
 	return func(t *v1alpha1.Topic) {
 		t.Spec.SetDefaults(gcpauthtesthelper.ContextWithDefaults())
 	}


### PR DESCRIPTION
Fixes #1182

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use config-gcp-auth for WI manipulation of GSAs
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
