### PR TITLE
Add immutable fields check in channel validation

### DIFF
--- a/pkg/apis/events/v1/cloudauditlogssource_validation.go
+++ b/pkg/apis/events/v1/cloudauditlogssource_validation.go
@@ -29,7 +29,13 @@ import (
 )
 
 func (current *CloudAuditLogsSource) Validate(ctx context.Context) *apis.FieldError {
-	return current.Spec.Validate(ctx).ViaField("spec")
+	err := current.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*CloudAuditLogsSource)
+		err = err.Also(current.CheckImmutableFields(ctx, original))
+	}
+	return err
 }
 
 func (current *CloudAuditLogsSourceSpec) Validate(ctx context.Context) *apis.FieldError {

--- a/pkg/apis/events/v1/cloudpubsubsource_validation.go
+++ b/pkg/apis/events/v1/cloudpubsubsource_validation.go
@@ -32,6 +32,11 @@ import (
 
 func (current *CloudPubSubSource) Validate(ctx context.Context) *apis.FieldError {
 	errs := current.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*CloudPubSubSource)
+		errs = errs.Also(current.CheckImmutableFields(ctx, original))
+	}
 	return duck.ValidateAutoscalingAnnotations(ctx, current.Annotations, errs)
 }
 

--- a/pkg/apis/events/v1/cloudschedulersource_validation.go
+++ b/pkg/apis/events/v1/cloudschedulersource_validation.go
@@ -29,6 +29,11 @@ import (
 
 func (current *CloudSchedulerSource) Validate(ctx context.Context) *apis.FieldError {
 	errs := current.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*CloudSchedulerSource)
+		errs = errs.Also(current.CheckImmutableFields(ctx, original))
+	}
 	return duck.ValidateAutoscalingAnnotations(ctx, current.Annotations, errs)
 }
 

--- a/pkg/apis/events/v1/cloudstoragesource_validation.go
+++ b/pkg/apis/events/v1/cloudstoragesource_validation.go
@@ -30,6 +30,11 @@ import (
 
 func (current *CloudStorageSource) Validate(ctx context.Context) *apis.FieldError {
 	errs := current.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*CloudStorageSource)
+		errs = errs.Also(current.CheckImmutableFields(ctx, original))
+	}
 	return duck.ValidateAutoscalingAnnotations(ctx, current.Annotations, errs)
 }
 

--- a/pkg/apis/events/v1alpha1/cloudauditlogssource_validation.go
+++ b/pkg/apis/events/v1alpha1/cloudauditlogssource_validation.go
@@ -29,7 +29,13 @@ import (
 )
 
 func (current *CloudAuditLogsSource) Validate(ctx context.Context) *apis.FieldError {
-	return current.Spec.Validate(ctx).ViaField("spec")
+	err := current.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*CloudAuditLogsSource)
+		err = err.Also(current.CheckImmutableFields(ctx, original))
+	}
+	return err
 }
 
 func (current *CloudAuditLogsSourceSpec) Validate(ctx context.Context) *apis.FieldError {

--- a/pkg/apis/events/v1alpha1/cloudbuildsource_validation.go
+++ b/pkg/apis/events/v1alpha1/cloudbuildsource_validation.go
@@ -28,6 +28,11 @@ import (
 
 func (current *CloudBuildSource) Validate(ctx context.Context) *apis.FieldError {
 	errs := current.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*CloudBuildSource)
+		errs = errs.Also(current.CheckImmutableFields(ctx, original))
+	}
 	return duck.ValidateAutoscalingAnnotations(ctx, current.Annotations, errs)
 }
 

--- a/pkg/apis/events/v1alpha1/cloudpubsubsource_validation.go
+++ b/pkg/apis/events/v1alpha1/cloudpubsubsource_validation.go
@@ -32,6 +32,11 @@ import (
 
 func (current *CloudPubSubSource) Validate(ctx context.Context) *apis.FieldError {
 	errs := current.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*CloudPubSubSource)
+		errs = errs.Also(current.CheckImmutableFields(ctx, original))
+	}
 	return duck.ValidateAutoscalingAnnotations(ctx, current.Annotations, errs)
 }
 

