### PR TITLE
Run Delivery Benchmarks with Multiple Payload Sizes

### DIFF
--- a/pkg/broker/handler/processors/deliver/processor_test.go
+++ b/pkg/broker/handler/processors/deliver/processor_test.go
@@ -19,6 +19,7 @@ package deliver
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"fmt"
 	"io"
 	"net/http"
@@ -548,4 +549,18 @@ func newSampleEvent() *event.Event {
 	sampleEvent.SetType("type")
 	sampleEvent.SetTime(time.Now())
 	return &sampleEvent
+}
+
+func newSampleEventWithRandomData(t testing.TB, size int) *event.Event {
+	event := newSampleEvent()
+	if size > 0 {
+		data := make([]byte, size)
+		_, err := rand.Read(data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		event.DataEncoded = data
+		return event
+	}
+	return event
 }

--- a/pkg/broker/handler/processors/deliver/processor_test.go
+++ b/pkg/broker/handler/processors/deliver/processor_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -333,6 +334,7 @@ type NoReplyHandler struct{}
 
 func (NoReplyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
+	io.Copy(ioutil.Discard, req.Body)
 }
 
 func BenchmarkDeliveryNoReply(b *testing.B) {
@@ -344,7 +346,11 @@ func BenchmarkDeliveryNoReply(b *testing.B) {
 	targetSvr := httptest.NewServer(NoReplyHandler(struct{}{}))
 	defer targetSvr.Close()
 
-	benchmarkNoReply(b, httpClient, targetSvr.URL)
+	for _, eventSize := range []int{0, 1000, 1000000} {
+		b.Run(fmt.Sprintf("%d bytes", eventSize), func(b *testing.B) {
+			benchmarkNoReply(b, &httpClient, targetSvr.URL, eventSize)
+		})
+	}
 }
 
 type ReplyHandler struct {
@@ -353,17 +359,26 @@ type ReplyHandler struct {
 
 func (h ReplyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	cehttp.WriteResponseWriter(req.Context(), h.msg, http.StatusOK, w)
+	io.Copy(ioutil.Discard, req.Body)
 }
 
 func BenchmarkDeliveryWithReply(b *testing.B) {
 	httpClient := http.Client{Transport: &http.Transport{MaxIdleConnsPerHost: runtime.NumCPU()}}
 	ingressSvr := httptest.NewServer(NoReplyHandler(struct{}{}))
 	defer ingressSvr.Close()
-	benchmarkWithReply(b, ingressSvr.URL, func(b *testing.B, reply *event.Event) (http.Client, string) {
-		targetSvr := httptest.NewServer(ReplyHandler{msg: binding.ToMessage(reply)})
-		b.Cleanup(targetSvr.Close)
-		return httpClient, targetSvr.URL
-	})
+	for _, eventSize := range []int{0, 1000, 1000000} {
+		b.Run(fmt.Sprintf("%d bytes", eventSize), func(b *testing.B) {
+			benchmarkWithReply(b, ingressSvr.URL, eventSize,
+				func(b *testing.B, reply *event.Event) (http.Client, string) {
+					targetSvr := httptest.NewServer(ReplyHandler{
+						msg: binding.ToMessage(reply),
+					})
+					b.Cleanup(targetSvr.Close)
+					return httpClient, targetSvr.URL
+				},
+			)
+		})
+	}
 }
 
 type fakeRoundTripper map[string]*http.Response
@@ -392,7 +407,11 @@ func BenchmarkDeliveryNoReplyFakeClient(b *testing.B) {
 			},
 		}),
 	}
-	benchmarkNoReply(b, httpClient, targetAddress)
+	for _, eventSize := range []int{0, 1000, 1000000} {
+		b.Run(fmt.Sprintf("%d bytes", eventSize), func(b *testing.B) {
+			benchmarkNoReply(b, &httpClient, targetAddress, eventSize)
+		})
+	}
 }
 
 type fakeBody struct {
@@ -437,17 +456,21 @@ func makeFakeTargetWithReply(b *testing.B, reply *event.Event) (httpClient http.
 // of the fake client helps to better isolate the performance of the processor itself and can
 // provide better profiling data.
 func BenchmarkDeliveryWithReplyFakeClient(b *testing.B) {
-	benchmarkWithReply(b, fakeIngressAddress, makeFakeTargetWithReply)
+	for _, eventSize := range []int{0, 1000, 1000000} {
+		b.Run(fmt.Sprintf("%d bytes", eventSize), func(b *testing.B) {
+			benchmarkWithReply(b, fakeIngressAddress, eventSize, makeFakeTargetWithReply)
+		})
+	}
 }
 
-func benchmarkNoReply(b *testing.B, httpClient http.Client, targetAddress string) {
+func benchmarkNoReply(b *testing.B, httpClient *http.Client, targetAddress string, eventSize int) {
 	reportertest.ResetDeliveryMetrics()
 	statsReporter, err := metrics.NewDeliveryReporter("pod", "container")
 	if err != nil {
 		b.Fatal(err)
 	}
 
-	sampleEvent := newSampleEvent()
+	sampleEvent := newSampleEventWithRandomData(b, eventSize)
 
 	broker := &config.Broker{Namespace: "ns", Name: "broker"}
 	target := &config.Target{Namespace: "ns", Name: "target", Broker: "broker", Address: targetAddress}
@@ -460,9 +483,10 @@ func benchmarkNoReply(b *testing.B, httpClient http.Client, targetAddress string
 	ctx = handlerctx.WithTargetKey(ctx, target.Key())
 
 	p := &Processor{
-		DeliverClient: &httpClient,
-		Targets:       testTargets,
-		StatsReporter: statsReporter,
+		DeliverClient:  httpClient,
+		Targets:        testTargets,
+		StatsReporter:  statsReporter,
+		RetryOnFailure: false,
 	}
 
 	b.ResetTimer()
@@ -475,14 +499,14 @@ func benchmarkNoReply(b *testing.B, httpClient http.Client, targetAddress string
 	})
 }
 
-func benchmarkWithReply(b *testing.B, ingressAddress string, makeTarget func(*testing.B, *event.Event) (httpClient http.Client, targetAdress string)) {
+func benchmarkWithReply(b *testing.B, ingressAddress string, eventSize int, makeTarget func(*testing.B, *event.Event) (httpClient http.Client, targetAdress string)) {
 	reportertest.ResetDeliveryMetrics()
 	statsReporter, err := metrics.NewDeliveryReporter("pod", "container")
 	if err != nil {
 		b.Fatal(err)
 	}
 
-	sampleEvent := newSampleEvent()
+	sampleEvent := newSampleEventWithRandomData(b, eventSize)
 	sampleReply := sampleEvent.Clone()
 	sampleReply.SetID("reply")
 


### PR DESCRIPTION
## Proposed Changes

- Runs each delivery processor benchmark with 0, 1000, and 1000000 byte payloads.
- Modifies the test HTTP handler to read the entire request body to allow for connection reuse.

Benchmark Results on my system:
```
goos: linux
goarch: amd64
pkg: github.com/google/knative-gcp/pkg/broker/handler/processors/deliver
BenchmarkDeliveryNoReply/0_bytes-16        	  123044	      9627 ns/op
BenchmarkDeliveryNoReply/1000_bytes-16     	  117711	     10078 ns/op
BenchmarkDeliveryNoReply/1000000_bytes-16  	    4237	    287431 ns/op
BenchmarkDeliveryWithReply/0_bytes-16      	   60488	     19159 ns/op
BenchmarkDeliveryWithReply/1000_bytes-16   	   36516	     32521 ns/op
BenchmarkDeliveryWithReply/1000000_bytes-16         	    1897	    589348 ns/op
BenchmarkDeliveryNoReplyFakeClient/0_bytes-16       	  485266	      2563 ns/op
BenchmarkDeliveryNoReplyFakeClient/1000_bytes-16    	  437392	      2691 ns/op
BenchmarkDeliveryNoReplyFakeClient/1000000_bytes-16 	    9333	    119508 ns/op
BenchmarkDeliveryWithReplyFakeClient/0_bytes-16     	  375190	      2974 ns/op
BenchmarkDeliveryWithReplyFakeClient/1000_bytes-16  	  372621	      3268 ns/op
BenchmarkDeliveryWithReplyFakeClient/1000000_bytes-16         	   10106	    119354 ns/op
PASS
ok  	github.com/google/knative-gcp/pkg/broker/handler/processors/deliver	20.104s
```