### PR TITLE
Use transformer to avoid making unnecessary event copy in delivery transformer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/pubsub v1.5.0
 	cloud.google.com/go/storage v1.10.0
 	github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.0.1-0.20200602143929-d07dc0510d45
-	github.com/cloudevents/sdk-go/v2 v2.0.1-0.20200630063327-b91da81265fe
+	github.com/cloudevents/sdk-go/v2 v2.0.1-0.20200727063607-52b184c5d780
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/protobuf v1.4.2
 	github.com/google/go-cmp v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -256,6 +256,8 @@ github.com/cloudevents/sdk-go/v2 v2.0.0 h1:AUdGJwaSUnA+VvepKqgjy6XDkPcf0hf/3L7ic
 github.com/cloudevents/sdk-go/v2 v2.0.0/go.mod h1:3CTrpB4+u7Iaj6fd7E2Xvm5IxMdRoaAhqaRVnOr2rCU=
 github.com/cloudevents/sdk-go/v2 v2.0.1-0.20200630063327-b91da81265fe h1:EY9DO05JZ+rMTUjJ7eYqjr+n2ZpLqE4UBeSeL2OH+v8=
 github.com/cloudevents/sdk-go/v2 v2.0.1-0.20200630063327-b91da81265fe/go.mod h1:3CTrpB4+u7Iaj6fd7E2Xvm5IxMdRoaAhqaRVnOr2rCU=
+github.com/cloudevents/sdk-go/v2 v2.0.1-0.20200727063607-52b184c5d780 h1:KagN4BVXwejG3YR15bMHU2xn8EczVgxiMubzs65FiSY=
+github.com/cloudevents/sdk-go/v2 v2.0.1-0.20200727063607-52b184c5d780/go.mod h1:3CTrpB4+u7Iaj6fd7E2Xvm5IxMdRoaAhqaRVnOr2rCU=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=