--- a/pkg/apis/events/v1alpha1/cloudschedulersource_validation.go
+++ b/pkg/apis/events/v1alpha1/cloudschedulersource_validation.go
@@ -30,6 +30,11 @@ import (
 
 func (current *CloudSchedulerSource) Validate(ctx context.Context) *apis.FieldError {
 	errs := current.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*CloudSchedulerSource)
+		errs = errs.Also(current.CheckImmutableFields(ctx, original))
+	}
 	return duck.ValidateAutoscalingAnnotations(ctx, current.Annotations, errs)
 }
 

--- a/pkg/apis/events/v1alpha1/cloudstoragesource_validation.go
+++ b/pkg/apis/events/v1alpha1/cloudstoragesource_validation.go
@@ -30,6 +30,11 @@ import (
 
 func (current *CloudStorageSource) Validate(ctx context.Context) *apis.FieldError {
 	errs := current.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*CloudStorageSource)
+		errs = errs.Also(current.CheckImmutableFields(ctx, original))
+	}
 	return duck.ValidateAutoscalingAnnotations(ctx, current.Annotations, errs)
 }
 

--- a/pkg/apis/events/v1beta1/cloudauditlogssource_validation.go
+++ b/pkg/apis/events/v1beta1/cloudauditlogssource_validation.go
@@ -29,7 +29,13 @@ import (
 )
 
 func (current *CloudAuditLogsSource) Validate(ctx context.Context) *apis.FieldError {
-	return current.Spec.Validate(ctx).ViaField("spec")
+	err := current.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*CloudAuditLogsSource)
+		err = err.Also(current.CheckImmutableFields(ctx, original))
+	}
+	return err
 }
 
 func (current *CloudAuditLogsSourceSpec) Validate(ctx context.Context) *apis.FieldError {

--- a/pkg/apis/events/v1beta1/cloudbuildsource_validation.go
+++ b/pkg/apis/events/v1beta1/cloudbuildsource_validation.go
@@ -27,6 +27,12 @@ import (
 
 func (current *CloudBuildSource) Validate(ctx context.Context) *apis.FieldError {
 	errs := current.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*CloudBuildSource)
+		errs = errs.Also(current.CheckImmutableFields(ctx, original))
+	}
+
 	return duck.ValidateAutoscalingAnnotations(ctx, current.Annotations, errs)
 }
 

--- a/pkg/apis/events/v1beta1/cloudpubsubsource_validation.go
+++ b/pkg/apis/events/v1beta1/cloudpubsubsource_validation.go
@@ -32,6 +32,11 @@ import (
 
 func (current *CloudPubSubSource) Validate(ctx context.Context) *apis.FieldError {
 	errs := current.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*CloudPubSubSource)
+		errs = errs.Also(current.CheckImmutableFields(ctx, original))
+	}
 	return duck.ValidateAutoscalingAnnotations(ctx, current.Annotations, errs)
 }
 

--- a/pkg/apis/events/v1beta1/cloudschedulersource_validation.go
+++ b/pkg/apis/events/v1beta1/cloudschedulersource_validation.go
@@ -29,6 +29,11 @@ import (
 
 func (current *CloudSchedulerSource) Validate(ctx context.Context) *apis.FieldError {
 	errs := current.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*CloudSchedulerSource)
+		errs = errs.Also(current.CheckImmutableFields(ctx, original))
+	}
 	return duck.ValidateAutoscalingAnnotations(ctx, current.Annotations, errs)
 }
 

--- a/pkg/apis/events/v1beta1/cloudstoragesource_validation.go
+++ b/pkg/apis/events/v1beta1/cloudstoragesource_validation.go
@@ -30,6 +30,11 @@ import (
 
 func (current *CloudStorageSource) Validate(ctx context.Context) *apis.FieldError {
 	errs := current.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*CloudStorageSource)
+		errs = errs.Also(current.CheckImmutableFields(ctx, original))
+	}
 	return duck.ValidateAutoscalingAnnotations(ctx, current.Annotations, errs)
 }
 

