### PR TITLE
Set correct broker status if topic is deleted

### DIFF
--- a/pkg/apis/broker/v1beta1/trigger_lifecycle.go
+++ b/pkg/apis/broker/v1beta1/trigger_lifecycle.go
@@ -65,11 +65,11 @@ func (ts *TriggerStatus) PropagateBrokerStatus(bs *BrokerStatus) {
 
 	switch {
 	case bc.Status == corev1.ConditionUnknown:
-		ts.MarkBrokerUnknown(bc.Reason, bc.Message)
+		ts.MarkBrokerUnknown("Broker-"+bc.Reason, bc.Message)
 	case bc.Status == corev1.ConditionTrue:
 		triggerCondSet.Manage(ts).MarkTrue(eventingv1beta1.TriggerConditionBroker)
 	case bc.Status == corev1.ConditionFalse:
-		ts.MarkBrokerFailed(bc.Reason, bc.Message)
+		ts.MarkBrokerFailed("Broker-"+bc.Reason, bc.Message)
 	default:
 		ts.MarkBrokerUnknown("BrokerUnknown", "The status of Broker is invalid: %v", bc.Status)
 	}

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -30,7 +30,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
@@ -47,23 +47,17 @@ import (
 	brokerreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/broker/v1beta1/broker"
 	brokerlisters "github.com/google/knative-gcp/pkg/client/listers/broker/v1beta1"
 	inteventslisters "github.com/google/knative-gcp/pkg/client/listers/intevents/v1alpha1"
-	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 	"github.com/google/knative-gcp/pkg/reconciler"
 	"github.com/google/knative-gcp/pkg/reconciler/broker/resources"
 	brokercellresources "github.com/google/knative-gcp/pkg/reconciler/brokercell/resources"
-	"github.com/google/knative-gcp/pkg/utils"
+	reconcilerutilspubsub "github.com/google/knative-gcp/pkg/reconciler/utils/pubsub"
 )
 
 const (
 	// Name of the corev1.Events emitted from the Broker reconciliation process.
-	brokerReconcileError = "BrokerReconcileError"
-	brokerReconciled     = "BrokerReconciled"
-	brokerFinalized      = "BrokerFinalized"
-	topicCreated         = "TopicCreated"
-	brokerCellCreated    = "BrokerCellCreated"
-	subCreated           = "SubscriptionCreated"
-	topicDeleted         = "TopicDeleted"
-	subDeleted           = "SubscriptionDeleted"
+	brokerReconciled  = "BrokerReconciled"
+	brokerFinalized   = "BrokerFinalized"
+	brokerCellCreated = "BrokerCellCreated"
 
 	targetsCMName         = "broker-targets"
 	targetsCMKey          = "targets"
@@ -105,8 +99,6 @@ type Reconciler struct {
 	// between multiple controller workers.
 	targetsNeedsUpdate chan struct{}
 
-	// projectID is used as the GCP project ID when present, skipping the
-	// metadata server check. Used by tests.
 	projectID string
 
 	// pubsubClient is used as the Pubsub client when present.
@@ -233,20 +225,10 @@ func (r *Reconciler) reconcileConfig(ctx context.Context, b *brokerv1beta1.Broke
 func (r *Reconciler) reconcileDecouplingTopicAndSubscription(ctx context.Context, b *brokerv1beta1.Broker) error {
 	logger := logging.FromContext(ctx)
 	logger.Debug("Reconciling decoupling topic", zap.Any("broker", b))
-	// get ProjectID from metadata if projectID isn't set
-	projectID, err := utils.ProjectID(r.projectID, metadataClient.NewDefaultMetadataClient())
-	if err != nil {
-		logger.Error("Failed to find project id", zap.Error(err))
-		b.Status.MarkTopicUnknown("ProjectIdNotFound", "Failed to find project id: %w", err)
-		return err
-	}
-	// Set the projectID in the status.
-	//TODO uncomment when eventing webhook allows this
-	//b.Status.ProjectID = projectID
 
 	client := r.pubsubClient
 	if client == nil {
-		client, err := pubsub.NewClient(ctx, projectID)
+		client, err := pubsub.NewClient(ctx, r.projectID)
 		if err != nil {
 			logger.Error("Failed to create Pub/Sub client", zap.Error(err))
 			b.Status.MarkTopicUnknown("PubSubClientCreationFailed", "Failed to create Pub/Sub client: %w", err)
@@ -254,85 +236,40 @@ func (r *Reconciler) reconcileDecouplingTopicAndSubscription(ctx context.Context
 		}
 		defer client.Close()
 	}
+	pubsubReconciler := reconcilerutilspubsub.NewReconciler(client, r.Recorder)
+
+	labels := map[string]string{
+		"resource":     "brokers",
+		"broker_class": brokerv1beta1.BrokerClass,
+		"namespace":    b.Namespace,
+		"name":         b.Name,
+		//TODO add resource labels, but need to be sanitized: https://cloud.google.com/pubsub/docs/labels#requirements
+	}
 
 	// Check if topic exists, and if not, create it.
 	topicID := resources.GenerateDecouplingTopicName(b)
-	topic := client.Topic(topicID)
-	exists, err := topic.Exists(ctx)
+	topicConfig := &pubsub.TopicConfig{Labels: labels}
+	topic, err := pubsubReconciler.ReconcileTopic(ctx, topicID, topicConfig, b, &b.Status)
 	if err != nil {
-		logger.Error("Failed to verify Pub/Sub topic exists", zap.Error(err))
-		b.Status.MarkTopicUnknown("TopicVerificationFailed", "Failed to verify Pub/Sub topic exists: %w", err)
 		return err
 	}
-
-	if !exists {
-		// TODO If this can ever change through the Broker's lifecycle, add
-		// update handling
-		topicConfig := &pubsub.TopicConfig{
-			Labels: map[string]string{
-				"resource":     "brokers",
-				"broker_class": brokerv1beta1.BrokerClass,
-				"namespace":    b.Namespace,
-				"name":         b.Name,
-				//TODO add resource labels, but need to be sanitized: https://cloud.google.com/pubsub/docs/labels#requirements
-			},
-		}
-		// Create a new topic.
-		logger.Debug("Creating topic with cfg", zap.String("id", topicID), zap.Any("cfg", topicConfig))
-		topic, err = client.CreateTopicWithConfig(ctx, topicID, topicConfig)
-		if err != nil {
-			logger.Error("Failed to create Pub/Sub topic", zap.Error(err))
-			b.Status.MarkTopicFailed("TopicCreationFailed", "Topic creation failed: %w", err)
-			return err
-		}
-		logger.Info("Created PubSub topic", zap.String("name", topic.ID()))
-		r.Recorder.Eventf(b, corev1.EventTypeNormal, topicCreated, "Created PubSub topic %q", topic.ID())
-	}
-
-	b.Status.MarkTopicReady()
 	// TODO(grantr): this isn't actually persisted due to webhook issues.
 	//TODO uncomment when eventing webhook allows this
 	//b.Status.TopicID = topic.ID()
 
 	// Check if PullSub exists, and if not, create it.
 	subID := resources.GenerateDecouplingSubscriptionName(b)
-	sub := client.Subscription(subID)
-	subExists, err := sub.Exists(ctx)
-	if err != nil {
-		logger.Error("Failed to verify Pub/Sub subscription exists", zap.Error(err))
-		b.Status.MarkSubscriptionUnknown("SubscriptionVerificationFailed", "Failed to verify Pub/Sub subscription exists: %w", err)
+	subConfig := pubsub.SubscriptionConfig{
+		Topic:  topic,
+		Labels: labels,
+		//TODO(grantr): configure these settings?
+		// AckDeadline
+		// RetentionDuration
+	}
+	if _, err := pubsubReconciler.ReconcileSubscription(ctx, subID, subConfig, b, &b.Status); err != nil {
 		return err
 	}
 
-	if !subExists {
-		// TODO If this can ever change through the Broker's lifecycle, add
-		// update handling
-		subConfig := pubsub.SubscriptionConfig{
-			Topic: topic,
-			Labels: map[string]string{
-				"resource":     "brokers",
-				"broker_class": brokerv1beta1.BrokerClass,
-				"namespace":    b.Namespace,
-				"name":         b.Name,
-				//TODO add resource labels, but need to be sanitized: https://cloud.google.com/pubsub/docs/labels#requirements
-			},
-			//TODO(grantr): configure these settings?
-			// AckDeadline
-			// RetentionDuration
-		}
-		// Create a new subscription to the previous topic with the given name.
-		logger.Debug("Creating sub with cfg", zap.String("id", subID), zap.Any("cfg", subConfig))
-		sub, err = client.CreateSubscription(ctx, subID, subConfig)
-		if err != nil {
-			logger.Error("Failed to create subscription", zap.Error(err))
-			b.Status.MarkSubscriptionFailed("SubscriptionCreationFailed", "Subscription creation failed: %w", err)
-			return err
-		}
-		logger.Info("Created PubSub subscription", zap.String("name", sub.ID()))
-		r.Recorder.Eventf(b, corev1.EventTypeNormal, subCreated, "Created PubSub subscription %q", sub.ID())
-	}
-
-	b.Status.MarkSubscriptionReady()
 	// TODO(grantr): this isn't actually persisted due to webhook issues.
 	//TODO uncomment when eventing webhook allows this
 	//b.Status.SubscriptionID = sub.ID()
@@ -344,61 +281,25 @@ func (r *Reconciler) deleteDecouplingTopicAndSubscription(ctx context.Context, b
 	logger := logging.FromContext(ctx)
 	logger.Debug("Deleting decoupling topic")
 
-	// get ProjectID from metadata if projectID isn't set
-	projectID, err := utils.ProjectID(r.projectID, metadataClient.NewDefaultMetadataClient())
-	if err != nil {
-		logger.Error("Failed to find project id", zap.Error(err))
-		return err
-	}
-
 	client := r.pubsubClient
 	if client == nil {
-		client, err := pubsub.NewClient(ctx, projectID)
+		client, err := pubsub.NewClient(ctx, r.projectID)
 		if err != nil {
 			logger.Error("Failed to create Pub/Sub client", zap.Error(err))
 			return err
 		}
 		defer client.Close()
 	}
+	pubsubReconciler := reconcilerutilspubsub.NewReconciler(client, r.Recorder)
 
 	// Delete topic if it exists. Pull subscriptions continue pulling from the
 	// topic until deleted themselves.
 	topicID := resources.GenerateDecouplingTopicName(b)
-	topic := client.Topic(topicID)
-	exists, err := topic.Exists(ctx)
-	if err != nil {
-		logger.Error("Failed to verify Pub/Sub topic exists", zap.Error(err))
-		return err
-	}
-	if exists {
-		if err := topic.Delete(ctx); err != nil {
-			logger.Error("Failed to delete Pub/Sub topic", zap.Error(err))
-			return err
-		}
-		logger.Info("Deleted PubSub topic", zap.String("name", topic.ID()))
-		r.Recorder.Eventf(b, corev1.EventTypeNormal, topicDeleted, "Deleted PubSub topic %q", topic.ID())
-	}
-
-	// Delete pull subscription if it exists.
-	// TODO could alternately set expiration policy to make pubsub delete it after some idle time.
-	// https://cloud.google.com/pubsub/docs/admin#deleting_a_topic
+	err := multierr.Append(nil, pubsubReconciler.DeleteTopic(ctx, topicID, b))
 	subID := resources.GenerateDecouplingSubscriptionName(b)
-	sub := client.Subscription(subID)
-	exists, err = sub.Exists(ctx)
-	if err != nil {
-		logger.Error("Failed to verify Pub/Sub subscription exists", zap.Error(err))
-		return err
-	}
-	if exists {
-		if err := sub.Delete(ctx); err != nil {
-			logger.Error("Failed to delete Pub/Sub subscription", zap.Error(err))
-			return err
-		}
-		logger.Info("Deleted PubSub subscription", zap.String("name", sub.ID()))
-		r.Recorder.Eventf(b, corev1.EventTypeNormal, subDeleted, "Deleted PubSub subscription %q", sub.ID())
-	}
+	err = multierr.Append(err, pubsubReconciler.DeleteSubscription(ctx, subID, b))
 
-	return nil
+	return err
 }
 
 //TODO all this stuff should be in a configmap variant of the config object
@@ -424,7 +325,7 @@ func (r *Reconciler) updateTargetsConfig(ctx context.Context) error {
 	r.Logger.Debug("Current targets config", zap.Any("targetsConfig", r.targetsConfig.String()))
 
 	existing, err := r.configMapLister.ConfigMaps(desired.Namespace).Get(desired.Name)
-	if errors.IsNotFound(err) {
+	if apierrs.IsNotFound(err) {
 		r.Logger.Debug("Creating targets ConfigMap", zap.String("namespace", desired.Namespace), zap.String("name", desired.Name))
 		existing, err = r.KubeClientSet.CoreV1().ConfigMaps(desired.Namespace).Create(desired)
 		if err != nil {
@@ -476,7 +377,7 @@ func (r *Reconciler) LoadTargetsConfig(ctx context.Context) error {
 	//TODO retry with wait.ExponentialBackoff
 	existing, err := r.configMapLister.ConfigMaps(system.Namespace()).Get(targetsCMName)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrs.IsNotFound(err) {
 			r.targetsConfig = memory.NewEmptyTargets()
 			return nil
 		}

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -119,7 +119,7 @@ func TestAllCases(t *testing.T) {
 		},
 		OtherTestData: map[string]interface{}{
 			"pre": []PubsubAction{
-				TopicAndSub("cre-bkr_testnamespace_test-broker_abc123"),
+				TopicAndSub("cre-bkr_testnamespace_test-broker_abc123", "cre-bkr_testnamespace_test-broker_abc123"),
 			},
 		},
 		PostConditions: []func(*testing.T, *TableRow){

--- a/pkg/reconciler/broker/controller_test.go
+++ b/pkg/reconciler/broker/controller_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package broker
 
 import (
+	"os"
 	"testing"
 
+	"github.com/google/knative-gcp/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/configmap"
@@ -43,7 +45,7 @@ import (
 
 func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
-
+	os.Setenv(utils.ProjectIDEnvKey, "test")
 	c := NewController(ctx, configmap.NewStaticWatcher(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/testing/pstest.go
+++ b/pkg/reconciler/testing/pstest.go
@@ -52,10 +52,10 @@ func SubscriptionWithTopic(id string, tid string) PubsubAction {
 	}
 }
 
-func TopicAndSub(id string) PubsubAction {
+func TopicAndSub(tid, sid string) PubsubAction {
 	return func(ctx context.Context, t *testing.T, c *pubsub.Client) {
-		Topic(id)(ctx, t, c)
-		SubscriptionWithTopic(id, id)(ctx, t, c)
+		Topic(tid)(ctx, t, c)
+		SubscriptionWithTopic(sid, tid)(ctx, t, c)
 	}
 }
 

--- a/pkg/reconciler/trigger/controller.go
+++ b/pkg/reconciler/trigger/controller.go
@@ -18,6 +18,7 @@ package trigger
 
 import (
 	"context"
+	"os"
 
 	"k8s.io/client-go/tools/cache"
 
@@ -58,15 +59,14 @@ const (
 var filterBroker = pkgreconciler.AnnotationFilterFunc(eventingv1beta1.BrokerClassAnnotationKey, brokerv1beta1.BrokerClass, false /*allowUnset*/)
 
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	// TODO initialize project ID here via env var or metadata.
-	projectID := ""
+	projectID, err := utils.ProjectID(os.Getenv(utils.ProjectIDEnvKey), metadataClient.NewDefaultMetadataClient())
 
 	triggerInformer := triggerinformer.Get(ctx)
 
 	// Attempt to create a pubsub client for all worker threads to use. If this
 	// fails, pass a nil value to the Reconciler. They will attempt to
 	// create a client on reconcile.
-	client, err := newPubsubClient(ctx, projectID)
+	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {
 		logging.FromContext(ctx).Error("Failed to create controller-wide Pub/Sub client", zap.Error(err))
 	}

--- a/pkg/reconciler/trigger/controller_test.go
+++ b/pkg/reconciler/trigger/controller_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package trigger
 
 import (
+	"os"
 	"testing"
 
+	"github.com/google/knative-gcp/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/configmap"
@@ -42,7 +44,7 @@ import (
 
 func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
-
+	os.Setenv(utils.ProjectIDEnvKey, "test")
 	c := NewController(ctx, configmap.NewStaticWatcher(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -133,7 +133,7 @@ func TestAllCasesTrigger(t *testing.T) {
 			},
 			OtherTestData: map[string]interface{}{
 				"pre": []PubsubAction{
-					TopicAndSub("cre-tgr_testnamespace_test-trigger_abc123"),
+					TopicAndSub("cre-tgr_testnamespace_test-trigger_abc123", "cre-tgr_testnamespace_test-trigger_abc123"),
 				},
 			},
 		},
@@ -152,7 +152,7 @@ func TestAllCasesTrigger(t *testing.T) {
 			},
 			OtherTestData: map[string]interface{}{
 				"pre": []PubsubAction{
-					TopicAndSub("cre-tgr_testnamespace_test-trigger_abc123"),
+					TopicAndSub("cre-tgr_testnamespace_test-trigger_abc123", "cre-tgr_testnamespace_test-trigger_abc123"),
 				},
 			},
 		},
@@ -173,7 +173,7 @@ func TestAllCasesTrigger(t *testing.T) {
 			},
 			OtherTestData: map[string]interface{}{
 				"pre": []PubsubAction{
-					TopicAndSub("cre-tgr_testnamespace_test-trigger_abc123"),
+					TopicAndSub("cre-tgr_testnamespace_test-trigger_abc123", "cre-tgr_testnamespace_test-trigger_abc123"),
 				},
 			},
 		},
@@ -193,7 +193,7 @@ func TestAllCasesTrigger(t *testing.T) {
 			},
 			OtherTestData: map[string]interface{}{
 				"pre": []PubsubAction{
-					TopicAndSub("cre-tgr_testnamespace_test-trigger_abc123"),
+					TopicAndSub("cre-tgr_testnamespace_test-trigger_abc123", "cre-tgr_testnamespace_test-trigger_abc123"),
 				},
 			},
 		},
@@ -213,7 +213,7 @@ func TestAllCasesTrigger(t *testing.T) {
 				Object: NewTrigger(triggerName, testNS, brokerName,
 					WithTriggerUID(testUID),
 					WithTriggerSubscriberRef(subscriberGVK, subscriberName, testNS),
-					WithTriggerBrokerUnknown("", ""),
+					WithTriggerBrokerUnknown("Broker-", ""),
 					WithTriggerSubscriptionReady,
 					WithTriggerTopicReady,
 					WithTriggerDependencyReady,

--- a/pkg/reconciler/utils/pubsub/subscription.go
+++ b/pkg/reconciler/utils/pubsub/subscription.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pubsub
+
+import (
+	"context"
+	"errors"
+
+	"cloud.google.com/go/pubsub"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/eventing/pkg/logging"
+)
+
+const (
+	// If the topic of the subscription has been deleted, the value of its topic becomes "_deleted-topic_".
+	// See https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#subscription
+	deletedTopic = "_deleted-topic_"
+	subCreated   = "SubscriptionCreated"
+	subDeleted   = "SubscriptionDeleted"
+)
+
+var deletedTopicErr = errors.New("topic of the subscription has been deleted")
+
+func (r *Reconciler) ReconcileSubscription(ctx context.Context, id string, subConfig pubsub.SubscriptionConfig, obj runtime.Object, updater StatusUpdater) (*pubsub.Subscription, error) {
+	logger := logging.FromContext(ctx)
+	sub := r.client.Subscription(id)
+	subExists, err := sub.Exists(ctx)
+	if err != nil {
+		logger.Error("Failed to verify Pub/Sub subscription exists", zap.Error(err))
+		updater.MarkSubscriptionUnknown("SubscriptionVerificationFailed", "Failed to verify Pub/Sub subscription exists: %w", err)
+		return nil, err
+	}
+
+	// Check if the topic of the subscription is "_deleted-topic_"
+	if subExists {
+		config, err := sub.Config(ctx)
+		if err != nil {
+			logger.Error("Failed to get Pub/Sub subscription Config", zap.Error(err))
+			updater.MarkSubscriptionUnknown("SubscriptionConfigUnknown", "Failed to get Pub/Sub subscription Config: %w", err)
+			return nil, err
+		}
+		if config.Topic != nil && config.Topic.String() == deletedTopic {
+			logger.Error("The topic is deleted")
+			updater.MarkSubscriptionFailed("DeletedTopic", "Pull subscriptions should be recreated to work with recreated topic")
+			return nil, deletedTopicErr
+		}
+		return sub, nil
+	}
+
+	// Create a new subscription.
+	logger.Debug("Creating sub with cfg", zap.String("id", id), zap.Any("cfg", subConfig))
+	sub, err = r.client.CreateSubscription(ctx, id, subConfig)
+	if err != nil {
+		logger.Error("Failed to create subscription", zap.Error(err))
+		updater.MarkSubscriptionFailed("SubscriptionCreationFailed", "Subscription creation failed: %w", err)
+		return nil, err
+	}
+	logger.Info("Created PubSub subscription", zap.String("name", sub.ID()))
+	r.Recorder.Eventf(obj, corev1.EventTypeNormal, subCreated, "Created PubSub subscription %q", sub.ID())
+	updater.MarkSubscriptionReady()
+	return sub, nil
+}
+
+func (r *Reconciler) DeleteSubscription(ctx context.Context, id string, obj runtime.Object) error {
+	logger := logging.FromContext(ctx)
+	logger.Debug("Deleting decoupling sub")
+
+	sub := r.client.Subscription(id)
+	exists, err := sub.Exists(ctx)
+	if err != nil {
+		logger.Error("Failed to verify Pub/Sub subscription exists", zap.Error(err))
+		return err
+	}
+	if exists {
+		if err := sub.Delete(ctx); err != nil {
+			logger.Error("Failed to delete Pub/Sub subscription", zap.Error(err))
+			return err
+		}
+		logger.Info("Deleted PubSub subscription", zap.String("name", sub.ID()))
+		r.Recorder.Eventf(obj, corev1.EventTypeNormal, subDeleted, "Deleted PubSub subscription %q", sub.ID())
+	}
+
+	return nil
+}

--- a/pkg/reconciler/utils/pubsub/subscription_test.go
+++ b/pkg/reconciler/utils/pubsub/subscription_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pubsub
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"cloud.google.com/go/pubsub"
+	reconcilertesting "github.com/google/knative-gcp/pkg/reconciler/testing"
+)
+
+const (
+	sub = "test-sub"
+)
+
+func TestReconcileSub(t *testing.T) {
+	tests := []testCase{
+		{
+			name:       "new sub created",
+			pre:        []reconcilertesting.PubsubAction{reconcilertesting.Topic(topic)},
+			wantEvents: []string{`Normal SubscriptionCreated Created PubSub subscription "test-sub"`},
+		},
+		{
+			name: "sub already exists",
+			pre:  []reconcilertesting.PubsubAction{reconcilertesting.TopicAndSub(topic, sub)},
+		},
+		{
+			name:    "deleted topic",
+			pre:     []reconcilertesting.PubsubAction{reconcilertesting.TopicAndSub(topic, sub), deleteTopic},
+			wantErr: deletedTopicErr,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tr, cleanup := newTestRunner(t, tc)
+			defer cleanup()
+			r := NewReconciler(tr.client, tr.recorder)
+			subConfig := pubsub.SubscriptionConfig{Topic: tr.client.Topic(topic)}
+			res, err := r.ReconcileSubscription(context.Background(), sub, subConfig, obj, su)
+
+			tr.verify(t, tc, err)
+			if res != nil {
+				verifySub(t, res, subConfig)
+			}
+		})
+	}
+
+}
+
+func TestDeleteSub(t *testing.T) {
+	tests := []testCase{
+		{
+			name:       "sub deleted",
+			pre:        []reconcilertesting.PubsubAction{reconcilertesting.TopicAndSub(topic, sub)},
+			wantEvents: []string{`Normal SubscriptionDeleted Deleted PubSub subscription "test-sub"`},
+		},
+		{
+			name: "nothing to delete",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tr, cleanup := newTestRunner(t, tc)
+			defer cleanup()
+			r := NewReconciler(tr.client, tr.recorder)
+			err := r.DeleteSubscription(context.Background(), sub, obj)
+			tr.verify(t, tc, err)
+			exists, err := tr.client.Subscription(sub).Exists(context.Background())
+			if err != nil {
+				t.Fatalf("Failed to verify sub exists: %v", err)
+			}
+			if exists {
+				t.Errorf("Sub still exists")
+			}
+		})
+	}
+
+}
+
+func deleteTopic(ctx context.Context, t *testing.T, c *pubsub.Client) {
+	if err := c.Topic(topic).Delete(ctx); err != nil {
+		t.Fatalf("Failed to delete topic: %v", err)
+	}
+}
+
+func verifySub(t *testing.T, got *pubsub.Subscription, wantConfig pubsub.SubscriptionConfig) {
+	want := fmt.Sprintf("projects/%s/subscriptions/%s", project, sub)
+	if got.String() != want {
+		t.Errorf("Unexpected sub, got: %v, want:%v", got.String(), want)
+	}
+	gotConfig, err := got.Config(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to get config: %v", err)
+	}
+	if !reflect.DeepEqual(gotConfig.Topic, wantConfig.Topic) {
+		t.Errorf("Unexpected topic for sub, got:%+v, want: %+v", gotConfig.Topic, wantConfig.Topic)
+	}
+	if !reflect.DeepEqual(gotConfig.Labels, wantConfig.Labels) {
+		t.Errorf("Unexpected labels in config, got:%+v, want: %+v", gotConfig.Labels, wantConfig.Labels)
+	}
+}

--- a/pkg/reconciler/utils/pubsub/testing/status_updater.go
+++ b/pkg/reconciler/utils/pubsub/testing/status_updater.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+type StatusUpdater struct {}
+
+func(su *StatusUpdater) MarkTopicFailed(reason, format string, args ...interface{}) {    }
+func(su *StatusUpdater) MarkTopicUnknown(reason, format string, args ...interface{}) {    }
+func(su *StatusUpdater) MarkTopicReady() {    }
+func(su *StatusUpdater) MarkSubscriptionFailed(reason, format string, args ...interface{}) {    }
+func(su *StatusUpdater) MarkSubscriptionUnknown(reason, format string, args ...interface{}) {    }
+func(su *StatusUpdater) MarkSubscriptionReady() {    }

--- a/pkg/reconciler/utils/pubsub/topic.go
+++ b/pkg/reconciler/utils/pubsub/topic.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pubsub
+
+import (
+	"context"
+
+	"cloud.google.com/go/pubsub"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/eventing/pkg/logging"
+)
+
+const (
+	topicCreated = "TopicCreated"
+	topicDeleted = "TopicDeleted"
+)
+
+func (r *Reconciler) ReconcileTopic(ctx context.Context, id string, topicConfig *pubsub.TopicConfig, obj runtime.Object, updater StatusUpdater) (*pubsub.Topic, error) {
+	logger := logging.FromContext(ctx)
+
+	// Check if topic exists, and if not, create it.
+	topic := r.client.Topic(id)
+	exists, err := topic.Exists(ctx)
+	if err != nil {
+		logger.Error("Failed to verify Pub/Sub topic exists", zap.Error(err))
+		updater.MarkTopicUnknown("TopicVerificationFailed", "Failed to verify Pub/Sub topic exists: %w", err)
+		return nil, err
+	}
+	if exists {
+		return topic, nil
+	}
+
+	// Create a new topic.
+	logger.Debug("Creating topic with cfg", zap.String("id", id), zap.Any("cfg", topicConfig))
+	topic, err = r.client.CreateTopicWithConfig(ctx, id, topicConfig)
+	if err != nil {
+		logger.Error("Failed to create Pub/Sub topic", zap.Error(err))
+		updater.MarkTopicFailed("TopicCreationFailed", "Topic creation failed: %w", err)
+		return nil, err
+	}
+	logger.Info("Created PubSub topic", zap.String("name", topic.ID()))
+	r.Recorder.Eventf(obj, corev1.EventTypeNormal, topicCreated, "Created PubSub topic %q", topic.ID())
+	updater.MarkTopicReady()
+	return topic, nil
+}
+
+func (r *Reconciler) DeleteTopic(ctx context.Context, id string, obj runtime.Object) error {
+	logger := logging.FromContext(ctx)
+	logger.Debug("Deleting decoupling topic")
+
+	// Delete topic if it exists. Pull subscriptions continue pulling from the
+	// topic until deleted themselves.
+	topic := r.client.Topic(id)
+	exists, err := topic.Exists(ctx)
+	if err != nil {
+		logger.Error("Failed to verify Pub/Sub topic exists", zap.Error(err))
+		return err
+	}
+	if exists {
+		if err := topic.Delete(ctx); err != nil {
+			logger.Error("Failed to delete Pub/Sub topic", zap.Error(err))
+			return err
+		}
+		logger.Info("Deleted PubSub topic", zap.String("name", topic.ID()))
+		r.Recorder.Eventf(obj, corev1.EventTypeNormal, topicDeleted, "Deleted PubSub topic %q", topic.ID())
+	}
+	return nil
+}

--- a/pkg/reconciler/utils/pubsub/topic_test.go
+++ b/pkg/reconciler/utils/pubsub/topic_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pubsub
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+
+	reconcilertesting "github.com/google/knative-gcp/pkg/reconciler/testing"
+	utilspubsubtesting "github.com/google/knative-gcp/pkg/reconciler/utils/pubsub/testing"
+)
+
+const (
+	project = "test-project"
+	topic   = "test-topic"
+)
+
+var (
+	// obj can be anything that implements runtime.Object. In real reconcilers this should be the object being reconciled.
+	obj         = &corev1.Namespace{}
+	su          = &utilspubsubtesting.StatusUpdater{}
+	topicConfig = pubsub.TopicConfig{}
+)
+
+func TestReconcileTopic(t *testing.T) {
+	tests := []testCase{
+		{
+			name:       "new topic created",
+			wantEvents: []string{`Normal TopicCreated Created PubSub topic "test-topic"`},
+		},
+		{
+			name: "topic already exists",
+			pre:  []reconcilertesting.PubsubAction{reconcilertesting.Topic(topic)},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tr, cleanup := newTestRunner(t, tc)
+			defer cleanup()
+			r := NewReconciler(tr.client, tr.recorder)
+			res, err := r.ReconcileTopic(context.Background(), topic, &topicConfig, obj, su)
+
+			tr.verify(t, tc, err)
+			verifyTopic(t, res)
+		})
+	}
+
+}
+
+func TestDeleteTopic(t *testing.T) {
+	tests := []testCase{
+		{
+			name:       "topic deleted",
+			pre:        []reconcilertesting.PubsubAction{reconcilertesting.Topic(topic)},
+			wantEvents: []string{`Normal TopicDeleted Deleted PubSub topic "test-topic"`},
+		},
+		{
+			name: "nothing to delete",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tr, cleanup := newTestRunner(t, tc)
+			defer cleanup()
+			r := NewReconciler(tr.client, tr.recorder)
+			err := r.DeleteTopic(context.Background(), topic, obj)
+			tr.verify(t, tc, err)
+			exists, err := tr.client.Topic(topic).Exists(context.Background())
+			if err != nil {
+				t.Fatalf("Failed to verify topic exists: %v", err)
+			}
+			if exists {
+				t.Errorf("Topic still exists")
+			}
+		})
+	}
+
+}
+
+func verifyTopic(t *testing.T, got *pubsub.Topic) {
+	want := fmt.Sprintf("projects/%s/topics/%s", project, topic)
+	if got.String() != want {
+		t.Errorf("Unexpected topic, got: %v, want:%v", got.String(), want)
+	}
+	gotConfig, err := got.Config(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to get config: %v", err)
+	}
+	if diff := cmp.Diff(gotConfig, topicConfig); diff != "" {
+		t.Errorf("Unexpected config, got:%+v, want: %+v", gotConfig, topicConfig)
+	}
+}
+
+type testCase struct {
+	name       string
+	pre        []reconcilertesting.PubsubAction
+	wantEvents []string
+	wantErr    error
+}
+
+// testRunner helps to setup resources such as pubsub client, as well as verify the common test case.
+type testRunner struct {
+	client   *pubsub.Client
+	close    func()
+	recorder *record.FakeRecorder
+}
+
+func newTestRunner(t *testing.T, tc testCase) (*testRunner, func()) {
+	client, close := reconcilertesting.TestPubsubClient(context.Background(), project)
+	for _, action := range tc.pre {
+		action(context.Background(), t, client)
+	}
+	return &testRunner{
+		client:   client,
+		recorder: record.NewFakeRecorder(len(tc.wantEvents)),
+	}, close
+}
+
+func (r *testRunner) verify(t *testing.T, tc testCase, err error) {
+	if tc.wantErr != err {
+		t.Fatalf("Expect error, got: %v, want: %v", err, tc.wantErr)
+	}
+
+	for _, event := range tc.wantEvents {
+		got := <-r.recorder.Events
+		if got != event {
+			t.Errorf("Unexpected event recorded, got: %v, want: %v", got, event)
+		}
+	}
+}

--- a/pkg/reconciler/utils/pubsub/types.go
+++ b/pkg/reconciler/utils/pubsub/types.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pubsub
+
+import (
+	"cloud.google.com/go/pubsub"
+	"k8s.io/client-go/tools/record"
+)
+
+type Reconciler struct {
+	client   *pubsub.Client
+	Recorder record.EventRecorder
+}
+
+func NewReconciler(client *pubsub.Client, recorder record.EventRecorder) *Reconciler {
+	return &Reconciler{
+		client:   client,
+		Recorder: recorder,
+	}
+}
+
+// StatusUpdater is an interface which updates resource status based on pubsub reconciliation results.
+type StatusUpdater interface {
+	MarkTopicFailed(reason, format string, args ...interface{})
+	MarkTopicUnknown(reason, format string, args ...interface{})
+	MarkTopicReady()
+	MarkSubscriptionFailed(reason, format string, args ...interface{})
+	MarkSubscriptionUnknown(reason, format string, args ...interface{})
+	MarkSubscriptionReady()
+}

--- a/pkg/utils/metadata.go
+++ b/pkg/utils/metadata.go
@@ -20,8 +20,9 @@ import (
 	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 )
 
-var (
+const (
 	clusterNameAttr = "cluster-name"
+	ProjectIDEnvKey = "PROJECT_ID"
 )
 
 // ProjectID returns the project ID for a particular resource.


### PR DESCRIPTION
Fixes #1233
Fixes #1235

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- If the topic of a subscription is "_deleted-topic_", mark Broker/Trigger condition false
- Also did some cleanup/refactoring
  - Moved topic/sub reconciliation logic into `pkg/reconclier/utils/pubsub` so it can be shared
  - Force project ID initialization in controller creation.
  - If a trigger condition is not True due to broker, prefix the reason with `Broker-`, otherwise it can be confusing. Example: `Broker-DeletedTopic`
  

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
