### PR TITLE
Use CloudEvents 1.0 in docs

### DIFF
--- a/docs/examples/gcpbroker/README.md
+++ b/docs/examples/gcpbroker/README.md
@@ -79,7 +79,7 @@ To show the various types of events you can send, you will make three requests:
    curl -v "http://default-brokercell-ingress.cloud-run-events.svc.cluster.local/cloud-run-events-example/test-broker" \
      -X POST \
      -H "Ce-Id: say-hello" \
-     -H "Ce-Specversion: 0.3" \
+     -H "Ce-Specversion: 1.0" \
      -H "Ce-Type: greeting" \
      -H "Ce-Source: not-sendoff" \
      -H "Content-Type: application/json" \
@@ -105,7 +105,7 @@ To show the various types of events you can send, you will make three requests:
    curl -v "http://default-brokercell-ingress.cloud-run-events.svc.cluster.local/cloud-run-events-example/test-broker" \
      -X POST \
      -H "Ce-Id: say-goodbye" \
-     -H "Ce-Specversion: 0.3" \
+     -H "Ce-Specversion: 1.0" \
      -H "Ce-Type: not-greeting" \
      -H "Ce-Source: sendoff" \
      -H "Content-Type: application/json" \
@@ -132,7 +132,7 @@ To show the various types of events you can send, you will make three requests:
    curl -v "http://default-brokercell-ingress.cloud-run-events.svc.cluster.local/cloud-run-events-example/test-broker" \
      -X POST \
      -H "Ce-Id: say-hello-goodbye" \
-     -H "Ce-Specversion: 0.3" \
+     -H "Ce-Specversion: 1.0" \
      -H "Ce-Type: greeting" \
      -H "Ce-Source: sendoff" \
      -H "Content-Type: application/json" \
@@ -177,7 +177,7 @@ After sending events, verify that your events were received by the appropriate
    ☁️  cloudevents.Event
    Validation: valid
    Context Attributes,
-     specversion: 0.3
+     specversion: 1.0
      type: greeting
      source: not-sendoff
      id: say-hello
@@ -192,7 +192,7 @@ After sending events, verify that your events were received by the appropriate
    ☁️  cloudevents.Event
    Validation: valid
    Context Attributes,
-     specversion: 0.3
+     specversion: 1.0
      type: greeting
      source: sendoff
      id: say-hello-goodbye
@@ -220,7 +220,7 @@ After sending events, verify that your events were received by the appropriate
    ☁️  cloudevents.Event
    Validation: valid
    Context Attributes,
-      specversion: 0.3
+      specversion: 1.0
       type: not-greeting
       source: sendoff
       id: say-goodbye
@@ -235,7 +235,7 @@ After sending events, verify that your events were received by the appropriate
     ☁️  cloudevents.Event
     Validation: valid
     Context Attributes,
-      specversion: 0.3
+      specversion: 1.0
       type: greeting
       source: sendoff
       id: say-hello-goodbye
@@ -277,7 +277,7 @@ consumers are back.
    curl -v "http://default-brokercell-ingress.cloud-run-events.svc.cluster.local/cloud-run-events-example/test-broker" \
      -X POST \
      -H "Ce-Id: say-hello-goodbye" \
-     -H "Ce-Specversion: 0.3" \
+     -H "Ce-Specversion: 1.0" \
      -H "Ce-Type: greeting" \
      -H "Ce-Source: sendoff" \
      -H "Content-Type: application/json" \

--- a/docs/spec/pubsub-protocol-binding.md
+++ b/docs/spec/pubsub-protocol-binding.md
@@ -230,7 +230,7 @@ Publish /some-topic
 }
 --- Data ---
 {
-  "specversion": "0.3-wip",
+  "specversion": "1.0",
   "type": "com.example.someevent",
   "time": "2018-04-05T03:56:24Z",
   "id": "1234-1234-1234",


### PR DESCRIPTION
Found a couple references to CloudEvents 0.3 in broker examples and pubsub binding spec. Changed them all to 1.0.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use CloudEvents 1.0 in broker examples and pubsub binding spec
