### PR TITLE
Provide the default GCP auth during the creation of the PullSubscription for E2E

### DIFF
--- a/pkg/apis/events/v1alpha1/cloudpubsubsource_defaults_test.go
+++ b/pkg/apis/events/v1alpha1/cloudpubsubsource_defaults_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -145,7 +144,7 @@ func TestCloudPubSubSourceDefaults_NoChange(t *testing.T) {
 	}
 
 	got := want.DeepCopy()
-	got.SetDefaults(context.Background())
+	got.SetDefaults(gcpauthtesthelper.ContextWithDefaults())
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)
 	}

--- a/pkg/apis/intevents/v1alpha1/pullsubscription_defaults_test.go
+++ b/pkg/apis/intevents/v1alpha1/pullsubscription_defaults_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -228,7 +227,7 @@ func TestPullSubscriptionDefaults_NoChange(t *testing.T) {
 	}
 
 	got := want.DeepCopy()
-	got.SetDefaults(context.Background())
+	got.SetDefaults(gcpauthtesthelper.ContextWithDefaults())
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)
 	}

--- a/pkg/reconciler/testing/auditlogs.go
+++ b/pkg/reconciler/testing/auditlogs.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testing
 
 import (
-	"context"
 	"time"
 
 	gcpauthtesthelper "github.com/google/knative-gcp/pkg/apis/configs/gcpauth/testhelper"
@@ -41,7 +40,7 @@ func NewCloudAuditLogsSource(name, namespace string, opts ...CloudAuditLogsSourc
 	for _, opt := range opts {
 		opt(cal)
 	}
-	cal.SetDefaults(context.Background())
+	cal.SetDefaults(gcpauthtesthelper.ContextWithDefaults())
 	return cal
 }
 

--- a/pkg/reconciler/testing/build.go
+++ b/pkg/reconciler/testing/build.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testing
 
 import (
-	"context"
 	"time"
 
 	gcpauthtesthelper "github.com/google/knative-gcp/pkg/apis/configs/gcpauth/testhelper"
@@ -47,7 +46,7 @@ func NewCloudBuildSource(name, namespace string, so ...CloudBuildSourceOption) *
 	for _, opt := range so {
 		opt(bs)
 	}
-	bs.SetDefaults(context.Background())
+	bs.SetDefaults(gcpauthtesthelper.ContextWithDefaults())
 	return bs
 }
 

--- a/pkg/reconciler/testing/pubsub.go
+++ b/pkg/reconciler/testing/pubsub.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testing
 
 import (
-	"context"
 	"time"
 
 	gcpauthtesthelper "github.com/google/knative-gcp/pkg/apis/configs/gcpauth/testhelper"
@@ -45,7 +44,7 @@ func NewCloudPubSubSource(name, namespace string, so ...CloudPubSubSourceOption)
 	for _, opt := range so {
 		opt(ps)
 	}
-	ps.SetDefaults(context.Background())
+	ps.SetDefaults(gcpauthtesthelper.ContextWithDefaults())
 	return ps
 }
 

--- a/pkg/reconciler/testing/pullsubscription.go
+++ b/pkg/reconciler/testing/pullsubscription.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testing
 
 import (
-	"context"
 	"time"
 
 	gcpauthtesthelper "github.com/google/knative-gcp/pkg/apis/configs/gcpauth/testhelper"
@@ -50,7 +49,7 @@ func NewPullSubscription(name, namespace string, so ...PullSubscriptionOption) *
 	for _, opt := range so {
 		opt(s)
 	}
-	s.SetDefaults(context.Background())
+	s.SetDefaults(gcpauthtesthelper.ContextWithDefaults())
 	return s
 }
 
@@ -79,7 +78,7 @@ func NewPullSubscriptionWithoutNamespace(name string, so ...PullSubscriptionOpti
 	for _, opt := range so {
 		opt(s)
 	}
-	s.SetDefaults(context.Background())
+	s.SetDefaults(gcpauthtesthelper.ContextWithDefaults())
 	return s
 }
 
@@ -179,7 +178,7 @@ func WithPullSubscriptionMarkDeployed(ps *v1alpha1.PullSubscription) {
 func WithPullSubscriptionSpec(spec v1alpha1.PullSubscriptionSpec) PullSubscriptionOption {
 	return func(s *v1alpha1.PullSubscription) {
 		s.Spec = spec
-		s.Spec.SetDefaults(context.Background())
+		s.Spec.SetDefaults(gcpauthtesthelper.ContextWithDefaults())
 	}
 }
 

--- a/pkg/reconciler/testing/scheduler.go
+++ b/pkg/reconciler/testing/scheduler.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testing
 
 import (
-	"context"
 	"time"
 
 	gcpauthtesthelper "github.com/google/knative-gcp/pkg/apis/configs/gcpauth/testhelper"
@@ -45,7 +44,7 @@ func NewCloudSchedulerSource(name, namespace string, so ...CloudSchedulerSourceO
 	for _, opt := range so {
 		opt(s)
 	}
-	s.SetDefaults(context.Background())
+	s.SetDefaults(gcpauthtesthelper.ContextWithDefaults())
 	return s
 }
 

--- a/pkg/reconciler/testing/storage.go
+++ b/pkg/reconciler/testing/storage.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testing
 
 import (
-	"context"
 	"time"
 
 	gcpauthtesthelper "github.com/google/knative-gcp/pkg/apis/configs/gcpauth/testhelper"
@@ -50,7 +49,7 @@ func NewCloudStorageSource(name, namespace string, so ...CloudStorageSourceOptio
 	for _, opt := range so {
 		opt(s)
 	}
-	s.SetDefaults(context.Background())
+	s.SetDefaults(gcpauthtesthelper.ContextWithDefaults())
 	return s
 }
 

--- a/pkg/reconciler/testing/topic.go
+++ b/pkg/reconciler/testing/topic.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testing
 
 import (
-	"context"
 	"time"
 
 	gcpauthtesthelper "github.com/google/knative-gcp/pkg/apis/configs/gcpauth/testhelper"
@@ -44,7 +43,7 @@ func NewTopic(name, namespace string, so ...TopicOption) *v1alpha1.Topic {
 	for _, opt := range so {
 		opt(s)
 	}
-	s.SetDefaults(context.Background())
+	s.SetDefaults(gcpauthtesthelper.ContextWithDefaults())
 	return s
 }
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Provide the default GCP auth during the creation of the PullSubscription for E2E
  - This doesn't alter the outcome of the tests, but before this change an error log was generated stating `Failed to get the GCPAuthDefaults`.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```
