### PR TITLE
Increase the time out for metrics assertions in an attempt to deflake…

### DIFF
--- a/test/e2e/lib/metrics/stackdriver.go
+++ b/test/e2e/lib/metrics/stackdriver.go
@@ -103,7 +103,7 @@ func CheckAssertions(t *testing.T, assertions ...Assertion) {
 		t.Error(err)
 		return
 	}
-	timeout := time.After(5 * time.Minute)
+	timeout := time.After(8 * time.Minute)
 	for {
 		errors := make([]error, 0, len(assertions))
 		for _, assertion := range assertions {
@@ -121,7 +121,8 @@ func CheckAssertions(t *testing.T, assertions ...Assertion) {
 				t.Error(err)
 			}
 			return
-		case <-time.After(5 * time.Second):
+		default:
+			time.Sleep(5 * time.Second)
 		}
 	}
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Increase the time out for metrics assertions in an attempt to deflake the test.

We see the following style flakes in roughly equal proportion:

1. 
```
    TestGCPBrokerMetrics: test_gcp_broker.go:68: unexpected metric "knative.dev/eventing/trigger/event_count" count (-want, +got) =   map[string]int64{
        - 	"resp-broker-gcp-vumhovdj":    1,
        - 	"trigger-broker-gcp-vumhovdj": 1,
          }
```
2. 
```
    TestGCPBrokerMetrics: test_gcp_broker.go:68: unexpected broker metric count (-want, +got) =   map[string]int64{
        - 	"e2e-dummy-event-type":              1,
        + 	"e2e-dummy-event-type":              0,
        - 	"e2e-testing-resp-event-type-dummy": 1,
        + 	"e2e-testing-resp-event-type-dummy": 0,
          }
```

We hope that this change helps resolve the first. 
<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```