--- a/pkg/broker/eventutil/hops.go
+++ b/pkg/broker/eventutil/hops.go
@@ -29,7 +29,7 @@ import (
 const (
 	// Intentionally make it short because the additional attribute
 	// increases Pubsub message size and could incur additional cost.
-	hopsAttribute = "kgcphops"
+	HopsAttribute = "kgcphops"
 )
 
 // UpdateRemainingHops update an event with proper remaining hops.
@@ -48,31 +48,31 @@ func UpdateRemainingHops(ctx context.Context, event *event.Event, preemptiveHops
 	} else {
 		logging.FromContext(ctx).Debug("Remaining hops not found in event, defaulting to the preemptive value.",
 			zap.String("event.id", event.ID()),
-			zap.Int32(hopsAttribute, preemptiveHops),
+			zap.Int32(HopsAttribute, preemptiveHops),
 		)
 		hops = preemptiveHops
 	}
 
-	event.SetExtension(hopsAttribute, hops)
+	event.SetExtension(HopsAttribute, hops)
 }
 
 // SetRemainingHops sets the remaining hops in the event.
 // It ignores any existing hops value.
 func SetRemainingHops(ctx context.Context, event *event.Event, hops int32) {
-	event.SetExtension(hopsAttribute, hops)
+	event.SetExtension(HopsAttribute, hops)
 }
 
 type SetRemainingHopsTransformer int32
 
 func (h SetRemainingHopsTransformer) Transform(_ binding.MessageMetadataReader, out binding.MessageMetadataWriter) error {
-	out.SetExtension(hopsAttribute, int32(h))
+	out.SetExtension(HopsAttribute, int32(h))
 	return nil
 }
 
 // GetRemainingHops returns the remaining hops of the event if it presents.
 // If there is no existing hops value or an invalid one, (0, false) will be returned.
 func GetRemainingHops(ctx context.Context, event *event.Event) (int32, bool) {
-	hopsRaw, ok := event.Extensions()[hopsAttribute]
+	hopsRaw, ok := event.Extensions()[HopsAttribute]
 	if !ok {
 		return 0, false
 	}
@@ -80,7 +80,7 @@ func GetRemainingHops(ctx context.Context, event *event.Event) (int32, bool) {
 	if err != nil {
 		logging.FromContext(ctx).Warn("Failed to convert existing hops value into integer, regarding it as there is no hops value.",
 			zap.String("event.id", event.ID()),
-			zap.Any(hopsAttribute, hopsRaw),
+			zap.Any(HopsAttribute, hopsRaw),
 			zap.Error(err),
 		)
 		return 0, false
@@ -90,5 +90,5 @@ func GetRemainingHops(ctx context.Context, event *event.Event) (int32, bool) {
 
 // DeleteRemainingHops deletes hops from the event extensions.
 func DeleteRemainingHops(_ context.Context, event *event.Event) {
-	event.SetExtension(hopsAttribute, nil)
+	event.SetExtension(HopsAttribute, nil)
 }

--- a/pkg/broker/eventutil/hops.go
+++ b/pkg/broker/eventutil/hops.go
@@ -56,12 +56,6 @@ func UpdateRemainingHops(ctx context.Context, event *event.Event, preemptiveHops
 	event.SetExtension(HopsAttribute, hops)
 }
 
-// SetRemainingHops sets the remaining hops in the event.
-// It ignores any existing hops value.
-func SetRemainingHops(ctx context.Context, event *event.Event, hops int32) {
-	event.SetExtension(HopsAttribute, hops)
-}
-
 type SetRemainingHopsTransformer int32
 
 func (h SetRemainingHopsTransformer) Transform(_ binding.MessageMetadataReader, out binding.MessageMetadataWriter) error {

--- a/pkg/broker/eventutil/hops_test.go
+++ b/pkg/broker/eventutil/hops_test.go
@@ -105,34 +105,3 @@ func TestUpdateHops(t *testing.T) {
 		})
 	}
 }
-
-func TestSetRemainingHops(t *testing.T) {
-	cases := []struct {
-		name         string
-		existingHops int32
-		hops         int32
-	}{{
-		name:         "without existing hops",
-		existingHops: 0,
-		hops:         123,
-	}, {
-		name:         "with existing hops",
-		existingHops: 99,
-		hops:         123,
-	}}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			e := event.New()
-			e.SetExtension(HopsAttribute, tc.existingHops)
-			SetRemainingHops(context.Background(), &e, tc.hops)
-			gotHops, ok := GetRemainingHops(context.Background(), &e)
-			if !ok {
-				t.Error("Found Hops after SetRemainingHops got=false, want=true")
-			}
-			if gotHops != tc.hops {
-				t.Errorf("Hops got=%d, want=%d", gotHops, tc.hops)
-			}
-		})
-	}
-}

