### PR TITLE
Switch serving from nightly to release in e2e tests

### DIFF
--- a/test/lib.sh
+++ b/test/lib.sh
@@ -21,7 +21,7 @@ readonly CLOUD_RUN_EVENTS_ISTIO_CONFIG="config/istio"
 
 # Install all required components for running knative-gcp.
 function start_knative_gcp() {
-  start_release_knative_serving || return 1
+  start_release_knative_serving 0.16.0|| return 1
   start_latest_knative_eventing || return 1
   start_knative_monitoring "$KNATIVE_MONITORING_RELEASE" || return 1
   cloud_run_events_setup || return 1

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -21,7 +21,7 @@ readonly CLOUD_RUN_EVENTS_ISTIO_CONFIG="config/istio"
 
 # Install all required components for running knative-gcp.
 function start_knative_gcp() {
-  start_latest_knative_serving || return 1
+  start_release_knative_serving || return 1
   start_latest_knative_eventing || return 1
   start_knative_monitoring "$KNATIVE_MONITORING_RELEASE" || return 1
   cloud_run_events_setup || return 1


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

It seems that the ongoing test failures are due to unstable serving nightly build. I propose to use serving release. I don't think we have any tests that depend on latest serving features. 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
