### PR TITLE
Add Handler Benchmark and Update Cloudevents SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	cloud.google.com/go/logging v1.0.1-0.20200331222814-69e77e66e597
 	cloud.google.com/go/pubsub v1.6.1
 	cloud.google.com/go/storage v1.10.0
-	github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.0.1-0.20200602143929-d07dc0510d45
-	github.com/cloudevents/sdk-go/v2 v2.2.0
+	github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.2.1-0.20200729225950-2d83dc10864e
+	github.com/cloudevents/sdk-go/v2 v2.2.1-0.20200729225950-2d83dc10864e
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/protobuf v1.4.2
 	github.com/google/go-cmp v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -251,12 +251,14 @@ github.com/clarketm/json v1.13.4/go.mod h1:ynr2LRfb0fQU34l07csRNBTcivjySLLiY1YzQ
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudevents/sdk-go v1.0.0 h1:gS5I0s2qPmdc4GBPlUmzZU7RH30BaiOdcRJ1RkXnPrc=
 github.com/cloudevents/sdk-go v1.0.0/go.mod h1:3TkmM0cFqkhCHOq5JzzRU/RxRkwzoS8TZ+G448qVTog=
-github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.0.1-0.20200602143929-d07dc0510d45 h1:BcfQO+2WfZp1SsjCQdu07Ksb+VGbqLR4FUqJ+LUE1ko=
-github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.0.1-0.20200602143929-d07dc0510d45/go.mod h1:KyGtbsR84tpP870ydX77lvHVq++zh3iUoY9dzUxj+cM=
+github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.2.1-0.20200729225950-2d83dc10864e h1:LYsfarHHum3oV7zTEihAu1ApT3x//8UOqfYs0mGxMwI=
+github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.2.1-0.20200729225950-2d83dc10864e/go.mod h1:KyGtbsR84tpP870ydX77lvHVq++zh3iUoY9dzUxj+cM=
 github.com/cloudevents/sdk-go/v2 v2.0.0 h1:AUdGJwaSUnA+VvepKqgjy6XDkPcf0hf/3L7icEs1ibs=
 github.com/cloudevents/sdk-go/v2 v2.0.0/go.mod h1:3CTrpB4+u7Iaj6fd7E2Xvm5IxMdRoaAhqaRVnOr2rCU=
 github.com/cloudevents/sdk-go/v2 v2.2.0 h1:FlBJg7W0QywbOjuZGmRXUyFk8qkCHx2euETp+tuopSU=
 github.com/cloudevents/sdk-go/v2 v2.2.0/go.mod h1:3CTrpB4+u7Iaj6fd7E2Xvm5IxMdRoaAhqaRVnOr2rCU=
+github.com/cloudevents/sdk-go/v2 v2.2.1-0.20200729225950-2d83dc10864e h1:xaqndWHYVJulyej25QsJsDRIHgdbxkmNgfx+mJsxzsE=
+github.com/cloudevents/sdk-go/v2 v2.2.1-0.20200729225950-2d83dc10864e/go.mod h1:3CTrpB4+u7Iaj6fd7E2Xvm5IxMdRoaAhqaRVnOr2rCU=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=

--- a/vendor/github.com/cloudevents/sdk-go/protocol/pubsub/v2/message.go
+++ b/vendor/github.com/cloudevents/sdk-go/protocol/pubsub/v2/message.go
@@ -96,7 +96,7 @@ func (m *Message) ReadBinary(ctx context.Context, encoder binding.BinaryWriter) 
 	}
 
 	if m.internal.Data != nil {
-		return encoder.SetData(bytes.NewReader(m.internal.Data))
+		return encoder.SetData(bytes.NewBuffer(m.internal.Data))
 	}
 
 	return

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/event_message.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/event_message.go
@@ -48,7 +48,7 @@ func (m *EventMessage) ReadBinary(ctx context.Context, b BinaryWriter) (err erro
 	// Pass the body
 	body := (*event.Event)(m).Data()
 	if len(body) > 0 {
-		err = b.SetData(bytes.NewReader(body))
+		err = b.SetData(bytes.NewBuffer(body))
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/to_event.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/to_event.go
@@ -79,12 +79,15 @@ func (b *messageToEventBuilder) End(ctx context.Context) error {
 }
 
 func (b *messageToEventBuilder) SetData(data io.Reader) error {
-	var buf bytes.Buffer
-	w, err := io.Copy(&buf, data)
-	if err != nil {
-		return err
+	buf, ok := data.(*bytes.Buffer)
+	if !ok {
+		buf = new(bytes.Buffer)
+		_, err := io.Copy(buf, data)
+		if err != nil {
+			return err
+		}
 	}
-	if w != 0 {
+	if buf.Len() > 0 {
 		b.DataEncoded = buf.Bytes()
 	}
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -104,12 +104,12 @@ github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1
 github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
-# github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.0.1-0.20200602143929-d07dc0510d45
+# github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.2.1-0.20200729225950-2d83dc10864e
 ## explicit
 github.com/cloudevents/sdk-go/protocol/pubsub/v2
 github.com/cloudevents/sdk-go/protocol/pubsub/v2/context
 github.com/cloudevents/sdk-go/protocol/pubsub/v2/internal
-# github.com/cloudevents/sdk-go/v2 v2.2.0
+# github.com/cloudevents/sdk-go/v2 v2.2.1-0.20200729225950-2d83dc10864e
 ## explicit
 github.com/cloudevents/sdk-go/v2
 github.com/cloudevents/sdk-go/v2/binding


### PR DESCRIPTION
Pulls in https://github.com/cloudevents/sdk-go/pull/561 which eliminates the copying of message data when converting a binary pubsub message to an event. The newly added benchmark shows a performance improvement in the broker handler with large payload sizes and the performance becomes nearly entirely dominated by the overhead of gRPC.

## Benchmark Results
> name                             old time/op  new time/op  delta
> HandlerReceive/0_bytes-16        1.02ms ± 0%  1.03ms ± 0%    ~     (p=0.197 n=10+11)
> HandlerReceive/1000_bytes-16     1.03ms ± 0%  1.03ms ± 0%    ~     (p=0.652 n=11+11)
> HandlerReceive/1000000_bytes-16  1.65ms ± 3%  1.54ms ± 5%  -6.48%  (p=0.000 n=9+10)
