### PR TITLE
moved channel storage version to v1beta1

### DIFF
--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -61,10 +61,7 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      # Note that the storage version here _must_ match StoredChannelVersion in
-      # pkg/apis/messaging/internal/constants.go. If the storage version is changing here, update
-      # the constant in code too.
-      storage: true
+      storage: false
       schema:
         openAPIV3Schema:
           type: object
@@ -201,7 +198,10 @@ spec:
                   type: string
     - name: v1beta1
       served: true
-      storage: false
+      # Note that the storage version here _must_ match StoredChannelVersion in
+      # pkg/apis/messaging/internal/constants.go. If the storage version is changing here, update
+      # the constant in code too.
+      storage: true
       schema:
         openAPIV3Schema:
           type: object

--- a/docs/examples/channel/subscription.yaml
+++ b/docs/examples/channel/subscription.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: messaging.knative.dev/v1beta1
 kind: Subscription
 metadata:
   name: demo

--- a/pkg/apis/messaging/internal/constants.go
+++ b/pkg/apis/messaging/internal/constants.go
@@ -17,4 +17,4 @@ limitations under the License.
 package internal
 
 // StoredChannelVersion is the version of the Channel that is stored in the API server.
-const StoredChannelVersion = "v1alpha1"
+const StoredChannelVersion = "v1beta1"

--- a/pkg/apis/messaging/v1alpha1/channel_defaults_test.go
+++ b/pkg/apis/messaging/v1alpha1/channel_defaults_test.go
@@ -32,7 +32,7 @@ func TestChannelDefaults(t *testing.T) {
 	want := &Channel{
 		ObjectMeta: v1.ObjectMeta{
 			Annotations: map[string]string{
-				"messaging.knative.dev/subscribable": "v1alpha1",
+				"messaging.knative.dev/subscribable": "v1beta1",
 				duckv1alpha1.ClusterNameAnnotation:   testingMetadataClient.FakeClusterName,
 			},
 		},

--- a/pkg/apis/messaging/v1beta1/channel_defaults_test.go
+++ b/pkg/apis/messaging/v1beta1/channel_defaults_test.go
@@ -35,7 +35,7 @@ func TestChannelDefaults(t *testing.T) {
 			want: Channel{
 				ObjectMeta: v1.ObjectMeta{
 					Annotations: map[string]string{
-						"messaging.knative.dev/subscribable": "v1alpha1",
+						"messaging.knative.dev/subscribable": "v1beta1",
 					},
 				},
 				Spec: ChannelSpec{


### PR DESCRIPTION
Fixes #

## Proposed Changes

- - 🧽 moved channel storage version to v1beta1

**Release Note**
moved channel storage version to v1beta1
