### PR TITLE
Make secret, project and serviceAccountName immutable for channel

### DIFF
--- a/pkg/apis/messaging/v1alpha1/channel_validation.go
+++ b/pkg/apis/messaging/v1alpha1/channel_validation.go
@@ -68,7 +68,7 @@ func (current *Channel) CheckImmutableFields(ctx context.Context, original *Chan
 
 	// Modification of Secret, ServiceAccountName and Project are not allowed. Everything else is mutable.
 	if diff := cmp.Diff(original.Spec, current.Spec,
-		cmpopts.IgnoreFields(ChannelSpec{}, "SubscribableSpec")); diff != "" {
+		cmpopts.IgnoreFields(ChannelSpec{}, "Subscribable")); diff != "" {
 		errs = errs.Also(&apis.FieldError{
 			Message: "Immutable fields changed (-old +new)",
 			Paths:   []string{"spec"},

--- a/pkg/apis/messaging/v1alpha1/channel_validation.go
+++ b/pkg/apis/messaging/v1alpha1/channel_validation.go
@@ -28,7 +28,13 @@ import (
 )
 
 func (c *Channel) Validate(ctx context.Context) *apis.FieldError {
-	return c.Spec.Validate(ctx).ViaField("spec")
+	err := c.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*Channel)
+		err = err.Also(c.CheckImmutableFields(ctx, original))
+	}
+	return err
 }
 
 func (cs *ChannelSpec) Validate(ctx context.Context) *apis.FieldError {

--- a/pkg/apis/messaging/v1alpha1/channel_validation.go
+++ b/pkg/apis/messaging/v1alpha1/channel_validation.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/google/knative-gcp/pkg/apis/duck"
 
 	"github.com/google/go-cmp/cmp"
@@ -64,24 +66,18 @@ func (current *Channel) CheckImmutableFields(ctx context.Context, original *Chan
 
 	var errs *apis.FieldError
 
-	// Modification of TopicID is not allowed.
-	if original.Status.TopicID != "" {
-		if diff := cmp.Diff(original.Status.TopicID, current.Status.TopicID); diff != "" {
-			errs = errs.Also(&apis.FieldError{
-				Message: "Immutable fields changed (-old +new)",
-				Paths:   []string{"status", "topicId"},
-				Details: diff,
-			})
-		}
-	}
-
-	if diff := cmp.Diff(original.Spec.ServiceAccountName, current.Spec.ServiceAccountName); diff != "" {
+	// Modification of Secret, ServiceAccountName and Project are not allowed. Everything else is mutable.
+	if diff := cmp.Diff(original.Spec, current.Spec,
+		cmpopts.IgnoreFields(ChannelSpec{}, "SubscribableSpec")); diff != "" {
 		errs = errs.Also(&apis.FieldError{
 			Message: "Immutable fields changed (-old +new)",
-			Paths:   []string{"status", "serviceAccount"},
+			Paths:   []string{"spec"},
 			Details: diff,
 		})
 	}
+
+	// Modification of AutoscalingClassAnnotations is not allowed.
+	errs = duck.CheckImmutableAutoscalingClassAnnotations(&current.ObjectMeta, &original.ObjectMeta, errs)
 
 	// Modification of non-empty cluster name annotation is not allowed.
 	return duck.CheckImmutableClusterNameAnnotation(&current.ObjectMeta, &original.ObjectMeta, errs)

--- a/pkg/apis/messaging/v1alpha1/channel_validation_test.go
+++ b/pkg/apis/messaging/v1alpha1/channel_validation_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/google/go-cmp/cmp"
 	gcpauthtesthelper "github.com/google/knative-gcp/pkg/apis/configs/gcpauth/testhelper"
 	"github.com/google/knative-gcp/pkg/apis/duck"
@@ -243,6 +245,25 @@ func TestCheckImmutableFields(t *testing.T) {
 				IdentitySpec: duckv1alpha1.IdentitySpec{
 					ServiceAccountName: "new-service-account",
 				},
+			},
+			allowed: false,
+		},
+		"Secret changed": {
+			orig: &channelSpec,
+			updated: ChannelSpec{
+				Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "some-other-name",
+					},
+					Key: "some-other-secret-key",
+				},
+			},
+			allowed: false,
+		},
+		"Project changed": {
+			orig: &channelSpec,
+			updated: ChannelSpec{
+				Project: "some-other-project",
 			},
 			allowed: false,
 		},

--- a/pkg/apis/messaging/v1beta1/channel_validation.go
+++ b/pkg/apis/messaging/v1beta1/channel_validation.go
@@ -26,7 +26,13 @@ import (
 )
 
 func (c *Channel) Validate(ctx context.Context) *apis.FieldError {
-	return c.Spec.Validate(ctx).ViaField("spec")
+	err := c.Spec.Validate(ctx).ViaField("spec")
+
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*Channel)
+		err = err.Also(c.CheckImmutableFields(ctx, original))
+	}
+	return err
 }
 
 func (cs *ChannelSpec) Validate(ctx context.Context) *apis.FieldError {

--- a/pkg/apis/messaging/v1beta1/channel_validation.go
+++ b/pkg/apis/messaging/v1beta1/channel_validation.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/knative-gcp/pkg/apis/duck"
 	"knative.dev/pkg/apis"
@@ -60,24 +62,21 @@ func (current *Channel) CheckImmutableFields(ctx context.Context, original *Chan
 		return nil
 	}
 
-	// Modification of TopicID is not allowed.
-	if original.Status.TopicID != "" {
-		if diff := cmp.Diff(original.Status.TopicID, current.Status.TopicID); diff != "" {
-			return &apis.FieldError{
-				Message: "Immutable fields changed (-old +new)",
-				Paths:   []string{"status", "topicId"},
-				Details: diff,
-			}
-		}
-	}
+	var errs *apis.FieldError
 
-	if diff := cmp.Diff(original.Spec.ServiceAccountName, current.Spec.ServiceAccountName); diff != "" {
-		return &apis.FieldError{
+	// Modification of Secret, ServiceAccountName and Project are not allowed. Everything else is mutable.
+	if diff := cmp.Diff(original.Spec, current.Spec,
+		cmpopts.IgnoreFields(ChannelSpec{}, "SubscribableSpec")); diff != "" {
+		errs = errs.Also(&apis.FieldError{
 			Message: "Immutable fields changed (-old +new)",
-			Paths:   []string{"status", "serviceAccount"},
+			Paths:   []string{"spec"},
 			Details: diff,
-		}
+		})
 	}
 
-	return nil
+	// Modification of AutoscalingClassAnnotations is not allowed.
+	errs = duck.CheckImmutableAutoscalingClassAnnotations(&current.ObjectMeta, &original.ObjectMeta, errs)
+
+	// Modification of non-empty cluster name annotation is not allowed.
+	return duck.CheckImmutableClusterNameAnnotation(&current.ObjectMeta, &original.ObjectMeta, errs)
 }

--- a/pkg/apis/messaging/v1beta1/channel_validation_test.go
+++ b/pkg/apis/messaging/v1beta1/channel_validation_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/google/go-cmp/cmp"
 	gcpauthtesthelper "github.com/google/knative-gcp/pkg/apis/configs/gcpauth/testhelper"
 	gcpduckv1 "github.com/google/knative-gcp/pkg/apis/duck/v1"
@@ -197,6 +199,25 @@ func TestCheckImmutableFields(t *testing.T) {
 				IdentitySpec: gcpduckv1.IdentitySpec{
 					ServiceAccountName: "new-service-account",
 				},
+			},
+			allowed: false,
+		},
+		"Secret changed": {
+			orig: &channelSpec,
+			updated: ChannelSpec{
+				Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "some-other-name",
+					},
+					Key: "some-other-secret-key",
+				},
+			},
+			allowed: false,
+		},
+		"Project changed": {
+			orig: &channelSpec,
+			updated: ChannelSpec{
+				Project: "some-other-project",
 			},
 			allowed: false,
 		},


### PR DESCRIPTION
Part of #1448

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Call CheckImmutableFields inside Validate() in channel validation.
- Modify code logic in CheckImmutableFields to make sure secret, project and serviceAccountName cannot be modified with kubectl edit
