### PR TITLE
Run ingress handler benchmark with multiple event payload sizes

### DIFF
--- a/pkg/broker/ingress/handler_test.go
+++ b/pkg/broker/ingress/handler_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/google/knative-gcp/pkg/broker/config/memory"
 	"github.com/google/knative-gcp/pkg/metrics"
 	reportertest "github.com/google/knative-gcp/pkg/metrics/testing"
+	kgcptesting "github.com/google/knative-gcp/pkg/testing"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/api/option"
@@ -291,10 +292,14 @@ func TestHandler(t *testing.T) {
 }
 
 func BenchmarkIngressHandler(b *testing.B) {
-	// Set parallelism to 32 so that the benchmark is not limited by the Pub/Sub publish latency
-	// over gRPC.
-	b.SetParallelism(32)
+	for _, eventSize := range kgcptesting.BenchmarkEventSizes {
+		b.Run(fmt.Sprintf("%d bytes", eventSize), func(b *testing.B) {
+			runIngressHandlerBenchmark(b, eventSize)
+		})
+	}
+}
 
+func runIngressHandlerBenchmark(b *testing.B, eventSize int) {
 	reportertest.ResetIngressMetrics()
 
 	ctx := logging.WithLogger(context.Background(),
@@ -321,13 +326,16 @@ func BenchmarkIngressHandler(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	req := httptest.NewRequest("POST", "/ns1/broker1", nil)
-	message := binding.ToMessage(createTestEvent("test-event"))
-	http.WriteRequest(ctx, message, req)
+	message := binding.ToMessage(kgcptesting.NewTestEvent(b, eventSize))
 
+	// Set parallelism to 32 so that the benchmark is not limited by the Pub/Sub publish latency
+	// over gRPC.
+	b.SetParallelism(32)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
+			req := httptest.NewRequest("POST", "/ns1/broker1", nil)
+			http.WriteRequest(ctx, message, req)
 			w := httptest.NewRecorder()
 			h.ServeHTTP(w, req)
 			if res := w.Result(); w.Result().StatusCode != nethttp.StatusAccepted {

--- a/pkg/testing/event.go
+++ b/pkg/testing/event.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2020 Google LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/cloudevents/sdk-go/v2/event"
+)
+
+var (
+	BenchmarkEventSizes []int = []int{0, 1000, 100000}
+)
+
+func NewTestEvent(t testing.TB, size int) *event.Event {
+	event := event.New()
+	event.SetID("id")
+	event.SetSource("source")
+	event.SetSubject("subject")
+	event.SetType("type")
+	event.SetTime(time.Now())
+	if size > 0 {
+		data := make([]byte, size)
+		_, err := rand.Read(data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		event.DataEncoded = data
+		return &event
+	}
+	return &event
+}


### PR DESCRIPTION
Reduce maximum event payload size to 100000 bytes to avoid overflowing the pubsub client buffer.

Benchstat results:
```
name                            time/op
IngressHandler/0_bytes-16       10.9µs ± 2%
IngressHandler/1000_bytes-16    11.1µs ± 2%
IngressHandler/100000_bytes-16   122µs ± 3%
```