--- a/pkg/apis/intevents/v1/pullsubscription_validation.go
+++ b/pkg/apis/intevents/v1/pullsubscription_validation.go
@@ -33,6 +33,11 @@ import (
 
 func (current *PullSubscription) Validate(ctx context.Context) *apis.FieldError {
 	errs := current.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*PullSubscription)
+		errs = errs.Also(current.CheckImmutableFields(ctx, original))
+	}
 	return duck.ValidateAutoscalingAnnotations(ctx, current.Annotations, errs)
 }
 

--- a/pkg/apis/intevents/v1/topic_validation.go
+++ b/pkg/apis/intevents/v1/topic_validation.go
@@ -28,7 +28,13 @@ import (
 )
 
 func (t *Topic) Validate(ctx context.Context) *apis.FieldError {
-	return t.Spec.Validate(ctx).ViaField("spec")
+	err := t.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*Topic)
+		err = err.Also(t.CheckImmutableFields(ctx, original))
+	}
+	return err
 }
 
 func (ts *TopicSpec) Validate(ctx context.Context) *apis.FieldError {

--- a/pkg/apis/intevents/v1alpha1/pullsubscription_validation.go
+++ b/pkg/apis/intevents/v1alpha1/pullsubscription_validation.go
@@ -33,6 +33,11 @@ import (
 
 func (current *PullSubscription) Validate(ctx context.Context) *apis.FieldError {
 	errs := current.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*PullSubscription)
+		errs = errs.Also(current.CheckImmutableFields(ctx, original))
+	}
 	return duck.ValidateAutoscalingAnnotations(ctx, current.Annotations, errs)
 }
 

--- a/pkg/apis/intevents/v1alpha1/topic_validation.go
+++ b/pkg/apis/intevents/v1alpha1/topic_validation.go
@@ -27,7 +27,13 @@ import (
 )
 
 func (t *Topic) Validate(ctx context.Context) *apis.FieldError {
-	return t.Spec.Validate(ctx).ViaField("spec")
+	err := t.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*Topic)
+		err = err.Also(t.CheckImmutableFields(ctx, original))
+	}
+	return err
 }
 
 func (ts *TopicSpec) Validate(ctx context.Context) *apis.FieldError {

--- a/pkg/apis/intevents/v1beta1/pullsubscription_validation.go
+++ b/pkg/apis/intevents/v1beta1/pullsubscription_validation.go
@@ -33,6 +33,11 @@ import (
 
 func (current *PullSubscription) Validate(ctx context.Context) *apis.FieldError {
 	errs := current.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*PullSubscription)
+		errs = errs.Also(current.CheckImmutableFields(ctx, original))
+	}
 	return duck.ValidateAutoscalingAnnotations(ctx, current.Annotations, errs)
 }
 

