### PR TITLE
Update WI e2e test to add a new permission for tracing

### DIFF
--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -78,7 +78,7 @@ function init_pubsub_service_account() {
   local project_id=${1}
   local pubsub_service_account=${2}
   echo "parameter project_id used when initiating pubsub service account is'${project_id}'"
-  echo "parameter control_plane_service_account used when initiating pubsub service account is'${pubsub_service_account}'"
+  echo "parameter data_plane_service_account used when initiating pubsub service account is'${pubsub_service_account}'"
   # Enable APIs.
   gcloud services enable pubsub.googleapis.com
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -90,13 +90,16 @@ function enable_monitoring(){
   local pubsub_service_account=${2}
 
   echo "parameter project_id used when enabling monitoring is'${project_id}'"
-  echo "parameter control_plane_service_account used when enabling monitoring is'${pubsub_service_account}'"
+  echo "parameter data_plane_service_account used when enabling monitoring is'${pubsub_service_account}'"
   # Enable monitoring
   echo "Enable Monitoring"
   gcloud services enable monitoring
   gcloud projects add-iam-policy-binding "${project_id}" \
       --member=serviceAccount:"${pubsub_service_account}"@"${project_id}".iam.gserviceaccount.com \
-      --role roles/monitoring.editor
+      --role roles/monitoring.metricWriter
+  gcloud projects add-iam-policy-binding "${project_id}" \
+      --member=serviceAccount:"${pubsub_service_account}"@"${project_id}".iam.gserviceaccount.com \
+      --role roles/cloudtrace.agent
 }
 
 function dump_extra_cluster_state() {

--- a/test/e2e-wi-tests.sh
+++ b/test/e2e-wi-tests.sh
@@ -116,7 +116,7 @@ function pubsub_setup() {
   if (( ! IS_PROW )); then
     # Enable monitoring
     gcloud services enable monitoring
-    echo "Set up ServiceAccount for Pub/Sub Admin"
+    echo "Set up ServiceAccount for Pub/Sub Editor"
     init_pubsub_service_account "${E2E_PROJECT_ID}" "${PUBSUB_SERVICE_ACCOUNT_NON_PROW}"
     enable_monitoring "${E2E_PROJECT_ID}" "${PUBSUB_SERVICE_ACCOUNT_NON_PROW}"
   fi

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -67,14 +67,21 @@ There are two ways to set up authentication mechanism.
 1.  (Optional) Note that if you plan on running metrics-related E2E tests using
     the StackDriver backend, you need to give your
     [Service Account](../../docs/install/pubsub-service-account.md) the
-    `Monitoring Editor` role on your Google Cloud project:
+    `monitoring.metricWriter` role on your Google Cloud project:
 
     ```shell
     gcloud projects add-iam-policy-binding $PROJECT_ID \
-      --member=serviceAccount:cloudrunevents-pullsub@$PROJECT_ID.iam.gserviceaccount.com \
-      --role roles/monitoring.editor
+      --member=serviceAccount:${your_service_account}@$PROJECT_ID.iam.gserviceaccount.com \
+      --role roles/monitoring.metricWriter
     ```
-
+    If you also plan on running tracing-related E2E tests using
+        the StackDriver backend, your [Service Account](../../docs/install/pubsub-service-account.md)
+    needs additional `cloudtrace.agent` role:
+    ```shell
+    gcloud projects add-iam-policy-binding $$PROJECT_ID \
+      --member=serviceAccount:"${your_service_account}"@$PROJECT_ID.iam.gserviceaccount.com \
+      --role roles/cloudtrace.agent
+    ```
 1.  (Optional) Note that if plan on running tracing-related E2E tests using the
     Zipkin backend, you need to install
     [zipkin-in-mem](https://github.com/knative/serving/tree/master/config/monitoring/tracing/zipkin-in-mem)


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

After tested locally:
- Update non-prow wi e2e test for additional `cloudtrace.agent` role to run tracing test.
- Changed `monitoring.Editor` role to `monitoring.metricWriter` role, for smaller permissions needed.
- Update e2e test docs
- Fix some comments.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
