### PR TITLE
Set pubsub status to true when resources already exist

### DIFF
--- a/pkg/reconciler/utils/pubsub/subscription.go
+++ b/pkg/reconciler/utils/pubsub/subscription.go
@@ -60,6 +60,7 @@ func (r *Reconciler) ReconcileSubscription(ctx context.Context, id string, subCo
 			updater.MarkSubscriptionFailed("DeletedTopic", "Pull subscriptions must be recreated to work with recreated topic")
 			return nil, deletedTopicErr
 		}
+		updater.MarkSubscriptionReady()
 		return sub, nil
 	}
 

--- a/pkg/reconciler/utils/pubsub/testing/status_updater.go
+++ b/pkg/reconciler/utils/pubsub/testing/status_updater.go
@@ -16,11 +16,53 @@ limitations under the License.
 
 package testing
 
-type StatusUpdater struct {}
+import (
+	"fmt"
 
-func(su *StatusUpdater) MarkTopicFailed(reason, format string, args ...interface{}) {    }
-func(su *StatusUpdater) MarkTopicUnknown(reason, format string, args ...interface{}) {    }
-func(su *StatusUpdater) MarkTopicReady() {    }
-func(su *StatusUpdater) MarkSubscriptionFailed(reason, format string, args ...interface{}) {    }
-func(su *StatusUpdater) MarkSubscriptionUnknown(reason, format string, args ...interface{}) {    }
-func(su *StatusUpdater) MarkSubscriptionReady() {    }
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+)
+
+type StatusUpdater struct {
+	TopicCondition apis.Condition
+	SubCondition   apis.Condition
+}
+
+func (su *StatusUpdater) MarkTopicFailed(reason, format string, args ...interface{}) {
+	su.TopicCondition = apis.Condition{
+		Status:  corev1.ConditionFalse,
+		Reason:  reason,
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+func (su *StatusUpdater) MarkTopicUnknown(reason, format string, args ...interface{}) {
+	su.TopicCondition = apis.Condition{
+		Status:  corev1.ConditionUnknown,
+		Reason:  reason,
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+func (su *StatusUpdater) MarkTopicReady() {
+	su.TopicCondition = apis.Condition{
+		Status: corev1.ConditionTrue,
+	}
+}
+func (su *StatusUpdater) MarkSubscriptionFailed(reason, format string, args ...interface{}) {
+	su.SubCondition = apis.Condition{
+		Status:  corev1.ConditionFalse,
+		Reason:  reason,
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+func (su *StatusUpdater) MarkSubscriptionUnknown(reason, format string, args ...interface{}) {
+	su.SubCondition = apis.Condition{
+		Status:  corev1.ConditionUnknown,
+		Reason:  reason,
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+func (su *StatusUpdater) MarkSubscriptionReady() {
+	su.SubCondition = apis.Condition{
+		Status: corev1.ConditionTrue,
+	}
+}

--- a/pkg/reconciler/utils/pubsub/topic.go
+++ b/pkg/reconciler/utils/pubsub/topic.go
@@ -43,6 +43,7 @@ func (r *Reconciler) ReconcileTopic(ctx context.Context, id string, topicConfig 
 		return nil, err
 	}
 	if exists {
+		updater.MarkTopicReady()
 		return topic, nil
 	}
 

--- a/pkg/reconciler/utils/pubsub/topic_test.go
+++ b/pkg/reconciler/utils/pubsub/topic_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
+	"knative.dev/pkg/apis"
 
 	reconcilertesting "github.com/google/knative-gcp/pkg/reconciler/testing"
 	utilspubsubtesting "github.com/google/knative-gcp/pkg/reconciler/utils/pubsub/testing"
@@ -45,12 +46,14 @@ var (
 func TestReconcileTopic(t *testing.T) {
 	tests := []testCase{
 		{
-			name:       "new topic created",
-			wantEvents: []string{`Normal TopicCreated Created PubSub topic "test-topic"`},
+			name:               "new topic created",
+			wantEvents:         []string{`Normal TopicCreated Created PubSub topic "test-topic"`},
+			wantTopicCondition: apis.Condition{Status: corev1.ConditionTrue,},
 		},
 		{
-			name: "topic already exists",
-			pre:  []reconcilertesting.PubsubAction{reconcilertesting.Topic(topic)},
+			name:               "topic already exists",
+			pre:                []reconcilertesting.PubsubAction{reconcilertesting.Topic(topic)},
+			wantTopicCondition: apis.Condition{Status: corev1.ConditionTrue,},
 		},
 	}
 	for _, tc := range tests {
@@ -58,9 +61,10 @@ func TestReconcileTopic(t *testing.T) {
 			tr, cleanup := newTestRunner(t, tc)
 			defer cleanup()
 			r := NewReconciler(tr.client, tr.recorder)
+			su := &utilspubsubtesting.StatusUpdater{}
 			res, err := r.ReconcileTopic(context.Background(), topic, &topicConfig, obj, su)
 
-			tr.verify(t, tc, err)
+			tr.verify(t, tc, su, err)
 			verifyTopic(t, res)
 		})
 	}
@@ -84,7 +88,7 @@ func TestDeleteTopic(t *testing.T) {
 			defer cleanup()
 			r := NewReconciler(tr.client, tr.recorder)
 			err := r.DeleteTopic(context.Background(), topic, obj)
-			tr.verify(t, tc, err)
+			tr.verify(t, tc, su, err)
 			exists, err := tr.client.Topic(topic).Exists(context.Background())
 			if err != nil {
 				t.Fatalf("Failed to verify topic exists: %v", err)
@@ -112,10 +116,12 @@ func verifyTopic(t *testing.T, got *pubsub.Topic) {
 }
 
 type testCase struct {
-	name       string
-	pre        []reconcilertesting.PubsubAction
-	wantEvents []string
-	wantErr    error
+	name               string
+	pre                []reconcilertesting.PubsubAction
+	wantEvents         []string
+	wantTopicCondition apis.Condition
+	wantSubCondition   apis.Condition
+	wantErr            error
 }
 
 // testRunner helps to setup resources such as pubsub client, as well as verify the common test case.
@@ -136,7 +142,7 @@ func newTestRunner(t *testing.T, tc testCase) (*testRunner, func()) {
 	}, close
 }
 
-func (r *testRunner) verify(t *testing.T, tc testCase, err error) {
+func (r *testRunner) verify(t *testing.T, tc testCase, su *utilspubsubtesting.StatusUpdater, err error) {
 	if tc.wantErr != err {
 		t.Fatalf("Expect error, got: %v, want: %v", err, tc.wantErr)
 	}
@@ -146,5 +152,13 @@ func (r *testRunner) verify(t *testing.T, tc testCase, err error) {
 		if got != event {
 			t.Errorf("Unexpected event recorded, got: %v, want: %v", got, event)
 		}
+	}
+
+	if diff := cmp.Diff(tc.wantTopicCondition, su.TopicCondition); diff != "" {
+		t.Errorf("Unexpected topic condition, diff: %s", diff)
+	}
+
+	if diff := cmp.Diff(tc.wantSubCondition, su.SubCondition); diff != "" {
+		t.Errorf("Unexpected subscription condition, diff: %s", diff)
 	}
 }


### PR DESCRIPTION
This should fix the flaky GCP broker e2e tests.

The root cause is that previously no status is set if pubsub resources already exists, if there are two reconciliation of the same broker object happen very quickly, the status may be overwritten to Unknown. The reconciler should make sure the status is always set.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
