### PR TITLE
Update hack scripts to remove outdated curl commands & key creation

### DIFF
--- a/hack/init_cloud_storage_source.sh
+++ b/hack/init_cloud_storage_source.sh
@@ -23,16 +23,7 @@ set -euo pipefail
 
 source $(dirname "$0")/lib.sh
 
-readonly PUBSUB_SERVICE_ACCOUNT_KEY_TEMP="$(mktemp)"
-
 PROJECT_ID=${1:-$(gcloud config get-value project)}
 echo "PROJECT_ID used when init_cloud_storage_source is'${PROJECT_ID}'"
 
-# Download a JSON key for the service account.
-gcloud iam service-accounts keys create "${PUBSUB_SERVICE_ACCOUNT_KEY_TEMP}" \
-  --iam-account="${PUBSUB_SERVICE_ACCOUNT}"@"${PROJECT_ID}".iam.gserviceaccount.com
-
-storage_admin_set_up "${PROJECT_ID}" "${PUBSUB_SERVICE_ACCOUNT}" "${PUBSUB_SERVICE_ACCOUNT_KEY_TEMP}"
-
-# Remove the tmp file.
-rm "${PUBSUB_SERVICE_ACCOUNT_KEY_TEMP}"
+storage_admin_set_up "${PROJECT_ID}" "${PUBSUB_SERVICE_ACCOUNT}"

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -162,7 +162,10 @@ function storage_admin_set_up() {
     --member=serviceAccount:"${pubsub_service_account}"@"${project_id}".iam.gserviceaccount.com \
     --role roles/storage.admin
 
-  # Get service account credentials from: https://cloud.google.com/storage/docs/json_api/v1/projects/serviceAccount/get/
+  # We assume the service account's name is in the form '<project-number>@gs-project-accounts.iam.gserviceaccount.com',
+  # because it has been for all projects we've encountered. However, nothing requires this
+  # format. To get the actual email, use this API:
+  # https://cloud.google.com/storage/docs/json_api/v1/projects/serviceAccount/get/
   local project_number="$(gcloud projects describe ${project_id} --format="value(projectNumber)")"
   gcloud projects add-iam-policy-binding "${project_id}" \
     --member="serviceAccount:service-${project_number}@gs-project-accounts.iam.gserviceaccount.com" \

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -152,7 +152,6 @@ function storage_admin_set_up() {
   echo "Update ServiceAccount for Storage Admin"
   local project_id=${1}
   local pubsub_service_account=${2}
-  local pubsub_service_account_key_temp=${3}
 
   echo "parameter project_id used when setting up storage admin is'${project_id}'"
   echo "parameter pubsub_service_account used when setting up storage admin is'${pubsub_service_account}'"
@@ -163,8 +162,7 @@ function storage_admin_set_up() {
     --member=serviceAccount:"${pubsub_service_account}"@"${project_id}".iam.gserviceaccount.com \
     --role roles/storage.admin
 
-  curl -s -X GET -H "Authorization: Bearer \`GOOGLE_APPLICATION_CREDENTIALS=${pubsub_service_account_key_temp} gcloud auth application-default print-access-token\`" \
-    "https://www.googleapis.com/storage/v1/projects/${project_id}/serviceAccount"
+  # Get service account credentials from: https://cloud.google.com/storage/docs/json_api/v1/projects/serviceAccount/get/
   local project_number="$(gcloud projects describe ${project_id} --format="value(projectNumber)")"
   gcloud projects add-iam-policy-binding "${project_id}" \
     --member="serviceAccount:service-${project_number}@gs-project-accounts.iam.gserviceaccount.com" \


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Remove the outdated curl command which was used to get the service account credentials
- Remove the pubsub_service_account_key_temp which was only used by the curl command

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->
