### PR TITLE
Fix test race by saving the loop variable

### DIFF
--- a/pkg/broker/handler/processors/deliver/processor_test.go
+++ b/pkg/broker/handler/processors/deliver/processor_test.go
@@ -108,6 +108,7 @@ func TestDeliverSuccess(t *testing.T) {
 	}}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			reportertest.ResetDeliveryMetrics()
 			ctx := logtest.TestContextWithLogger(t)


### PR DESCRIPTION
## Proposed Changes

- Fix test race by saving the loop variable.
 
Before this change:

```
go test ./pkg/broker/handler/processors/deliver -race -count 10

==================
WARNING: DATA RACE
Write at 0x00c000ad9db8 by goroutine 79:
  github.com/google/knative-gcp/pkg/broker/handler/processors/deliver.TestDeliverSuccess()
      /Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/processors/deliver/processor_test.go:110 +0x314
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:991 +0x1eb

Previous read at 0x00c000ad9db8 by goroutine 87:
  github.com/google/knative-gcp/pkg/broker/handler/processors/deliver.TestDeliverSuccess.func3.2()
      /Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/processors/deliver/processor_test.go:163 +0x38d

Goroutine 79 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1042 +0x660
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1284 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:991 +0x1eb
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1282 +0x527
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1199 +0x2ff
  main.main()
      _testmain.go:56 +0x223

Goroutine 87 (finished) created at:
  github.com/google/knative-gcp/pkg/broker/handler/processors/deliver.TestDeliverSuccess.func3()
      /Users/harwayne/go/src/github.com/google/knative-gcp/pkg/broker/handler/processors/deliver/processor_test.go:150 +0xbfd
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:991 +0x1eb
==================
--- FAIL: TestDeliverSuccess (4.01s)
    testing.go:906: race detected during execution of test
FAIL
FAIL    github.com/google/knative-gcp/pkg/broker/handler/processors/deliver     160.818s
FAIL
```

---

How I figured out the fix:

The race detector tells us what lines the problematic variables are on, 110 and 163. In particular, it says the variable was written to on line 110. The only variable written to on line 110 is `tc`, so that must be the problem. Once I saw that it was the loop iterator variable that was the problem, I remembered the golang gotcha that that variable is defined outside the loop, not inside. So it is really one variable whose value keeps changing, instead of a new variable on each iteration. So if the goroutine runs after the next iteration begins, it uses the wrong value for `tc`. Therefore, we need to do something to make sure the gorroutines use the correct value of `tc`.

I took the easy way out and shadowed the loop iteration variable inside the loop. The variable defined inside the loop has the lifetime of a single iteration, so won't be overwritten. It shadows the loop iteration variable, so none of the other code had to change. See https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables for other options.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```