### PR TITLE
Use pubsub bindings in broker ingress

### DIFF
--- a/cmd/broker/ingress/wire_gen.go
+++ b/cmd/broker/ingress/wire_gen.go
@@ -25,11 +25,7 @@ func InitializeHandler(ctx context.Context, port ingress.Port, projectID ingress
 	if err != nil {
 		return nil, err
 	}
-	clientClient, err := ingress.NewPubsubDecoupleClient(ctx, client)
-	if err != nil {
-		return nil, err
-	}
-	multiTopicDecoupleSink := ingress.NewMultiTopicDecoupleSink(ctx, readonlyTargets, clientClient)
+	multiTopicDecoupleSink := ingress.NewMultiTopicDecoupleSink(ctx, readonlyTargets, client)
 	ingressReporter, err := metrics.NewIngressReporter(podName, containerName)
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/google/wire v0.4.0
 	github.com/googleapis/gax-go/v2 v2.0.5
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/pkg/errors v0.9.1
 	go.opencensus.io v0.22.4-0.20200604162333-785d8992f1ac
 	go.opentelemetry.io/otel v0.3.0 // indirect
 	go.uber.org/multierr v1.5.0

--- a/pkg/broker/ingress/handler.go
+++ b/pkg/broker/ingress/handler.go
@@ -62,7 +62,6 @@ var HandlerSet wire.ProviderSet = wire.NewSet(
 	NewMultiTopicDecoupleSink,
 	wire.Bind(new(DecoupleSink), new(*multiTopicDecoupleSink)),
 	NewPubsubClient,
-	NewPubsubDecoupleClient,
 	metrics.NewIngressReporter,
 )
 

--- a/pkg/broker/ingress/multi_topic_decouple_sink.go
+++ b/pkg/broker/ingress/multi_topic_decouple_sink.go
@@ -43,7 +43,8 @@ func NewMultiTopicDecoupleSink(ctx context.Context, brokerConfig config.Readonly
 		logger:       logging.FromContext(ctx),
 		pubsub:       client,
 		brokerConfig: brokerConfig,
-		topics:       make(map[types.NamespacedName]*pubsub.Topic),
+		// TODO(#1118): remove Topic when broker config is removed
+		topics: make(map[types.NamespacedName]*pubsub.Topic),
 	}
 }
 

--- a/pkg/broker/ingress/multi_topic_decouple_sink.go
+++ b/pkg/broker/ingress/multi_topic_decouple_sink.go
@@ -109,10 +109,9 @@ func (m *multiTopicDecoupleSink) updateTopicForBroker(broker types.NamespacedNam
 		if topic.ID() == topicID {
 			// Topic already updated.
 			return topic, nil
-		} else {
-			// Stop old topic.
-			m.topics[broker].Stop()
 		}
+		// Stop old topic.
+		m.topics[broker].Stop()
 	}
 	topic := m.pubsub.Topic(topicID)
 	m.topics[broker] = topic

