### PR TITLE
[WIP] Trigger Metrics Fanout E2E

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -323,7 +323,7 @@ func TestSmokeGCPBroker(t *testing.T) {
 func TestGCPBroker(t *testing.T) {
 	cancel := logstream.Start(t)
 	defer cancel()
-	GCPBrokerTestImpl(t, authConfig, false /* assertMetrics */)
+	GCPBrokerTestImpl(t, authConfig, true /* assertMetrics */)
 }
 
 // TestGCPBroker tests we can knock a Knative Service from a gcp broker.

--- a/test/e2e/lib/constants.go
+++ b/test/e2e/lib/constants.go
@@ -24,8 +24,14 @@ const (
 	StorageResourceGroup     = "storages.events.cloud.google.com"
 	PubsubResourceGroup      = "pubsubs.events.cloud.google.com"
 
+	// https://cloud.google.com/monitoring/api/metrics_knative
 	BrokerEventCountMetricType = "knative.dev/eventing/broker/event_count"
-	BrokerMetricResourceType   = "knative_broker"
+	TriggerEventCountMetricType = "knative.dev/eventing/trigger/event_count"
+	TriggerEventDispatchLatenciesMetricType = "knative.dev/eventing/trigger/event_dispatch_latencies"
+	TriggerEventProcessingLatenciesMetricType = "knative.dev/eventing/trigger/event_processing_latencies"
+
+	BrokerMetricResourceType   = "knative_broker" // https://cloud.google.com/monitoring/api/resources#tag_knative_broker
+	TriggerMetricResourceType  = "knative_trigger" // https://cloud.google.com/monitoring/api/resources#tag_knative_trigger
 
 	EventType          = "type"
 	EventSource        = "source"


### PR DESCRIPTION
Assert that the Stackdriver metrics for trigger/event_count get emitted in GCP Broker E2E test