--- a/pkg/apis/intevents/v1beta1/topic_validation.go
+++ b/pkg/apis/intevents/v1beta1/topic_validation.go
@@ -28,7 +28,13 @@ import (
 )
 
 func (t *Topic) Validate(ctx context.Context) *apis.FieldError {
-	return t.Spec.Validate(ctx).ViaField("spec")
+	err := t.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*Topic)
+		err = err.Also(t.CheckImmutableFields(ctx, original))
+	}
+	return err
 }
 
 func (ts *TopicSpec) Validate(ctx context.Context) *apis.FieldError {

--- a/pkg/apis/messaging/v1alpha1/channel_validation.go
+++ b/pkg/apis/messaging/v1alpha1/channel_validation.go
@@ -28,7 +28,13 @@ import (
 )
 
 func (c *Channel) Validate(ctx context.Context) *apis.FieldError {
-	return c.Spec.Validate(ctx).ViaField("spec")
+	err := c.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*Channel)
+		err = err.Also(c.CheckImmutableFields(ctx, original))
+	}
+	return err
 }
 
 func (cs *ChannelSpec) Validate(ctx context.Context) *apis.FieldError {

--- a/pkg/apis/messaging/v1alpha1/channel_validation.go
+++ b/pkg/apis/messaging/v1alpha1/channel_validation.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/google/knative-gcp/pkg/apis/duck"
 
 	"github.com/google/go-cmp/cmp"
@@ -64,24 +66,18 @@ func (current *Channel) CheckImmutableFields(ctx context.Context, original *Chan
 
 	var errs *apis.FieldError
 
-	// Modification of TopicID is not allowed.
-	if original.Status.TopicID != "" {
-		if diff := cmp.Diff(original.Status.TopicID, current.Status.TopicID); diff != "" {
-			errs = errs.Also(&apis.FieldError{
-				Message: "Immutable fields changed (-old +new)",
-				Paths:   []string{"status", "topicId"},
-				Details: diff,
-			})
-		}
-	}
-
-	if diff := cmp.Diff(original.Spec.ServiceAccountName, current.Spec.ServiceAccountName); diff != "" {
+	// Modification of Secret, ServiceAccountName and Project are not allowed. Everything else is mutable.
+	if diff := cmp.Diff(original.Spec, current.Spec,
+		cmpopts.IgnoreFields(ChannelSpec{}, "SubscribableSpec")); diff != "" {
 		errs = errs.Also(&apis.FieldError{
 			Message: "Immutable fields changed (-old +new)",
-			Paths:   []string{"status", "serviceAccount"},
+			Paths:   []string{"spec"},
 			Details: diff,
 		})
 	}
+
+	// Modification of AutoscalingClassAnnotations is not allowed.
+	errs = duck.CheckImmutableAutoscalingClassAnnotations(&current.ObjectMeta, &original.ObjectMeta, errs)
 
 	// Modification of non-empty cluster name annotation is not allowed.
 	return duck.CheckImmutableClusterNameAnnotation(&current.ObjectMeta, &original.ObjectMeta, errs)

--- a/pkg/apis/messaging/v1beta1/channel_validation.go
+++ b/pkg/apis/messaging/v1beta1/channel_validation.go
@@ -26,7 +26,13 @@ import (
 )
 
 func (c *Channel) Validate(ctx context.Context) *apis.FieldError {
-	return c.Spec.Validate(ctx).ViaField("spec")
+	err := c.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*Channel)
+		err = err.Also(c.CheckImmutableFields(ctx, original))
+	}
+	return err
 }
 
 func (cs *ChannelSpec) Validate(ctx context.Context) *apis.FieldError {

--- a/pkg/apis/messaging/v1beta1/channel_validation.go
+++ b/pkg/apis/messaging/v1beta1/channel_validation.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/knative-gcp/pkg/apis/duck"
 	"knative.dev/pkg/apis"
@@ -60,24 +62,21 @@ func (current *Channel) CheckImmutableFields(ctx context.Context, original *Chan
 		return nil
 	}
 
-	// Modification of TopicID is not allowed.
-	if original.Status.TopicID != "" {
-		if diff := cmp.Diff(original.Status.TopicID, current.Status.TopicID); diff != "" {
-			return &apis.FieldError{
-				Message: "Immutable fields changed (-old +new)",
-				Paths:   []string{"status", "topicId"},
-				Details: diff,
-			}
-		}
-	}
+	var errs *apis.FieldError
 
-	if diff := cmp.Diff(original.Spec.ServiceAccountName, current.Spec.ServiceAccountName); diff != "" {
-		return &apis.FieldError{
+	// Modification of Secret, ServiceAccountName and Project are not allowed. Everything else is mutable.
+	if diff := cmp.Diff(original.Spec, current.Spec,
+		cmpopts.IgnoreFields(ChannelSpec{}, "SubscribableSpec")); diff != "" {
+		errs = errs.Also(&apis.FieldError{
 			Message: "Immutable fields changed (-old +new)",
-			Paths:   []string{"status", "serviceAccount"},
+			Paths:   []string{"spec"},
 			Details: diff,
-		}
+		})
 	}
 
-	return nil
+	// Modification of AutoscalingClassAnnotations is not allowed.
+	errs = duck.CheckImmutableAutoscalingClassAnnotations(&current.ObjectMeta, &original.ObjectMeta, errs)
+
+	// Modification of non-empty cluster name annotation is not allowed.
+	return duck.CheckImmutableClusterNameAnnotation(&current.ObjectMeta, &original.ObjectMeta, errs)
 }


### PR DESCRIPTION
Part of https://github.com/google/knative-gcp/issues/1448

## Proposed Changes

- Call CheckImmutableFields inside Validate() in channel validation to make sure only mutable fields can be modified with kubectl edit