--- a/pkg/broker/ingress/multi_topic_decouple_sink.go
+++ b/pkg/broker/ingress/multi_topic_decouple_sink.go
@@ -19,11 +19,17 @@ package ingress
 import (
 	"context"
 	"fmt"
+	"sync"
 
+	"cloud.google.com/go/pubsub"
+	"go.opencensus.io/trace"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
 
+	cepubsub "github.com/cloudevents/sdk-go/protocol/pubsub/v2"
 	cev2 "github.com/cloudevents/sdk-go/v2"
-	cecontext "github.com/cloudevents/sdk-go/v2/context"
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/extensions"
 	"github.com/cloudevents/sdk-go/v2/protocol"
 	"github.com/google/knative-gcp/pkg/broker/config"
 	"knative.dev/eventing/pkg/logging"
@@ -32,19 +38,23 @@ import (
 const projectEnvKey = "PROJECT_ID"
 
 // NewMultiTopicDecoupleSink creates a new multiTopicDecoupleSink.
-func NewMultiTopicDecoupleSink(ctx context.Context, brokerConfig config.ReadonlyTargets, client cev2.Client) *multiTopicDecoupleSink {
+func NewMultiTopicDecoupleSink(ctx context.Context, brokerConfig config.ReadonlyTargets, client *pubsub.Client) *multiTopicDecoupleSink {
 	return &multiTopicDecoupleSink{
 		logger:       logging.FromContext(ctx),
-		client:       client,
+		pubsub:       client,
 		brokerConfig: brokerConfig,
+		topics:       make(map[types.NamespacedName]*pubsub.Topic),
 	}
 }
 
 // multiTopicDecoupleSink implements DecoupleSink and routes events to pubsub topics corresponding
 // to the broker to which the events are sent.
 type multiTopicDecoupleSink struct {
-	// client talks to pubsub.
-	client cev2.Client
+	// pubsub talks to pubsub.
+	pubsub *pubsub.Client
+	// map from brokers to topics
+	topics    map[types.NamespacedName]*pubsub.Topic
+	topicsMut sync.RWMutex
 	// brokerConfig holds configurations for all brokers. It's a view of a configmap populated by
 	// the broker controller.
 	brokerConfig config.ReadonlyTargets
@@ -53,31 +63,85 @@ type multiTopicDecoupleSink struct {
 
 // Send sends incoming event to its corresponding pubsub topic based on which broker it belongs to.
 func (m *multiTopicDecoupleSink) Send(ctx context.Context, ns, broker string, event cev2.Event) protocol.Result {
-	topic, err := m.getTopicForBroker(ns, broker)
+	topic, err := m.getTopicForBroker(types.NamespacedName{Namespace: ns, Name: broker})
 	if err != nil {
 		return err
 	}
-	ctx = cecontext.WithTopic(ctx, topic)
-	return m.client.Send(ctx, event)
+
+	dt := extensions.FromSpanContext(trace.FromContext(ctx).SpanContext())
+	msg := new(pubsub.Message)
+	if err := cepubsub.WritePubSubMessage(ctx, binding.ToMessage(&event), msg, dt.WriteTransformer()); err != nil {
+		return err
+	}
+
+	_, err = topic.Publish(ctx, msg).Get(ctx)
+	return err
 }
 
 // getTopicForBroker finds the corresponding decouple topic for the broker from the mounted broker configmap volume.
-func (m *multiTopicDecoupleSink) getTopicForBroker(ns, broker string) (string, error) {
-	brokerConfig, ok := m.brokerConfig.GetBroker(ns, broker)
+func (m *multiTopicDecoupleSink) getTopicForBroker(broker types.NamespacedName) (*pubsub.Topic, error) {
+	topicID, err := m.getTopicIDForBroker(broker)
+	if err != nil {
+		return nil, err
+	}
+
+	if topic, ok := m.getExistingTopic(broker); ok {
+		// Check that the broker's topic ID hasn't changed.
+		if topic.ID() == topicID {
+			return topic, nil
+		}
+	}
+
+	// Topic needs to be created or updated.
+	return m.updateTopicForBroker(broker)
+}
+
+func (m *multiTopicDecoupleSink) updateTopicForBroker(broker types.NamespacedName) (*pubsub.Topic, error) {
+	m.topicsMut.Lock()
+	defer m.topicsMut.Unlock()
+	// Fetch latest decouple topic ID under lock.
+	topicID, err := m.getTopicIDForBroker(broker)
+	if err != nil {
+		return nil, err
+	}
+
+	if topic, ok := m.topics[broker]; ok {
+		if topic.ID() == topicID {
+			// Topic already updated.
+			return topic, nil
+		} else {
+			// Stop old topic.
+			m.topics[broker].Stop()
+		}
+	}
+	topic := m.pubsub.Topic(topicID)
+	m.topics[broker] = topic
+	return topic, nil
+}
+
+func (m *multiTopicDecoupleSink) getTopicIDForBroker(broker types.NamespacedName) (string, error) {
+	brokerConfig, ok := m.brokerConfig.GetBroker(broker.Namespace, broker.Name)
 	if !ok {
 		// There is an propagation delay between the controller reconciles the broker config and
 		// the config being pushed to the configmap volume in the ingress pod. So sometimes we return
 		// an error even if the request is valid.
-		m.logger.Warn("config is not found for", zap.Any("ns", ns), zap.Any("broker", broker))
-		return "", fmt.Errorf("%q/%q: %w", ns, broker, ErrNotFound)
+		m.logger.Warn("config is not found for", zap.String("broker", broker.String()))
+		return "", fmt.Errorf("%q: %w", broker, ErrNotFound)
 	}
 	if brokerConfig.State != config.State_READY {
-		m.logger.Debug("broker is not ready", zap.Any("ns", ns), zap.Any("broker", broker))
-		return "", fmt.Errorf("%q/%q: %w", ns, broker, ErrNotReady)
+		m.logger.Debug("broker is not ready", zap.Any("ns", broker.Namespace), zap.Any("broker", broker))
+		return "", fmt.Errorf("%q: %w", broker, ErrNotReady)
 	}
 	if brokerConfig.DecoupleQueue == nil || brokerConfig.DecoupleQueue.Topic == "" {
 		m.logger.Error("DecoupleQueue or topic missing for broker, this should NOT happen.", zap.Any("brokerConfig", brokerConfig))
-		return "", fmt.Errorf("decouple queue of %q/%q: %w", ns, broker, ErrIncomplete)
+		return "", fmt.Errorf("decouple queue of %q: %w", broker, ErrIncomplete)
 	}
 	return brokerConfig.DecoupleQueue.Topic, nil
+}
+
+func (m *multiTopicDecoupleSink) getExistingTopic(broker types.NamespacedName) (*pubsub.Topic, bool) {
+	m.topicsMut.RLock()
+	defer m.topicsMut.RUnlock()
+	topic, ok := m.topics[broker]
+	return topic, ok
 }

--- a/pkg/broker/ingress/multi_topic_decouple_sink_test.go
+++ b/pkg/broker/ingress/multi_topic_decouple_sink_test.go
@@ -18,12 +18,16 @@ package ingress
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/pstest"
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 
+	cepubsub "github.com/cloudevents/sdk-go/protocol/pubsub/v2"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/client/test"
 	cecontext "github.com/cloudevents/sdk-go/v2/context"
 	"github.com/cloudevents/sdk-go/v2/event"
@@ -31,17 +35,15 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/knative-gcp/pkg/broker/config"
 	"github.com/google/knative-gcp/pkg/broker/config/memory"
-	"knative.dev/pkg/logging"
 	logtest "knative.dev/pkg/logging/testing"
 )
 
 func TestMultiTopicDecoupleSink(t *testing.T) {
 	type brokerTestCase struct {
-		ns          string
-		broker      string
-		topic       string
-		clientErrFn func(client *fakePubsubClient)
-		wantErr     bool
+		ns      string
+		broker  string
+		topic   string
+		wantErr bool
 	}
 	tests := []struct {
 		name         string
@@ -81,23 +83,6 @@ func TestMultiTopicDecoupleSink(t *testing.T) {
 					ns:     "test_ns_2",
 					broker: "test_broker_2",
 					topic:  "test_topic_2",
-				},
-			},
-		},
-		{
-			name: "client returns error",
-			brokerConfig: &config.TargetsConfig{
-				Brokers: map[string]*config.Broker{
-					"test_ns_1/test_broker_1": {State: config.State_READY, DecoupleQueue: &config.Queue{Topic: "test_topic_1"}},
-				},
-			},
-			cases: []brokerTestCase{
-				{
-					ns:          "test_ns_1",
-					broker:      "test_broker_1",
-					topic:       "test_topic_1",
-					clientErrFn: injectErr("test_topic_1", errors.New("inject error")),
-					wantErr:     true,
 				},
 			},
 		},
@@ -164,18 +149,30 @@ func TestMultiTopicDecoupleSink(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fakeClient := newFakePubsubClient(t)
+			ctx := logtest.TestContextWithLogger(t)
+			psSrv := pstest.NewServer()
+			defer psSrv.Close()
+			psClient := createPubsubClient(ctx, t, psSrv)
 			brokerConfig := memory.NewTargets(tt.brokerConfig)
-			for _, testCase := range tt.cases {
-				ctx := logging.WithLogger(context.Background(), logtest.TestLogger(t))
-				if testCase.clientErrFn != nil {
-					testCase.clientErrFn(fakeClient)
+			for i, testCase := range tt.cases {
+				topic := psClient.Topic(testCase.topic)
+				if exists, err := topic.Exists(ctx); err != nil {
+					t.Fatal(err)
+				} else if !exists {
+					if topic, err = psClient.CreateTopic(ctx, testCase.topic); err != nil {
+						t.Fatal(err)
+					}
 				}
-				sink := NewMultiTopicDecoupleSink(ctx, brokerConfig, fakeClient)
+				subscription, err := psClient.CreateSubscription(
+					ctx, fmt.Sprintf("test-sub-%d", i), pubsub.SubscriptionConfig{Topic: topic})
+				if err != nil {
+					t.Fatal(err)
+				}
 
+				sink := NewMultiTopicDecoupleSink(ctx, brokerConfig, psClient)
 				// Send events
 				event := createTestEvent(uuid.New().String())
-				err := sink.Send(context.Background(), testCase.ns, testCase.broker, *event)
+				err = sink.Send(context.Background(), testCase.ns, testCase.broker, *event)
 
 				// Verify results.
 				if testCase.wantErr && err == nil {
@@ -185,9 +182,23 @@ func TestMultiTopicDecoupleSink(t *testing.T) {
 					t.Fatalf("Unexpected error: %v", err)
 				}
 				if !testCase.wantErr {
-					got := <-fakeClient.topics[testCase.topic]
-					if dif := cmp.Diff(*event, got); dif != "" {
-						t.Errorf("Output event doesn't match input, dif: %v", dif)
+					rctx, cancel := context.WithCancel(ctx)
+					msgCh := make(chan *pubsub.Message, 1)
+					subscription.Receive(rctx,
+						func(ctx context.Context, m *pubsub.Message) {
+							select {
+							case msgCh <- m:
+								cancel()
+							case <-ctx.Done():
+							}
+							m.Ack()
+						},
+					)
+					msg := <-msgCh
+					if got, err := binding.ToEvent(ctx, cepubsub.NewMessage(msg)); err != nil {
+						t.Error(err)
+					} else if diff := cmp.Diff(event, got); diff != "" {
+						t.Errorf("Output event doesn't match input, diff: %v", diff)
 					}
 				}
 			}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -275,7 +275,6 @@ github.com/openzipkin/zipkin-go/propagation
 github.com/openzipkin/zipkin-go/reporter
 github.com/openzipkin/zipkin-go/reporter/http
 # github.com/pkg/errors v0.9.1 => github.com/pkg/errors v0.8.1
-## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib


### PR DESCRIPTION
## Proposed Changes

- Directly use pubsub client and bindings in ingress handler. Removes unnecessary overhead and allows for better control over the metrics and trace spans that get emitted. Results in a ~10% performance improvement for small events. For very large events the reduction in overhead is negligible.

## Benchmark Results
```
name                            old time/op  new time/op  delta
IngressHandler/0_bytes-16       11.0µs ± 3%   9.7µs ± 2%  -11.63%  (p=0.000 n=9+10)
IngressHandler/1000_bytes-16    11.2µs ± 1%  10.1µs ± 2%   -9.54%  (p=0.000 n=10+10)
IngressHandler/100000_bytes-16   122µs ± 5%   123µs ± 4%     ~     (p=0.798 n=8+8)
```


