### PR TITLE
More detailed examples for CloudEvents Pub/Sub

### DIFF
--- a/docs/spec/pubsub-protocol-binding.md
+++ b/docs/spec/pubsub-protocol-binding.md
@@ -167,7 +167,6 @@ CloudEvents attribute type's [canonical string representation][ce-types].
 This example shows the _binary_ mode mapping of an event to a Pub/Sub Message:
 
 ```text
-Publish /some-topic
 --- Attributes ---
 {
   "ce-specversion": "1.0",
@@ -181,6 +180,31 @@ Publish /some-topic
 --- Data ---
 {
     ... application data ...
+}
+```
+
+This example show a publish request on the REST API of the above Pub/Sub Message:
+
+```text
+POST https://pubsub.googleapis.com/v1/{topic}:publish HTTP/1.1
+Content-Type: application/json; charset=utf-8
+Authorization: Bearer ... token ...
+
+{
+  "messages": [
+    {
+      "attributes": {
+        "ce-specversion": "1.0",
+        "ce-type": "com.example.someevent",
+        "ce-time": "2020-03-10T03:56:24Z",
+        "ce-id": "1234-1234-1234",
+        "ce-source": "/mycontext/subcontext",
+          .... further attributes ...
+        "ce-datacontenttype": "application/json; charset=utf-8",
+      },
+      "data": "... base64 encoded Data JSON (see above) ..."
+    }
+  ]
 }
 ```
 
@@ -223,10 +247,9 @@ This example shows the _structured_ mode mapping of an event to a Pub/Sub
 Message:
 
 ```text
-Publish /some-topic
 --- Attributes ---
 {
-  "content-type": "application/cloudevents+json; charset=utf-8",
+  "content-type": "application/cloudevents+json; charset=utf-8"
 }
 --- Data ---
 {
@@ -240,6 +263,25 @@ Publish /some-topic
   "data": {
     ... application data ...
   }
+}
+```
+
+This example show a publish request on the REST API of the above Pub/Sub Message:
+
+```text
+POST https://pubsub.googleapis.com/v1/{topic}:publish HTTP/1.1
+Content-Type: application/json; charset=utf-8
+Authorization: Bearer ... token ...
+
+{
+  "messages": [
+    {
+      "attributes": {
+        "content-type": "application/cloudevents+json; charset=utf-8"
+      },
+      "data": "... base64 encoded Data JSON (see above) ..."
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
I implemented the Pub/Sub binding for CloudEvents and found the examples not very helpful. They claim to be a `publish` operation, but they're missing a lot of details to make it a real `publish`.

## Proposed Changes

- The first example shows only the mapping to attributes and data
- Add a second example that shows mapping the message onto a real publish request on the REST API

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
