### PR TITLE
Add an option to setup test cluster and skip tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -18,6 +18,13 @@ source $(dirname "$0")/e2e-secret-tests.sh
 
 initialize $@
 
+if [ "${SKIP_TESTS:-}" == "true" ]; then
+  echo "**************************************"
+  echo "***         TESTS SKIPPED          ***"
+  echo "**************************************"
+  exit 0
+fi
+
 go_test_e2e -timeout=30m -parallel=12 ./test/e2e \
   -channels='messaging.cloud.google.com/v1alpha1:Channel,messaging.cloud.google.com/v1beta1:Channel' \
   || fail_test

--- a/test/e2e-wi-tests.sh
+++ b/test/e2e-wi-tests.sh
@@ -159,6 +159,13 @@ function gcp_auth_setup() {
 # We could specify --cluster-version to force the cluster using a particular GKE version.
 initialize $@ --cluster-creation-flag "--workload-pool=\${PROJECT}.svc.id.goog"
 
+if [ "${SKIP_TESTS:-}" == "true" ]; then
+  echo "**************************************"
+  echo "***         TESTS SKIPPED          ***"
+  echo "**************************************"
+  exit 0
+fi
+
 # Channel related e2e tests we have in Eventing is not running here.
 go_test_e2e -timeout=30m -parallel=6 ./test/e2e -workloadIndentity=true -serviceAccountName="${K8S_SERVICE_ACCOUNT_NAME}" || fail_test
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -24,6 +24,22 @@ We leverage the
 as much as possible for implementing the e2e tests. Logic specific to
 knative-gcp should be added under [knative-gcp e2e test lib](lib).
 
+## Setup a test cluster
+
+Run the following command:
+
+```shell
+SKIP_TESTS=true ./test/e2e-tests.sh --skip-teardowns
+```
+
+`SKIP_TESTS` will skip the actual tests so only the cluster initialization is run.
+`--skip-teardowns` tells the script to not tear down the cluster.
+This command runs the cluster initialization logic and leaves the cluster in a state
+that's ready to run tests.
+
+If you run into `Something went wrong: error creating deployer: --gcp-zone and --gcp-region cannot both be set`,
+you may have set the `ZONE` environment variable. Try `unset ZONE`. 
+
 ## Running E2E Tests on an existing cluster
 
 ### Prerequisites


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add an option in e2e tests to skip tests
- When combined with --skip-teardown, one can set up the test cluster without running tests.
- Tests can be run using `go test` once the cluster is up and running.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
