### PR TITLE
Verify no custom metrics are emitted at the end of all tests

### DIFF
--- a/test/e2e/lib/pubsub.go
+++ b/test/e2e/lib/pubsub.go
@@ -96,12 +96,10 @@ func AssertMetrics(t *testing.T, client *Client, topicName, psName string) {
 
 	actualCount, err := client.StackDriverEventCountMetricFor(client.Namespace, projectID, filter)
 	if err != nil {
-		t.Errorf("failed to get stackdriver event count metric: %v", err)
-		t.Fail()
+		t.Fatalf("failed to get stackdriver event count metric: %v", err)
 	}
 	expectedCount := int64(1)
-	if *actualCount != expectedCount {
+	if actualCount != expectedCount {
 		t.Errorf("Actual count different than expected count, actual: %d, expected: %d", actualCount, expectedCount)
-		t.Fail()
 	}
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -19,26 +19,39 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
+	"fmt"
 	"log"
 	"os"
 	"testing"
+	"time"
 
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
+	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/google/knative-gcp/test"
 	"github.com/google/knative-gcp/test/e2e/lib"
+	"github.com/google/knative-gcp/test/e2e/lib/metrics"
 	"github.com/google/knative-gcp/test/e2e/lib/resources"
+	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	eventingtest "knative.dev/eventing/test"
 	eventingtestlib "knative.dev/eventing/test/lib"
 	"knative.dev/pkg/test/zipkin"
 )
 
-var channelTestRunner eventingtestlib.ComponentsTestRunner
-var authConfig lib.AuthConfig
+const knativeCustomMetricPrefix = "custom.googleapis.com/knative.dev/"
+
+var (
+	channelTestRunner eventingtestlib.ComponentsTestRunner
+	authConfig        lib.AuthConfig
+	projectID         string
+)
 
 func TestMain(m *testing.M) {
 	os.Exit(func() int {
 		test.InitializeFlags()
 		eventingtest.InitializeEventingFlags()
+		projectID = os.Getenv(lib.ProwProjectKey)
 		channelTestRunner = eventingtestlib.ComponentsTestRunner{
 			// ChannelFeatureMap saves the channel-features mapping.
 			// Each pair means the channel support the given list of features.
@@ -72,6 +85,71 @@ func TestMain(m *testing.M) {
 		// tests that need the tracing in place.
 		defer zipkin.CleanupZipkinTracingSetup(log.Printf)
 
-		return m.Run()
+		if code := m.Run(); code > 0 {
+			return code
+		}
+
+		// The knative/pkg base controller emits custom metrics, plus some other components can
+		// potentially emit custom metrics. By default custom metrics should not be published to
+		// Stackdriver.
+		// After running all tests, we verify that no custom metrics have been emitted in the past
+		// 30 min to cover roughly how long the e2e tests run.
+		return verifyNoCustomMetrics(projectID, time.Duration(-30)*time.Minute)
 	}())
+}
+
+// Return code meaning
+// 0: success, no custom metrics found
+// 1: failure, found custom metrics
+// 2: failure, unable to verify custom metrics
+func verifyNoCustomMetrics(projectID string, duration time.Duration) int {
+	client, err := monitoring.NewMetricClient(context.TODO())
+	if err != nil {
+		fmt.Printf("Failed to create metrics client: %v\n", err)
+		return 2
+	}
+	defer client.Close()
+	// Get the metric descriptors with custom metric prefix.
+	req := &monitoringpb.ListMetricDescriptorsRequest{
+		Name:   fmt.Sprintf("projects/%s", projectID),
+		Filter: fmt.Sprintf(`metric.type=starts_with("%s")`, knativeCustomMetricPrefix),
+	}
+	descriptors, err := metrics.ListMetricDescriptors(context.TODO(), client, req)
+	if err != nil {
+		fmt.Printf("Failed to list custom metrics: %v\n", err)
+		return 2
+	}
+
+	// Check no data points of custom metrics in the past duration.
+	fmt.Printf("Got %d custom metric definitions with prefix %s\n", len(descriptors), knativeCustomMetricPrefix)
+	for _, d := range descriptors {
+		if code := verifyNoPoints(client, projectID, d.GetType(), duration); code > 0 {
+			return code
+		}
+	}
+	return 0
+}
+
+// verifyNoPoints verifies no metrics data points are found for the given metric type.
+func verifyNoPoints(client *monitoring.MetricClient, projectID string, mt string, duration time.Duration) int {
+	req := &monitoringpb.ListTimeSeriesRequest{
+		Name:   fmt.Sprintf("projects/%s", projectID),
+		Filter: fmt.Sprintf(`metric.type="%s"`, mt),
+		Interval: &monitoringpb.TimeInterval{
+			StartTime: &timestamp.Timestamp{Seconds: time.Now().Add(duration).Unix()},
+			EndTime:   &timestamp.Timestamp{Seconds: time.Now().Unix()},
+		},
+	}
+	tss, err := metrics.ListTimeSeries(context.TODO(), client, req)
+	if err != nil {
+		fmt.Printf("Failed to fetch data points of custom metric %s: %s\n", mt, err)
+		return 2
+	}
+	for _, ts := range tss {
+		if len(ts.GetPoints()) > 0 {
+			fmt.Printf("Found data points of custom metric %s, which should be disabled", mt)
+			return 1
+		}
+	}
+	return 0
 }

--- a/test/e2e/test_storage.go
+++ b/test/e2e/test_storage.go
@@ -188,13 +188,11 @@ func CloudStorageSourceWithTargetTestImpl(t *testing.T, assertMetrics bool, auth
 
 		actualCount, err := client.StackDriverEventCountMetricFor(client.Namespace, projectID, filter)
 		if err != nil {
-			t.Errorf("failed to get stackdriver event count metric: %v", err)
-			t.Fail()
+			t.Fatalf("failed to get stackdriver event count metric: %v", err)
 		}
 		expectedCount := int64(1)
-		if *actualCount != expectedCount {
+		if actualCount != expectedCount {
 			t.Errorf("Actual count different than expected count, actual: %d, expected: %d", actualCount, expectedCount)
-			t.Fail()
 		}
 	}
 }


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- At the end of all tests, verify no custom metrics are emitted for the last 30 min
- Also did some cleanup - removed some helper functions in stackdriver.go as directly calling the SDK is more straight forward
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
