### PR TITLE
Fix the brokerCell UT to test broker targets config

### DIFF
--- a/pkg/reconciler/brokercell/brokercell_test.go
+++ b/pkg/reconciler/brokercell/brokercell_test.go
@@ -948,6 +948,9 @@ func TestBrokerTargetsReconcileConfig(t *testing.T) {
 		NewTrigger("trigger1", testNS, "broker", WithTriggerSetDefaults),
 		NewTrigger("trigger2", testNS, "broker", WithTriggerSetDefaults))
 	gotMap, err := client.CoreV1().ConfigMaps(testNS).Get(resources.Name(bc.Name, targetsCMName),metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get ConfigMap from client: %v", err)
+	}
 	// compare the ObjectMeta field
 	if diff := cmp.Diff(wantMap.ObjectMeta, gotMap.ObjectMeta); diff != "" {
 		t.Fatalf("Unexpected ObjectMeta in ConfigMap(-want, +got): %s", diff)
@@ -956,10 +959,10 @@ func TestBrokerTargetsReconcileConfig(t *testing.T) {
 	var wantBrokerTargets config.TargetsConfig
 	var gotBrokerTargets config.TargetsConfig
 	if err := proto.Unmarshal(wantMap.BinaryData[targetsCMKey], &wantBrokerTargets); err != nil {
-		t.Fatalf("Failed to deserialize the binary data in configMap: %v", err)
+		t.Fatalf("Failed to deserialize the binary data in ConfigMap: %v", err)
 	}
 	if err := proto.Unmarshal(gotMap.BinaryData[targetsCMKey], &gotBrokerTargets); err != nil {
-		t.Fatalf("Failed to deserialize the binary data in configMap: %v", err)
+		t.Fatalf("Failed to deserialize the binary data in ConfigMap: %v", err)
 	}
 	// compare the broker targets config
 	if diff := cmp.Diff(wantBrokerTargets.String(), gotBrokerTargets.String()); diff != "" {

--- a/pkg/reconciler/brokercell/brokercell_test.go
+++ b/pkg/reconciler/brokercell/brokercell_test.go
@@ -24,25 +24,33 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	hpav2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	clientgotesting "k8s.io/client-go/testing"
 
+	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	intv1alpha1 "github.com/google/knative-gcp/pkg/apis/intevents/v1alpha1"
+	"github.com/google/knative-gcp/pkg/broker/config"
 	bcreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/intevents/v1alpha1/brokercell"
 	"github.com/google/knative-gcp/pkg/reconciler"
 	"github.com/google/knative-gcp/pkg/reconciler/brokercell/testingdata"
 	. "github.com/google/knative-gcp/pkg/reconciler/testing"
+
+	"google.golang.org/protobuf/proto"
 )
 
 const (
 	testNS         = "testnamespace"
 	brokerCellName = "test-brokercell"
+	targetsCMKey  = "targets"
 )
 
 var (
@@ -798,41 +806,6 @@ func TestAllCases(t *testing.T) {
 			},
 		},
 		{
-			Name: "BrokerCell created successfully, broker targets config should be updated with broker and triggers",
-			Key:  testKey,
-			Objects: []runtime.Object{
-				NewBrokerCell(brokerCellName, testNS, WithBrokerCellSetDefaults),
-				NewBroker("broker", testNS, WithBrokerSetDefaults),
-				NewTrigger("trigger1", testNS, "broker", WithTriggerSetDefaults),
-				NewTrigger("trigger2", testNS, "broker", WithTriggerSetDefaults),
-				NewEndpoints(brokerCellName+"-brokercell-ingress", testNS,
-					WithEndpointsAddresses(corev1.EndpointAddress{IP: "127.0.0.1"})),
-				testingdata.IngressDeploymentWithStatus(t),
-				testingdata.IngressServiceWithStatus(t),
-				testingdata.FanoutDeploymentWithStatus(t),
-				testingdata.RetryDeploymentWithStatus(t),
-				testingdata.IngressHPA(t),
-				testingdata.FanoutHPA(t),
-				testingdata.RetryHPA(t),
-			},
-			WantCreates: []runtime.Object{
-				testingdata.Config(t, NewBrokerCell(brokerCellName, testNS, WithBrokerCellSetDefaults),
-					NewBroker("broker", testNS, WithBrokerSetDefaults),
-					NewTrigger("trigger1", testNS, "broker", WithTriggerSetDefaults),
-					NewTrigger("trigger2", testNS, "broker", WithTriggerSetDefaults)),
-			},
-			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
-				{Object: NewBrokerCell(brokerCellName, testNS,
-					WithBrokerCellReady,
-					WithIngressTemplate("http://test-brokercell-brokercell-ingress.testnamespace.svc.cluster.local/{namespace}/{name}"),
-				)},
-			},
-			WantEvents: []string{
-				configmapCreatedEvent,
-				brokerCellReconciledEvent,
-			},
-		},
-		{
 			Name: "googlecloud created BrokerCell shouldn't be gc'ed because there are brokers",
 			Key:  testKey,
 			Objects: []runtime.Object{
@@ -934,4 +907,65 @@ func TestAllCases(t *testing.T) {
 func emptyHPASpec(template *hpav2beta2.HorizontalPodAutoscaler) *hpav2beta2.HorizontalPodAutoscaler {
 	template.Spec = hpav2beta2.HorizontalPodAutoscalerSpec{}
 	return template
+}
+
+// The unit test to test when the brokerCell created successfully, the broker targets config should be updated with broker
+// and trigger. Since the serialization order of the binary data of brokerTargets in the configMap is not guaranteed, we need
+// to deserialization the binary data to a brokerTargets proto to compare, so it should be rewritten without using the tableTest Utility.
+func TestBrokerTargetsReconcileConfig(t *testing.T) {
+	setReconcilerEnv()
+	bc := NewBrokerCell(brokerCellName, testNS, WithBrokerCellSetDefaults)
+	objects:= []runtime.Object{
+		bc,
+		NewBroker("broker", testNS, WithBrokerSetDefaults),
+		NewTrigger("trigger1", testNS, "broker", WithTriggerSetDefaults),
+		NewTrigger("trigger2", testNS, "broker", WithTriggerSetDefaults),
+	}
+	ctx, _ := SetupFakeContext(t)
+	cmw := configmap.NewStaticWatcher()
+	ctx, client := fakekubeclient.With(ctx,)
+	base := reconciler.NewBase(ctx, controllerAgentName, cmw)
+	testingListers := NewListers(objects)
+	ls := listers{
+		brokerLister:     testingListers.GetBrokerLister(),
+		hpaLister:        testingListers.GetHPALister(),
+		triggerLister:    testingListers.GetTriggerLister(),
+		configMapLister:  testingListers.GetConfigMapLister(),
+		serviceLister:    testingListers.GetK8sServiceLister(),
+		endpointsLister:  testingListers.GetEndpointsLister(),
+		deploymentLister: testingListers.GetDeploymentLister(),
+		podLister:        testingListers.GetPodLister(),
+	}
+	r, err := NewReconciler(base, ls)
+	if err != nil {
+		t.Fatalf("Failed to created BrokerCell reconciler: %v", err)
+	}
+	// here we only want to test the functionality of the reconcileConfig that it should create a brokerTargets config successfully
+	r.reconcileConfig(ctx, bc)
+	wantMap := testingdata.Config(t, NewBrokerCell(brokerCellName, testNS, WithBrokerCellSetDefaults),
+		NewBroker("broker", testNS, WithBrokerSetDefaults),
+		NewTrigger("trigger1", testNS, "broker", WithTriggerSetDefaults),
+		NewTrigger("trigger2", testNS, "broker", WithTriggerSetDefaults))
+	mapList, err := client.CoreV1().ConfigMaps(testNS).List(metav1.ListOptions{})
+	if err != nil || len(mapList.Items) != 1 {
+		t.Fatalf("Failed to get configMap: %v", err)
+	}
+	gotMap := mapList.Items[0]
+	// compare the ObjectMeta field
+	if diff := cmp.Diff(wantMap.ObjectMeta, gotMap.ObjectMeta, cmpopts.EquateEmpty()); diff != "" {
+		t.Fatalf("Unexpected ObjectMeta in ConfigMap(-want, +got): %s", diff)
+	}
+	// deserialize the binary data to a broker targets config proto
+	var wantBrokerTargets config.TargetsConfig
+	var gotBrokerTargets config.TargetsConfig
+	if err := proto.Unmarshal(wantMap.BinaryData[targetsCMKey], &wantBrokerTargets); err != nil {
+		t.Fatalf("Failed to deserialize the binary data in configMap: %v", err)
+	}
+	if err := proto.Unmarshal(gotMap.BinaryData[targetsCMKey], &gotBrokerTargets); err != nil {
+		t.Fatalf("Failed to deserialize the binary data in configMap: %v", err)
+	}
+	// compare the broker targets config
+	if diff := cmp.Diff(wantBrokerTargets.String(), gotBrokerTargets.String(), cmpopts.EquateEmpty()); diff != "" {
+		t.Fatalf("Unexpected brokerTargets in ConfigMap(-want, +got): %s", diff)
+	}
 }


### PR DESCRIPTION
Fixes #1326 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🐛  Fix the brokercell UT that when the brokercell creates successfully, the broker target config should be updated with broker and triggers
- Synced with Cong, since this test involves testing the binary data in the configMap, but the binary data are not guaranteed the serialization order, we need to deserialize the binary data back to the broker target config proto, so it should be rewritten to a stand-alone test case without utilizing the tableTest framework.


<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
