### PR TITLE
Update event-display image path to support CE 1.0 in GCP broker

### DIFF
--- a/docs/examples/gcpbroker/README.md
+++ b/docs/examples/gcpbroker/README.md
@@ -289,7 +289,7 @@ consumers are back.
 1. Now let's bring the event consumers back:
 
    ```shell
-   kubectl delete -f event-consumers.yaml
+   kubectl apply -f event-consumers.yaml
    ```
 
    Wait a couple of seconds, and you should see the event delivered to the event

--- a/docs/examples/gcpbroker/event-consumers.yaml
+++ b/docs/examples/gcpbroker/event-consumers.yaml
@@ -29,8 +29,8 @@ spec:
       containers:
         - name: event-display
           # Source code: https://github.com/knative/eventing-contrib/tree/master/cmd/event_display
-          image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display:latest
-          
+          image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display:latest
+
 ---
 
 # Service pointing at the previous Deployment. This will be the target for event
@@ -66,7 +66,7 @@ spec:
       containers:
         - name: event-display
           # Source code: https://github.com/knative/eventing-contrib/tree/master/cmd/event_display
-          image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display:latest
+          image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display:latest
 
 ---
 

--- a/docs/install/install-gcp-broker.md
+++ b/docs/install/install-gcp-broker.md
@@ -9,7 +9,7 @@ GCP using [Cloud Pub/Sub](https://cloud.google.com/pubsub).
 Knative Eventing allows different Broker implementations via `BrokerClass`
 annotation. If annotated with
 `"eventing.knative.dev/broker.class": "googlecloud"`, the `Knative-GCP`
-contorller will create a GCP Broker. Compared to the default
+controller will create a GCP Broker. Compared to the default
 [MT Channel Based Broker](https://knative.dev/docs/eventing/broker/mt-channel-based-broker/),
 GCP Broker is more performant and cost-effective by reducing hops and Pub/Sub
 message consumption.
@@ -126,8 +126,8 @@ kubectl create namespace ${NAMESPACE}
    This shows the broker you just created like so:
 
    ```shell
-   NAME          READY   REASON   URL                                                                                             AGE
-   test-broker   True             http://broker-ingress.cloud-run-events.svc.cluster.local/cloud-run-events-example/test-broker   15s
+   NAME          READY   REASON   URL                                                                                                         AGE
+   test-broker   True             http://default-brokercell-ingress.cloud-run-events.svc.cluster.local/cloud-run-events-example/test-broker   15s
    ```
 
 Once the GCP broker is ready, you can use it by sending events to its `URL` and


### PR DESCRIPTION
Fixes #1275 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🐛 Fixed the event-display image path in the gcp broker example to support CE 1.0
- 🐛 Fixed the gcp broker URL in broker installation guide
- 🐛 Fixed some typos 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
