### PR TITLE
Unskip TestGCPBrokerMetrics in WI mode

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -326,9 +326,6 @@ func TestGCPBroker(t *testing.T) {
 
 // TestGCPBrokerMetrics tests we can knock a Knative Service from a GCP broker and the GCP Broker correctly reports its metrics to StackDriver.
 func TestGCPBrokerMetrics(t *testing.T) {
-	if authConfig.WorkloadIdentity {
-		t.Skip("Skip metric test in Workload Identity mode for issue: https://github.com/google/knative-gcp/issues/1346")
-	}
 	cancel := logstream.Start(t)
 	defer cancel()
 	GCPBrokerMetricsTestImpl(t, authConfig)


### PR DESCRIPTION
Flakiness should have been fixed by https://github.com/census-instrumentation/opencensus-go/pull/1220. Fixes #1346.