### PR TITLE
fixed EventsAPIVersion and IntEventsAPIVersion to v1beta1 in e2e

### DIFF
--- a/test/e2e/lib/resources/constants.go
+++ b/test/e2e/lib/resources/constants.go
@@ -23,8 +23,8 @@ const (
 	BatchAPIVersion            = "batch/v1"
 	MessagingAPIVersion        = "messaging.cloud.google.com/v1alpha1"
 	MessagingV1beta1APIVersion = "messaging.cloud.google.com/v1beta1"
-	EventsAPIVersion           = "events.cloud.google.com/v1alpha1"
-	IntEventsAPIVersion        = "internal.events.cloud.google.com/v1alpha1"
+	EventsAPIVersion           = "events.cloud.google.com/v1beta1"
+	IntEventsAPIVersion        = "internal.events.cloud.google.com/v1beta1"
 	ServingAPIVersion          = "serving.knative.dev/v1"
 )
 


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🐛 Change EventsAPIVersion and IntEventsAPIVersion from v1alpha1 to v1beta1