### PR TITLE
Use config-gcp-auth to default Channel auth.

### DIFF
--- a/pkg/apis/messaging/v1alpha1/channel_defaults_test.go
+++ b/pkg/apis/messaging/v1alpha1/channel_defaults_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
 	"testing"
+
+	gcpauthtesthelper "github.com/google/knative-gcp/pkg/apis/configs/gcpauth/testhelper"
 
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +37,7 @@ func TestChannelDefaults(t *testing.T) {
 			},
 		},
 		Spec: ChannelSpec{
-			Secret: defaultSecretSelector(),
+			Secret: &gcpauthtesthelper.Secret,
 		}}
 
 	got := &Channel{
@@ -47,7 +48,7 @@ func TestChannelDefaults(t *testing.T) {
 		},
 		Spec: ChannelSpec{},
 	}
-	got.SetDefaults(context.Background())
+	got.SetDefaults(gcpauthtesthelper.ContextWithDefaults())
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("failed to get expected (-want, +got) = %v", diff)

--- a/pkg/apis/messaging/v1alpha1/channel_validation_test.go
+++ b/pkg/apis/messaging/v1alpha1/channel_validation_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	gcpauthtesthelper "github.com/google/knative-gcp/pkg/apis/configs/gcpauth/testhelper"
+
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -198,7 +200,7 @@ func TestChannelValidation(t *testing.T) {
 				IdentitySpec: duckv1alpha1.IdentitySpec{
 					ServiceAccountName: validServiceAccountName,
 				},
-				Secret: defaultSecretSelector(),
+				Secret: &gcpauthtesthelper.Secret,
 				Subscribable: &eventingduck.Subscribable{
 					Subscribers: []eventingduck.SubscriberSpec{{
 						SubscriberURI: apis.HTTP("subscriberendpoint"),

--- a/pkg/apis/messaging/v1beta1/channel_defaults_test.go
+++ b/pkg/apis/messaging/v1beta1/channel_defaults_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
 	"testing"
+
+	gcpauthtesthelper "github.com/google/knative-gcp/pkg/apis/configs/gcpauth/testhelper"
 
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +39,7 @@ func TestChannelDefaults(t *testing.T) {
 					},
 				},
 				Spec: ChannelSpec{
-					Secret: defaultSecretSelector(),
+					Secret: &gcpauthtesthelper.Secret,
 				},
 			},
 		},
@@ -57,14 +58,14 @@ func TestChannelDefaults(t *testing.T) {
 					},
 				},
 				Spec: ChannelSpec{
-					Secret: defaultSecretSelector(),
+					Secret: &gcpauthtesthelper.Secret,
 				},
 			},
 		},
 	} {
 		t.Run(n, func(t *testing.T) {
 			got := tc.in
-			got.SetDefaults(context.Background())
+			got.SetDefaults(gcpauthtesthelper.ContextWithDefaults())
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("failed to get expected (-want, +got) = %v", diff)

--- a/pkg/apis/messaging/v1beta1/channel_validation_test.go
+++ b/pkg/apis/messaging/v1beta1/channel_validation_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	gcpauthtesthelper "github.com/google/knative-gcp/pkg/apis/configs/gcpauth/testhelper"
 	duckv1beta1 "github.com/google/knative-gcp/pkg/apis/duck/v1beta1"
 
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1beta1"
@@ -155,7 +156,7 @@ func TestChannelValidation(t *testing.T) {
 				IdentitySpec: duckv1beta1.IdentitySpec{
 					ServiceAccountName: validServiceAccountName,
 				},
-				Secret: defaultSecretSelector(),
+				Secret: &gcpauthtesthelper.Secret,
 				SubscribableSpec: &eventingduck.SubscribableSpec{
 					Subscribers: []eventingduck.SubscriberSpec{{
 						SubscriberURI: apis.HTTP("subscriberendpoint"),

--- a/pkg/reconciler/testing/channel.go
+++ b/pkg/reconciler/testing/channel.go
@@ -17,8 +17,9 @@ limitations under the License.
 package testing
 
 import (
-	"context"
 	"time"
+
+	gcpauthtesthelper "github.com/google/knative-gcp/pkg/apis/configs/gcpauth/testhelper"
 
 	"knative.dev/pkg/apis"
 
@@ -45,7 +46,7 @@ func NewChannel(name, namespace string, so ...ChannelOption) *v1alpha1.Channel {
 	for _, opt := range so {
 		opt(s)
 	}
-	s.SetDefaults(context.Background())
+	s.SetDefaults(gcpauthtesthelper.ContextWithDefaults())
 	return s
 }
 
@@ -59,7 +60,7 @@ func NewChannelWithoutNamespace(name string, so ...ChannelOption) *v1alpha1.Chan
 	for _, opt := range so {
 		opt(s)
 	}
-	s.SetDefaults(context.Background())
+	s.SetDefaults(gcpauthtesthelper.ContextWithDefaults())
 	return s
 }
 
@@ -125,7 +126,7 @@ func WithChannelSpec(spec v1alpha1.ChannelSpec) ChannelOption {
 }
 
 func WithChannelDefaults(s *v1alpha1.Channel) {
-	s.SetDefaults(context.Background())
+	s.SetDefaults(gcpauthtesthelper.ContextWithDefaults())
 }
 
 func WithChannelGCPServiceAccount(gServiceAccount string) ChannelOption {


### PR DESCRIPTION
Fixes #1182.
Should have been part of #1183.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use config-gcp-auth to default Channel auth.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```