### PR TITLE
Fail TestGCPBrokerMetrics test immediately if event cannot be sent

### DIFF
--- a/test/e2e/lib/helpers/broker_event_transformation_test_with_source.go
+++ b/test/e2e/lib/helpers/broker_event_transformation_test_with_source.go
@@ -146,13 +146,11 @@ func BrokerEventTransformationMetricsTestHelper(client *lib.Client, projectID st
 
 	// Check if dummy CloudEvent is sent out.
 	if done := jobDone(client, senderName); !done {
-		client.T.Error("dummy event wasn't sent to broker")
-		client.T.Failed()
+		client.T.Fatal("dummy event wasn't sent to broker")
 	}
 	// Check if resp CloudEvent hits the target Service.
 	if done := jobDone(client, targetName); !done {
-		client.T.Error("resp event didn't hit the target pod")
-		client.T.Failed()
+		client.T.Fatal("resp event didn't hit the target pod")
 	}
 	metrics.CheckAssertions(client.T,
 		lib.BrokerMetricAssertion{


### PR DESCRIPTION
This skips metrics assertions and prevents unrelated broker failures from being conflated with
metrics related failures.
