### PR TITLE
Add Delivery Retry Benchmark and Update PubSub Protocol

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	cloud.google.com/go/logging v1.0.1-0.20200331222814-69e77e66e597
 	cloud.google.com/go/pubsub v1.6.1
 	cloud.google.com/go/storage v1.10.0
-	github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.2.1-0.20200729225950-2d83dc10864e
+	github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.2.1-0.20200806165906-9ae0708e27fa
 	github.com/cloudevents/sdk-go/v2 v2.2.1-0.20200729225950-2d83dc10864e
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/protobuf v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudevents/sdk-go v0.0.0-20190509003705-56931988abe3/go.mod h1:j1nZWMLGg3om8SswStBoY6/SHvcLM19MuZqwDtMtmzs=
 github.com/cloudevents/sdk-go v1.0.0 h1:gS5I0s2qPmdc4GBPlUmzZU7RH30BaiOdcRJ1RkXnPrc=
 github.com/cloudevents/sdk-go v1.0.0/go.mod h1:3TkmM0cFqkhCHOq5JzzRU/RxRkwzoS8TZ+G448qVTog=
-github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.2.1-0.20200729225950-2d83dc10864e h1:LYsfarHHum3oV7zTEihAu1ApT3x//8UOqfYs0mGxMwI=
-github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.2.1-0.20200729225950-2d83dc10864e/go.mod h1:KyGtbsR84tpP870ydX77lvHVq++zh3iUoY9dzUxj+cM=
+github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.2.1-0.20200806165906-9ae0708e27fa h1:FAj/qLSnlOc1sXV4JEXgqNn+2rdfB/848JnHSf70uA0=
+github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.2.1-0.20200806165906-9ae0708e27fa/go.mod h1:KyGtbsR84tpP870ydX77lvHVq++zh3iUoY9dzUxj+cM=
 github.com/cloudevents/sdk-go/v2 v2.0.0 h1:AUdGJwaSUnA+VvepKqgjy6XDkPcf0hf/3L7icEs1ibs=
 github.com/cloudevents/sdk-go/v2 v2.0.0/go.mod h1:3CTrpB4+u7Iaj6fd7E2Xvm5IxMdRoaAhqaRVnOr2rCU=
 github.com/cloudevents/sdk-go/v2 v2.2.0 h1:FlBJg7W0QywbOjuZGmRXUyFk8qkCHx2euETp+tuopSU=

