### PR TITLE
Deleting storage bucket upon test teardown

### DIFF
--- a/test/e2e/lib/helpers/broker_event_transformation_test_with_source.go
+++ b/test/e2e/lib/helpers/broker_event_transformation_test_with_source.go
@@ -298,6 +298,7 @@ func BrokerEventTransformationTestWithStorageSourceHelper(client *lib.Client, au
 	project := os.Getenv(lib.ProwProjectKey)
 
 	bucketName := lib.MakeBucket(ctx, client.T, project)
+	defer lib.DeleteBucket(ctx, client.T, bucketName)
 	storageName := helpers.AppendRandomString(bucketName + "-storage")
 	targetName := helpers.AppendRandomString(bucketName + "-target")
 	source := v1beta1.CloudStorageSourceEventSource(bucketName)

--- a/test/e2e/lib/storage.go
+++ b/test/e2e/lib/storage.go
@@ -19,15 +19,16 @@ package lib
 import (
 	"context"
 	"fmt"
-	"knative.dev/pkg/test/helpers"
+
 	"testing"
 
 	"cloud.google.com/go/storage"
 	kngcptesting "github.com/google/knative-gcp/pkg/reconciler/testing"
 	"github.com/google/knative-gcp/test/e2e/lib/resources"
 	"google.golang.org/api/iterator"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/test/helpers"
 )
 
 type StorageConfig struct {
@@ -105,7 +106,7 @@ func MakeBucket(ctx context.Context, t *testing.T, project string) string {
 		t.Fatalf("failed to create storage client, %s", err.Error())
 	}
 	it := client.Buckets(ctx, project)
-	// Name should be between -63 characters. https://cloud.google.com/storage/docs/naming-buckets
+	// Name should be between 3-63 characters. https://cloud.google.com/storage/docs/naming-buckets
 	bucketName := helpers.AppendRandomString(fmt.Sprintf("storage-e2e-test-%s", project))
 	// Iterate buckets to check if there has a bucket for e2e test
 	for {
@@ -149,7 +150,7 @@ func DeleteBucket(ctx context.Context, t *testing.T, bucketName string) {
 	}
 
 	// If we fail to delete the bucket, we will fail the test so that users are aware that
-	// we leaked a bucket in project.
+	// we leaked a bucket in the project. If this makes the test flake, then we can revisit and maybe avoid failing.
 	if err := bucket.Delete(ctx); err != nil {
 		t.Errorf("Failed to delete Bucket %s", bucketName)
 	}

--- a/test/e2e/lib/storage.go
+++ b/test/e2e/lib/storage.go
@@ -144,6 +144,7 @@ func DeleteBucket(ctx context.Context, t *testing.T, bucketName string) {
 		// If the bucket was already deleted, we are good
 		if err == storage.ErrBucketNotExist {
 			t.Logf("Bucket %s already deleted", bucketName)
+			return
 		} else {
 			t.Errorf("Failed to fetch attrs of Bucket %s", bucketName)
 		}

--- a/test/e2e/lib/storage.go
+++ b/test/e2e/lib/storage.go
@@ -19,13 +19,14 @@ package lib
 import (
 	"context"
 	"fmt"
+	"knative.dev/pkg/test/helpers"
 	"testing"
 
 	"cloud.google.com/go/storage"
 	kngcptesting "github.com/google/knative-gcp/pkg/reconciler/testing"
 	"github.com/google/knative-gcp/test/e2e/lib/resources"
 	"google.golang.org/api/iterator"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -104,7 +105,8 @@ func MakeBucket(ctx context.Context, t *testing.T, project string) string {
 		t.Fatalf("failed to create storage client, %s", err.Error())
 	}
 	it := client.Buckets(ctx, project)
-	bucketName := "storage-e2e-test-" + project
+	// Name should be between -63 characters. https://cloud.google.com/storage/docs/naming-buckets
+	bucketName := helpers.AppendRandomString(fmt.Sprintf("storage-e2e-test-%s", project))
 	// Iterate buckets to check if there has a bucket for e2e test
 	for {
 		bucketAttrs, err := it.Next()
@@ -125,6 +127,32 @@ func MakeBucket(ctx context.Context, t *testing.T, project string) string {
 		}
 	}
 	return bucketName
+}
+
+func DeleteBucket(ctx context.Context, t *testing.T, bucketName string) {
+	t.Helper()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		t.Fatalf("failed to create storage client, %s", err.Error())
+	}
+	// Load the Bucket.
+	bucket := client.Bucket(bucketName)
+
+	// Check whether bucket exists or not
+	if _, err := bucket.Attrs(ctx); err != nil {
+		// If the bucket was already deleted, we are good
+		if err == storage.ErrBucketNotExist {
+			t.Logf("Bucket %s already deleted", bucketName)
+		} else {
+			t.Errorf("Failed to fetch attrs of Bucket %s", bucketName)
+		}
+	}
+
+	// If we fail to delete the bucket, we will fail the test so that users are aware that
+	// we leaked a bucket in project.
+	if err := bucket.Delete(ctx); err != nil {
+		t.Errorf("Failed to delete Bucket %s", bucketName)
+	}
 }
 
 func getBucketHandle(ctx context.Context, t *testing.T, bucketName, project string) *storage.BucketHandle {

--- a/test/e2e/test_storage.go
+++ b/test/e2e/test_storage.go
@@ -48,6 +48,7 @@ func SmokeCloudStorageSourceTestImpl(t *testing.T, authConfig lib.AuthConfig) {
 	project := os.Getenv(lib.ProwProjectKey)
 
 	bucketName := lib.MakeBucket(ctx, t, project)
+	defer lib.DeleteBucket(ctx, t, bucketName)
 	storageName := helpers.AppendRandomString(bucketName + "-storage")
 	svcName := helpers.AppendRandomString(bucketName + "-event-display")
 
@@ -86,7 +87,7 @@ func SmokeCloudStorageSourceTestImpl(t *testing.T, authConfig lib.AuthConfig) {
 
 	deletedNotificationExists := lib.NotificationExists(t, bucketName, notificationID)
 	if deletedNotificationExists {
-		t.Errorf("Expected notification%q tto get deleted", notificationID)
+		t.Errorf("Expected notification%q to get deleted", notificationID)
 	}
 
 	deletedTopicExists := lib.TopicExists(t, topicID)
@@ -106,6 +107,7 @@ func CloudStorageSourceWithTargetTestImpl(t *testing.T, assertMetrics bool, auth
 	project := os.Getenv(lib.ProwProjectKey)
 
 	bucketName := lib.MakeBucket(ctx, t, project)
+	defer lib.DeleteBucket(ctx, t, bucketName)
 	storageName := helpers.AppendRandomString(bucketName + "-storage")
 	targetName := helpers.AppendRandomString(bucketName + "-target")
 


### PR DESCRIPTION
Fixes https://github.com/google/knative-gcp/issues/1344

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🐛 Creating a new random bucket for each test run, instead of using always the same for the project `storage-e2e-test-<project>`
-  🐛 Deleting the bucket upon test teardown
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
