### PR TITLE
[master] golang format tools

### DIFF
--- a/pkg/apis/duck/v1/pubsub_lifecycle_test.go
+++ b/pkg/apis/duck/v1/pubsub_lifecycle_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1
 
 import (
-	"knative.dev/pkg/apis"
 	"testing"
+
+	"knative.dev/pkg/apis"
 )
 
 var cs = apis.NewLivingConditionSet(
@@ -28,9 +29,9 @@ var cs = apis.NewLivingConditionSet(
 
 func TestPubSubStatusIsReady(t *testing.T) {
 	tests := []struct {
-		name                string
-		ps                  *PubSubStatus
-		want                bool
+		name string
+		ps   *PubSubStatus
+		want bool
 	}{{
 		name: "uninitialized",
 		ps:   &PubSubStatus{},

--- a/pkg/apis/duck/v1/pubsub_types_test.go
+++ b/pkg/apis/duck/v1/pubsub_types_test.go
@@ -17,13 +17,14 @@ limitations under the License.
 package v1
 
 import (
+	"testing"
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-	"testing"
-	"time"
 )
 
 func TestPubSub_GetFullType(t *testing.T) {
@@ -50,7 +51,7 @@ func TestPubSub_Populate(t *testing.T) {
 	got := &PubSub{}
 
 	want := &PubSub{
-		Spec: PubSubSpec {
+		Spec: PubSubSpec{
 			SourceSpec: duckv1.SourceSpec{
 				Sink: duckv1.Destination{
 					URI: &apis.URL{
@@ -59,7 +60,7 @@ func TestPubSub_Populate(t *testing.T) {
 						RawQuery: "flip=mattmoor",
 					},
 				},
-				CloudEventOverrides: &duckv1.CloudEventOverrides {
+				CloudEventOverrides: &duckv1.CloudEventOverrides{
 					Extensions: map[string]string{
 						"boosh": "kakow",
 					},
@@ -90,8 +91,8 @@ func TestPubSub_Populate(t *testing.T) {
 				Host:     "tableflip.dev",
 				RawQuery: "flip=mattmoor",
 			},
-			ProjectID: "projectid",
-			TopicID: "topicid",
+			ProjectID:      "projectid",
+			TopicID:        "topicid",
 			SubscriptionID: "subscriptionid",
 		},
 	}

--- a/pkg/apis/duck/v1/resource_types_test.go
+++ b/pkg/apis/duck/v1/resource_types_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestResource_GetFullType(t *testing.T) {
@@ -46,7 +47,7 @@ func TestResource_Populate(t *testing.T) {
 	got := &Resource{}
 
 	want := &Resource{
-		TypeMeta: metav1.TypeMeta {
+		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "MyKind",
 		},
@@ -62,4 +63,3 @@ func TestResource_Populate(t *testing.T) {
 		t.Errorf("Unexpected difference (-want, +got): %v", diff)
 	}
 }
-

--- a/pkg/apis/duck/v1alpha1/pubsub_lifecycle_test.go
+++ b/pkg/apis/duck/v1alpha1/pubsub_lifecycle_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"knative.dev/pkg/apis"
 	"testing"
+
+	"knative.dev/pkg/apis"
 )
 
 var cs = apis.NewLivingConditionSet(
@@ -28,9 +29,9 @@ var cs = apis.NewLivingConditionSet(
 
 func TestPubSubStatusIsReady(t *testing.T) {
 	tests := []struct {
-		name                string
-		ps                  *PubSubStatus
-		want                bool
+		name string
+		ps   *PubSubStatus
+		want bool
 	}{{
 		name: "uninitialized",
 		ps:   &PubSubStatus{},

--- a/pkg/apis/duck/v1alpha1/pubsub_types_test.go
+++ b/pkg/apis/duck/v1alpha1/pubsub_types_test.go
@@ -17,13 +17,14 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"testing"
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-	"testing"
-	"time"
 )
 
 func TestPubSub_GetFullType(t *testing.T) {
@@ -50,7 +51,7 @@ func TestPubSub_Populate(t *testing.T) {
 	got := &PubSub{}
 
 	want := &PubSub{
-		Spec: PubSubSpec {
+		Spec: PubSubSpec{
 			SourceSpec: duckv1.SourceSpec{
 				Sink: duckv1.Destination{
 					URI: &apis.URL{
@@ -59,7 +60,7 @@ func TestPubSub_Populate(t *testing.T) {
 						RawQuery: "flip=mattmoor",
 					},
 				},
-				CloudEventOverrides: &duckv1.CloudEventOverrides {
+				CloudEventOverrides: &duckv1.CloudEventOverrides{
 					Extensions: map[string]string{
 						"boosh": "kakow",
 					},
@@ -90,8 +91,8 @@ func TestPubSub_Populate(t *testing.T) {
 				Host:     "tableflip.dev",
 				RawQuery: "flip=mattmoor",
 			},
-			ProjectID: "projectid",
-			TopicID: "topicid",
+			ProjectID:      "projectid",
+			TopicID:        "topicid",
 			SubscriptionID: "subscriptionid",
 		},
 	}

--- a/pkg/apis/duck/v1alpha1/resource_types_test.go
+++ b/pkg/apis/duck/v1alpha1/resource_types_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestResource_GetFullType(t *testing.T) {
@@ -62,5 +63,3 @@ func TestResource_Populate(t *testing.T) {
 		t.Errorf("Unexpected difference (-want, +got): %v", diff)
 	}
 }
-
-

--- a/pkg/apis/duck/v1beta1/pubsub_lifecycle_test.go
+++ b/pkg/apis/duck/v1beta1/pubsub_lifecycle_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1beta1
 
 import (
-	"knative.dev/pkg/apis"
 	"testing"
+
+	"knative.dev/pkg/apis"
 )
 
 var cs = apis.NewLivingConditionSet(
@@ -28,9 +29,9 @@ var cs = apis.NewLivingConditionSet(
 
 func TestPubSubStatusIsReady(t *testing.T) {
 	tests := []struct {
-		name                string
-		ps                  *PubSubStatus
-		want                bool
+		name string
+		ps   *PubSubStatus
+		want bool
 	}{{
 		name: "uninitialized",
 		ps:   &PubSubStatus{},

--- a/pkg/apis/duck/v1beta1/pubsub_types_test.go
+++ b/pkg/apis/duck/v1beta1/pubsub_types_test.go
@@ -17,13 +17,14 @@ limitations under the License.
 package v1beta1
 
 import (
+	"testing"
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-	"testing"
-	"time"
 )
 
 func TestPubSub_GetFullType(t *testing.T) {
@@ -50,7 +51,7 @@ func TestPubSub_Populate(t *testing.T) {
 	got := &PubSub{}
 
 	want := &PubSub{
-		Spec: PubSubSpec {
+		Spec: PubSubSpec{
 			SourceSpec: duckv1.SourceSpec{
 				Sink: duckv1.Destination{
 					URI: &apis.URL{
@@ -59,7 +60,7 @@ func TestPubSub_Populate(t *testing.T) {
 						RawQuery: "flip=mattmoor",
 					},
 				},
-				CloudEventOverrides: &duckv1.CloudEventOverrides {
+				CloudEventOverrides: &duckv1.CloudEventOverrides{
 					Extensions: map[string]string{
 						"boosh": "kakow",
 					},
@@ -90,8 +91,8 @@ func TestPubSub_Populate(t *testing.T) {
 				Host:     "tableflip.dev",
 				RawQuery: "flip=mattmoor",
 			},
-			ProjectID: "projectid",
-			TopicID: "topicid",
+			ProjectID:      "projectid",
+			TopicID:        "topicid",
 			SubscriptionID: "subscriptionid",
 		},
 	}

--- a/pkg/apis/duck/v1beta1/resource_types_test.go
+++ b/pkg/apis/duck/v1beta1/resource_types_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestResource_GetFullType(t *testing.T) {
@@ -46,7 +47,7 @@ func TestResource_Populate(t *testing.T) {
 	got := &Resource{}
 
 	want := &Resource{
-		TypeMeta: metav1.TypeMeta {
+		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1beta1",
 			Kind:       "MyKind",
 		},
@@ -62,5 +63,3 @@ func TestResource_Populate(t *testing.T) {
 		t.Errorf("Unexpected difference (-want, +got): %v", diff)
 	}
 }
-
-


### PR DESCRIPTION
<!--[master] golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -path './third_party' -prune -o -name '*.pb.go' -prune -o -type f -name '*.go' -print)`
  `goimports -w $(find -name '*.go' | grep -v vendor | grep -v third_party | grep -v .pb.go | grep -v wire_gen.go)`
/assign grantr ian-mi nachocano
/cc grantr ian-mi nachocano