--- a/vendor/github.com/cloudevents/sdk-go/protocol/pubsub/v2/write_pubsub_message.go
+++ b/vendor/github.com/cloudevents/sdk-go/protocol/pubsub/v2/write_pubsub_message.go
@@ -50,10 +50,13 @@ func (b *pubsubMessagePublisher) End(ctx context.Context) error {
 }
 
 func (b *pubsubMessagePublisher) SetData(reader io.Reader) error {
-	var buf bytes.Buffer
-	_, err := io.Copy(&buf, reader)
-	if err != nil {
-		return err
+	buf, ok := reader.(*bytes.Buffer)
+	if !ok {
+		buf = new(bytes.Buffer)
+		_, err := io.Copy(buf, reader)
+		if err != nil {
+			return err
+		}
 	}
 	b.Data = buf.Bytes()
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -104,7 +104,7 @@ github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1
 github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
-# github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.2.1-0.20200729225950-2d83dc10864e
+# github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.2.1-0.20200806165906-9ae0708e27fa
 ## explicit
 github.com/cloudevents/sdk-go/protocol/pubsub/v2
 github.com/cloudevents/sdk-go/protocol/pubsub/v2/context


### PR DESCRIPTION
## Proposed Changes

- Adds a delivery benchmark which tests publishing events to a retry queue
- Updates the pubsub protocol to include https://github.com/cloudevents/sdk-go/pull/565 which removes the data copy when writing pubsub messages.

## Benchmark Results
### Fanout Delivery

<table class='benchstat oldnew'>
<tr class='configs'><th><th>old<th>new


<tbody>
<tr><th>name<th colspan='2' class='metric'>time/op<th>delta
<tr class='unchanged'><td>DeliveryNoReply/0_bytes-16<td>9.01µs ± 1%<td>9.00µs ± 1%<td class='nodelta'>~<td class='note'>(p=0.672 n=29&#43;28)
<tr class='worse'><td>DeliveryNoReply/1000_bytes-16<td>9.25µs ± 1%<td>9.27µs ± 1%<td class='delta'>&#43;0.25%<td class='note'>(p=0.030 n=29&#43;30)
<tr class='unchanged'><td>DeliveryNoReply/1000000_bytes-16<td>146µs ± 2%<td>145µs ± 2%<td class='nodelta'>~<td class='note'>(p=0.113 n=25&#43;27)
<tr class='unchanged'><td>DeliveryWithReply/0_bytes-16<td>18.5µs ± 1%<td>18.5µs ± 1%<td class='nodelta'>~<td class='note'>(p=0.982 n=30&#43;30)
<tr class='unchanged'><td>DeliveryWithReply/1000_bytes-16<td>31.0µs ± 1%<td>31.0µs ± 1%<td class='nodelta'>~<td class='note'>(p=0.635 n=29&#43;29)
<tr class='unchanged'><td>DeliveryWithReply/1000000_bytes-16<td>375µs ± 1%<td>374µs ± 2%<td class='nodelta'>~<td class='note'>(p=0.701 n=29&#43;30)
<tr class='better'><td>DeliveryNoReplyFakeClient/0_bytes-16<td>2.49µs ± 2%<td>2.47µs ± 2%<td class='delta'>−0.57%<td class='note'>(p=0.015 n=30&#43;30)
<tr class='better'><td>DeliveryNoReplyFakeClient/1000_bytes-16<td>2.50µs ± 2%<td>2.49µs ± 1%<td class='delta'>−0.62%<td class='note'>(p=0.007 n=30&#43;28)
<tr class='better'><td>DeliveryNoReplyFakeClient/100000_bytes-16<td>2.51µs ± 1%<td>2.48µs ± 1%<td class='delta'>−1.32%<td class='note'>(p=0.000 n=30&#43;28)
<tr class='unchanged'><td>DeliveryWithReplyFakeClient/0_bytes-16<td>2.67µs ± 3%<td>2.66µs ± 3%<td class='nodelta'>~<td class='note'>(p=0.755 n=27&#43;30)
<tr class='unchanged'><td>DeliveryWithReplyFakeClient/1000_bytes-16<td>2.66µs ± 3%<td>2.65µs ± 4%<td class='nodelta'>~<td class='note'>(p=0.133 n=30&#43;30)
<tr class='unchanged'><td>DeliveryWithReplyFakeClient/100000_bytes-16<td>2.62µs ± 3%<td>2.63µs ± 3%<td class='nodelta'>~<td class='note'>(p=0.897 n=29&#43;30)
<tr class='unchanged'><td>DeliveryWithRetry/0_bytes-16<td>30.6µs ± 1%<td>30.6µs ± 1%<td class='nodelta'>~<td class='note'>(p=0.510 n=29&#43;30)
<tr class='unchanged'><td>DeliveryWithRetry/1000_bytes-16<td>30.3µs ± 1%<td>30.4µs ± 1%<td class='nodelta'>~<td class='note'>(p=0.068 n=29&#43;28)
<tr class='better'><td>DeliveryWithRetry/1000000_bytes-16<td>1.01ms ± 3%<td>0.90ms ± 4%<td class='delta'>−10.46%<td class='note'>(p=0.000 n=27&#43;27)
</tbody>

<tbody>
<tr><th>name<th colspan='2' class='metric'>alloc/op<th>delta
<tr class='unchanged'><td>DeliveryNoReply/0_bytes-16<td>7.39kB ± 0%<td>7.39kB ± 0%<td class='nodelta'>~<td class='note'>(p=0.594 n=27&#43;29)
<tr class='unchanged'><td>DeliveryNoReply/1000_bytes-16<td>7.71kB ± 0%<td>7.72kB ± 0%<td class='nodelta'>~<td class='note'>(p=0.289 n=30&#43;30)
<tr class='unchanged'><td>DeliveryNoReply/1000000_bytes-16<td>7.76kB ± 0%<td>7.75kB ± 0%<td class='nodelta'>~<td class='note'>(p=0.343 n=30&#43;30)
<tr class='unchanged'><td>DeliveryWithReply/0_bytes-16<td>14.6kB ± 0%<td>14.6kB ± 0%<td class='nodelta'>~<td class='note'>(p=0.642 n=28&#43;30)
<tr class='unchanged'><td>DeliveryWithReply/1000_bytes-16<td>49.5kB ± 0%<td>49.5kB ± 0%<td class='nodelta'>~<td class='note'>(p=0.225 n=30&#43;30)
<tr class='unchanged'><td>DeliveryWithReply/1000000_bytes-16<td>49.6kB ± 0%<td>49.6kB ± 0%<td class='nodelta'>~<td class='note'>(p=0.061 n=30&#43;30)
<tr class='unchanged'><td>DeliveryNoReplyFakeClient/0_bytes-16<td>3.30kB ± 0%<td>3.30kB ± 0%<td class='nodelta'>~<td class='note'>(all equal)
<tr class='unchanged'><td>DeliveryNoReplyFakeClient/1000_bytes-16<td>3.39kB ± 0%<td>3.39kB ± 0%<td class='nodelta'>~<td class='note'>(all equal)
<tr class='unchanged'><td>DeliveryNoReplyFakeClient/100000_bytes-16<td>3.39kB ± 0%<td>3.39kB ± 0%<td class='nodelta'>~<td class='note'>(all equal)
<tr class='unchanged'><td>DeliveryWithReplyFakeClient/0_bytes-16<td>4.90kB ± 0%<td>4.90kB ± 0%<td class='nodelta'>~<td class='note'>(all equal)
<tr class='unchanged'><td>DeliveryWithReplyFakeClient/1000_bytes-16<td>4.99kB ± 0%<td>4.99kB ± 0%<td class='nodelta'>~<td class='note'>(all equal)
<tr class='unchanged'><td>DeliveryWithReplyFakeClient/100000_bytes-16<td>4.99kB ± 0%<td>4.99kB ± 0%<td class='nodelta'>~<td class='note'>(all equal)
<tr class='unchanged'><td>DeliveryWithRetry/0_bytes-16<td>24.2kB ± 0%<td>24.2kB ± 0%<td class='nodelta'>~<td class='note'>(p=0.403 n=28&#43;30)
<tr class='better'><td>DeliveryWithRetry/1000_bytes-16<td>29.4kB ± 0%<td>28.3kB ± 0%<td class='delta'>−3.66%<td class='note'>(p=0.000 n=30&#43;30)
<tr class='better'><td>DeliveryWithRetry/1000000_bytes-16<td>4.55MB ± 1%<td>3.55MB ± 1%<td class='delta'>−22.10%<td class='note'>(p=0.000 n=30&#43;30)
</tbody>

<tbody>
<tr><th>name<th colspan='2' class='metric'>allocs/op<th>delta
<tr class='unchanged'><td>DeliveryNoReply/0_bytes-16<td>122 ± 0%<td>122 ± 0%<td class='nodelta'>~<td class='note'>(all equal)
<tr class='unchanged'><td>DeliveryNoReply/1000_bytes-16<td>132 ± 0%<td>132 ± 0%<td class='nodelta'>~<td class='note'>(all equal)
<tr class='unchanged'><td>DeliveryNoReply/1000000_bytes-16<td>132 ± 0%<td>132 ± 0%<td class='nodelta'>~<td class='note'>(all equal)
<tr class='unchanged'><td>DeliveryWithReply/0_bytes-16<td>237 ± 0%<td>237 ± 0%<td class='nodelta'>~<td class='note'>(all equal)
<tr class='unchanged'><td>DeliveryWithReply/1000_bytes-16<td>273 ± 0%<td>273 ± 0%<td class='nodelta'>~<td class='note'>(all equal)
<tr class='unchanged'><td>DeliveryWithReply/1000000_bytes-16<td>304 ± 0%<td>304 ± 0%<td class='nodelta'>~<td class='note'>(all equal)
<tr class='unchanged'><td>DeliveryNoReplyFakeClient/0_bytes-16<td>68.4 ± 1%<td>68.5 ± 1%<td class='nodelta'>~<td class='note'>(p=0.441 n=30&#43;30)
<tr class='unchanged'><td>DeliveryNoReplyFakeClient/1000_bytes-16<td>71.3 ± 1%<td>71.6 ± 1%<td class='nodelta'>~<td class='note'>(p=0.073 n=30&#43;30)
<tr class='unchanged'><td>DeliveryNoReplyFakeClient/100000_bytes-16<td>71.5 ± 1%<td>71.3 ± 1%<td class='nodelta'>~<td class='note'>(p=0.197 n=30&#43;30)
<tr class='unchanged'><td>DeliveryWithReplyFakeClient/0_bytes-16<td>96.0 ± 0%<td>96.0 ± 0%<td class='nodelta'>~<td class='note'>(all equal)
<tr class='unchanged'><td>DeliveryWithReplyFakeClient/1000_bytes-16<td>99.0 ± 0%<td>99.0 ± 0%<td class='nodelta'>~<td class='note'>(all equal)
<tr class='unchanged'><td>DeliveryWithReplyFakeClient/100000_bytes-16<td>99.0 ± 0%<td>99.0 ± 0%<td class='nodelta'>~<td class='note'>(all equal)
<tr class='unchanged'><td>DeliveryWithRetry/0_bytes-16<td>450 ± 0%<td>450 ± 0%<td class='nodelta'>~<td class='note'>(all equal)
<tr class='better'><td>DeliveryWithRetry/1000_bytes-16<td>464 ± 0%<td>462 ± 0%<td class='delta'>−0.43%<td class='note'>(p=0.000 n=30&#43;30)
<tr class='unchanged'><td>DeliveryWithRetry/1000000_bytes-16<td>516 ± 5%<td>510 ± 4%<td class='nodelta'>~<td class='note'>(p=0.104 n=30&#43;30)
</tbody>
</table>

### Ingress
#### Time/Op
<table>
<tr><th>name<th colspan='2' class='metric'>time/op<th>delta
<tr class='unchanged'><td>IngressHandler/0_bytes-16<td>9.61µs ± 2%<td>9.67µs ± 2%<td class='nodelta'>~<td class='note'>(p=0.325 n=10&#43;10)
<tr class='unchanged'><td>IngressHandler/1000_bytes-16<td>10.1µs ± 3%<td>10.0µs ± 2%<td class='nodelta'>~<td class='note'>(p=0.342 n=10&#43;10)
<tr class='better'><td>IngressHandler/100000_bytes-16<td>122µs ± 3%<td>115µs ±12%<td class='delta'>−5.64%<td class='note'>(p=0.015 n=8&#43;9)
</table>

#### Bytes/OP
<table>
<tr><th>name<th colspan='2' class='metric'>alloc/op<th>delta
<tr class='better'><td>IngressHandler/0_bytes-16<td>15.3kB ± 0%<td>15.3kB ± 0%<td class='delta'>−0.10%<td class='note'>(p=0.014 n=9&#43;10)
<tr class='better'><td>IngressHandler/1000_bytes-16<td>22.3kB ± 0%<td>21.2kB ± 0%<td class='delta'>−4.81%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='better'><td>IngressHandler/100000_bytes-16<td>759kB ± 0%<td>653kB ± 0%<td class='delta'>−13.96%<td class='note'>(p=0.000 n=8&#43;10)
</table>

#### Allocs/OP
<table>
<tr><th><th colspan='2' class='metric'>allocs/op<th>delta
<tr class='unchanged'><td>IngressHandler/0_bytes-16<td>269 ± 0%<td>269 ± 0%<td class='nodelta'>~<td class='note'>(all equal)
<tr class='better'><td>IngressHandler/1000_bytes-16<td>278 ± 0%<td>276 ± 0%<td class='delta'>−0.72%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='better'><td>IngressHandler/100000_bytes-16<td>310 ± 0%<td>308 ± 1%<td class='delta'>−0.61%<td class='note'>(p=0.000 n=9&#43;9)
</table>
