### PR TITLE
Recreate subscription if topic has been deleted

### DIFF
--- a/pkg/reconciler/utils/pubsub/subscription.go
+++ b/pkg/reconciler/utils/pubsub/subscription.go
@@ -54,7 +54,8 @@ func (r *Reconciler) ReconcileSubscription(ctx context.Context, id string, subCo
 			return nil, err
 		}
 		if config.Topic != nil && config.Topic.String() == deletedTopic {
-			logger.Warn("Detected deleted topic. Going to recreate the pull subscription.")
+			logger.Error("Detected deleted topic. Going to recreate the pull subscription. Unacked messages will be lost.")
+			r.recorder.Eventf(obj, corev1.EventTypeWarning, topicDeleted, "Unexpected topic deletion detected for subscription: %q", sub.ID())
 			// Subscription with "_deleted-topic_" cannot pull from the new topic. In order to recover, we first delete
 			// the sub and then create it. Unacked messages will be lost.
 			if err := r.deleteSubscription(ctx, sub, obj); err != nil {

--- a/pkg/reconciler/utils/pubsub/subscription_test.go
+++ b/pkg/reconciler/utils/pubsub/subscription_test.go
@@ -53,6 +53,7 @@ func TestReconcileSub(t *testing.T) {
 			// deletion, then recreate it to simulate topic reconciliation before sub reconciliation.
 			pre: []reconcilertesting.PubsubAction{reconcilertesting.TopicAndSub(topic, sub), deleteTopic, reconcilertesting.Topic(topic)},
 			wantEvents: []string{
+				`Warning TopicDeleted Unexpected topic deletion detected for subscription: "test-sub"`,
 				`Normal SubscriptionDeleted Deleted PubSub subscription "test-sub"`,
 				`Normal SubscriptionCreated Created PubSub subscription "test-sub"`,
 			},

--- a/pkg/reconciler/utils/pubsub/subscription_test.go
+++ b/pkg/reconciler/utils/pubsub/subscription_test.go
@@ -48,14 +48,15 @@ func TestReconcileSub(t *testing.T) {
 			wantSubCondition: apis.Condition{Status: corev1.ConditionTrue,},
 		},
 		{
-			name:    "deleted topic",
-			pre:     []reconcilertesting.PubsubAction{reconcilertesting.TopicAndSub(topic, sub), deleteTopic},
-			wantErr: deletedTopicErr,
-			wantSubCondition: apis.Condition{
-				Status:  corev1.ConditionFalse,
-				Reason:  "DeletedTopic",
-				Message: `Pull subscriptions must be recreated to work with recreated topic`,
+			name: "deleted topic",
+			// First create the topic and sub to simulate a stable state. Then delete the topic to simulate manual topic
+			// deletion, then recreate it to simulate topic reconciliation before sub reconciliation.
+			pre: []reconcilertesting.PubsubAction{reconcilertesting.TopicAndSub(topic, sub), deleteTopic, reconcilertesting.Topic(topic)},
+			wantEvents: []string{
+				`Normal SubscriptionDeleted Deleted PubSub subscription "test-sub"`,
+				`Normal SubscriptionCreated Created PubSub subscription "test-sub"`,
 			},
+			wantSubCondition: apis.Condition{Status: corev1.ConditionTrue},
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/reconciler/utils/pubsub/topic_test.go
+++ b/pkg/reconciler/utils/pubsub/topic_test.go
@@ -121,7 +121,6 @@ type testCase struct {
 	wantEvents         []string
 	wantTopicCondition apis.Condition
 	wantSubCondition   apis.Condition
-	wantErr            error
 }
 
 // testRunner helps to setup resources such as pubsub client, as well as verify the common test case.
@@ -143,10 +142,6 @@ func newTestRunner(t *testing.T, tc testCase) (*testRunner, func()) {
 }
 
 func (r *testRunner) verify(t *testing.T, tc testCase, su *utilspubsubtesting.StatusUpdater, err error) {
-	if tc.wantErr != err {
-		t.Fatalf("Expect error, got: %v, want: %v", err, tc.wantErr)
-	}
-
 	for _, event := range tc.wantEvents {
 		got := <-r.recorder.Events
 		if got != event {


### PR DESCRIPTION
Fixes #1259

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Recreate the topic and subscription if topic is manually deleted.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
If topic of a broker/trigger is manually deleted, the topic and subscription will be recreated. This may cause unacknowledged events to be lost.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