--- a/pkg/broker/eventutil/hops_test.go
+++ b/pkg/broker/eventutil/hops_test.go
@@ -45,7 +45,7 @@ func TestGetRemainingHops(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			e := event.New()
-			e.SetExtension(hopsAttribute, tc.val)
+			e.SetExtension(HopsAttribute, tc.val)
 			gotHops, gotOK := GetRemainingHops(context.Background(), &e)
 			if gotOK != tc.wantOK {
 				t.Errorf("Found Hops OK got=%v, want=%v", gotOK, tc.wantOK)
@@ -59,9 +59,9 @@ func TestGetRemainingHops(t *testing.T) {
 
 func TestDeleteRemainingHops(t *testing.T) {
 	e := event.New()
-	e.SetExtension(hopsAttribute, 100)
+	e.SetExtension(HopsAttribute, 100)
 	DeleteRemainingHops(context.Background(), &e)
-	_, ok := e.Extensions()[hopsAttribute]
+	_, ok := e.Extensions()[HopsAttribute]
 	if ok {
 		t.Error("After DeleteRemainingHops Hops found got=true, want=false")
 	}
@@ -93,7 +93,7 @@ func TestUpdateHops(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			e := event.New()
-			e.SetExtension(hopsAttribute, tc.existingHops)
+			e.SetExtension(HopsAttribute, tc.existingHops)
 			UpdateRemainingHops(context.Background(), &e, tc.preemptive)
 			gotHops, ok := GetRemainingHops(context.Background(), &e)
 			if !ok {
@@ -124,7 +124,7 @@ func TestSetRemainingHops(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			e := event.New()
-			e.SetExtension(hopsAttribute, tc.existingHops)
+			e.SetExtension(HopsAttribute, tc.existingHops)
 			SetRemainingHops(context.Background(), &e, tc.hops)
 			gotHops, ok := GetRemainingHops(context.Background(), &e)
 			if !ok {

--- a/pkg/broker/eventutil/immutable_event_message.go
+++ b/pkg/broker/eventutil/immutable_event_message.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 Google LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eventutil
+
+import (
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/event"
+)
+
+// ImmutableEventMessage wraps binding.EventMessage and sets binary encoding to avoid mutation of
+// the underlying event.
+
+type ImmutableEventMessage struct {
+	*binding.EventMessage
+}
+
+func NewImmutableEventMessage(e *event.Event) ImmutableEventMessage {
+	return ImmutableEventMessage{(*binding.EventMessage)(e)}
+}
+
+func (m ImmutableEventMessage) ReadEncoding() binding.Encoding {
+	return binding.EncodingBinary
+}

--- a/pkg/broker/eventutil/immutable_event_message.go
+++ b/pkg/broker/eventutil/immutable_event_message.go
@@ -23,7 +23,6 @@ import (
 
 // ImmutableEventMessage wraps binding.EventMessage and sets binary encoding to avoid mutation of
 // the underlying event.
-
 type ImmutableEventMessage struct {
 	*binding.EventMessage
 }
@@ -32,6 +31,8 @@ func NewImmutableEventMessage(e *event.Event) ImmutableEventMessage {
 	return ImmutableEventMessage{(*binding.EventMessage)(e)}
 }
 
+// ReadEncoding overrides the encoding used by EventMessage with EncodingBinary instead of
+// EncodingEvent to avoid unnecessarily converting the message to an event.
 func (m ImmutableEventMessage) ReadEncoding() binding.Encoding {
 	return binding.EncodingBinary
 }

--- a/pkg/broker/eventutil/immutable_event_message_test.go
+++ b/pkg/broker/eventutil/immutable_event_message_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 Google LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eventutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/binding/transformer"
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestImmutableEventMessage(t *testing.T) {
+	e := event.New()
+	e.SetID("id")
+	e.SetType("type")
+	e.SetSource("source")
+
+	e.SetExtension("ext", "val")
+	e.SetExtension("ext2", "val2")
+
+	e2, err := binding.ToEvent(context.TODO(), NewImmutableEventMessage(&e), transformer.DeleteExtension("ext"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(map[string]interface{}{"ext2": "val2"}, e2.Extensions()); diff != "" {
+		t.Errorf("unexpected extensions in transformed event (-want, +got) = %v", diff)
+	}
+
+	if diff := cmp.Diff(map[string]interface{}{"ext": "val", "ext2": "val2"}, e.Extensions()); diff != "" {
+		t.Errorf("unexpected mutation of event extensions (-want, +got) = %v", diff)
+	}
+}

--- a/pkg/broker/handler/processors/deliver/processor.go
+++ b/pkg/broker/handler/processors/deliver/processor.go
@@ -126,7 +126,7 @@ func (p *Processor) Process(ctx context.Context, e *event.Event) error {
 		defer cancel()
 	}
 
-	if err := p.deliver(dctx, target, broker, binding.ToMessage(e), hops); err != nil {
+	if err := p.deliver(dctx, target, broker, eventutil.NewImmutableEventMessage(e), hops); err != nil {
 		if !p.RetryOnFailure {
 			return err
 		}

--- a/pkg/broker/handler/testing/helper.go
+++ b/pkg/broker/handler/testing/helper.go
@@ -443,6 +443,7 @@ func (h *Helper) VerifyAndRespondNextTargetEvent(ctx context.Context, t *testing
 // If wantEvent is nil, then it means such an event is not expected.
 // This function is blocking and should be invoked in a separate goroutine with context timeout.
 func (h *Helper) VerifyNextTargetRetryEvent(ctx context.Context, t *testing.T, targetKey string, wantEvent *event.Event) {
+	t.Helper()
 	target, ok := h.Targets.GetTargetByKey(targetKey)
 	if !ok {
 		t.Fatalf("target with key %q doesn't exist", targetKey)
@@ -450,6 +451,7 @@ func (h *Helper) VerifyNextTargetRetryEvent(ctx context.Context, t *testing.T, t
 
 	var gotEvent *event.Event
 	defer func() {
+		t.Helper()
 		assertEvent(t, wantEvent, gotEvent, fmt.Sprintf("target (key=%q)", targetKey))
 	}()
 
@@ -482,6 +484,7 @@ func (h *Helper) VerifyNextTargetRetryEvent(ctx context.Context, t *testing.T, t
 }
 
 func assertEvent(t *testing.T, want, got *event.Event, msg string) {
+	t.Helper()
 	if got != nil && want != nil {
 		// Clone events so that we don't modify the original copy.
 		gotCopy, wantCopy := got.Clone(), want.Clone()

--- a/vendor/github.com/cloudevents/sdk-go/v2/event/event_validation.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/event/event_validation.go
@@ -27,7 +27,7 @@ func (e Event) Validate() error {
 
 	errs := map[string]error{}
 	if e.FieldErrors != nil {
-		for k, v := range errs {
+		for k, v := range e.FieldErrors {
 			errs[k] = v
 		}
 	}

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/write_request.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/write_request.go
@@ -106,6 +106,7 @@ func (b *httpRequestWriter) SetAttribute(attribute spec.Attribute, value interfa
 	mapping := attributeHeadersMapping[attribute.Name()]
 	if value == nil {
 		delete(b.Header, mapping)
+		return nil
 	}
 
 	// Http headers, everything is a string!
@@ -120,6 +121,7 @@ func (b *httpRequestWriter) SetAttribute(attribute spec.Attribute, value interfa
 func (b *httpRequestWriter) SetExtension(name string, value interface{}) error {
 	if value == nil {
 		delete(b.Header, extNameToHeaderName(name))
+		return nil
 	}
 	// Http headers, everything is a string!
 	s, err := types.Format(value)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -109,7 +109,7 @@ github.com/cespare/xxhash/v2
 github.com/cloudevents/sdk-go/protocol/pubsub/v2
 github.com/cloudevents/sdk-go/protocol/pubsub/v2/context
 github.com/cloudevents/sdk-go/protocol/pubsub/v2/internal
-# github.com/cloudevents/sdk-go/v2 v2.0.1-0.20200630063327-b91da81265fe
+# github.com/cloudevents/sdk-go/v2 v2.0.1-0.20200727063607-52b184c5d780
 ## explicit
 github.com/cloudevents/sdk-go/v2
 github.com/cloudevents/sdk-go/v2/binding


### PR DESCRIPTION
When sending to a retry topic it is still necessary to clone EventContext since the retry client
does not yet use message bindings.

Fixes #1511

Benchmark results show significant improvement for large payload sizes since this avoids buffering payload data:
> DeliveryNoReply/0_bytes-16                 9.68µs ± 1%  9.26µs ± 2%   -4.28%  (p=0.000 n=9+10)
> DeliveryNoReply/1000_bytes-16              10.4µs ± 2%   9.5µs ± 1%   -8.42%  (p=0.000 n=9+10)
> DeliveryNoReply/1000000_bytes-16            294µs ± 2%   146µs ± 0%  -50.28%  (p=0.000 n=10+9)
> DeliveryNoReplyFakeClient/0_bytes-16       2.63µs ± 1%  2.45µs ± 1%   -6.70%  (p=0.000 n=8+10)
> DeliveryNoReplyFakeClient/1000_bytes-16    2.81µs ± 3%  2.47µs ± 1%  -12.14%  (p=0.000 n=10+10)
> DeliveryNoReplyFakeClient/100000_bytes-16  14.9µs ± 1%   2.5µs ± 2%  -83.51%  (p=0.000 n=10+9)

