### PR TITLE
 Mark v1alpha1 source as deprecated in conversion

### DIFF
--- a/pkg/apis/convert/conversion_helper.go
+++ b/pkg/apis/convert/conversion_helper.go
@@ -18,6 +18,7 @@ package convert
 
 import (
 	"context"
+
 	duckv1 "github.com/google/knative-gcp/pkg/apis/duck/v1"
 	duckv1alpha1 "github.com/google/knative-gcp/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "github.com/google/knative-gcp/pkg/apis/duck/v1beta1"
@@ -32,7 +33,7 @@ import (
 
 const (
 	deprecatedV1Alpha1Reason = "v1alpha1Deprecated"
-	deprecatedV1Alpha1Msg = "V1alpha1 Sources will be deprecated after 0.18 cut."
+	deprecatedV1Alpha1Msg    = "V1alpha1 Sources will be deprecated after 0.18 cut."
 )
 
 var (

--- a/pkg/apis/convert/conversion_helper.go
+++ b/pkg/apis/convert/conversion_helper.go
@@ -32,13 +32,14 @@ import (
 )
 
 const (
+	DeprecatedType           = "Deprecated"
 	deprecatedV1Alpha1Reason = "v1alpha1Deprecated"
-	deprecatedV1Alpha1Msg    = "V1alpha1 Sources will be deprecated after 0.18 cut."
+	deprecatedV1Alpha1Msg    = "V1alpha1 has been deprecated and will be removed in 0.18."
 )
 
 var (
 	DeprecatedV1Alpha1Condition = apis.Condition{
-		Type:     "Deprecated",
+		Type:     DeprecatedType,
 		Reason:   deprecatedV1Alpha1Reason,
 		Status:   corev1.ConditionTrue,
 		Severity: apis.ConditionSeverityWarning,
@@ -328,12 +329,14 @@ func FromV1beta1SubscribableSpec(from *eventingduckv1beta1.SubscribableSpec) *ev
 
 // A helper function to mark v1alpha1 Deprecated Condition in the Status.
 // We mark the Condition in status during conversion from a higher version to v1alpha1.
+// TODO: remove after the 0.17 cut.
 func MarkV1alpha1Deprecated(cs *apis.ConditionSet, s *pkgduckv1.Status) {
 	cs.Manage(s).SetCondition(DeprecatedV1Alpha1Condition)
 }
 
 // A helper function to remove Deprecated Condition from the Status during conversion
 // from v1alpha1 to a higher version.
+// TODO: remove after the 0.17 cut.
 func RemoveV1alpha1Deprecated(cs *apis.ConditionSet, s *pkgduckv1.Status) {
-	cs.Manage(s).ClearCondition("Deprecated")
+	cs.Manage(s).ClearCondition(DeprecatedType)
 }

--- a/pkg/apis/convert/conversion_helper.go
+++ b/pkg/apis/convert/conversion_helper.go
@@ -18,16 +18,31 @@ package convert
 
 import (
 	"context"
-
-	pkgduckv1 "knative.dev/pkg/apis/duck/v1"
-
 	duckv1 "github.com/google/knative-gcp/pkg/apis/duck/v1"
 	duckv1alpha1 "github.com/google/knative-gcp/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "github.com/google/knative-gcp/pkg/apis/duck/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	eventingduckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
+	"knative.dev/pkg/apis"
+	pkgduckv1 "knative.dev/pkg/apis/duck/v1"
 	pkgduckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	pkgduckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+)
+
+const (
+	deprecatedV1Alpha1Reason = "v1alpha1Deprecated"
+	deprecatedV1Alpha1Msg = "V1alpha1 Sources will be deprecated after 0.18 cut."
+)
+
+var (
+	DeprecatedV1Alpha1Condition = apis.Condition{
+		Type:     "Deprecated",
+		Reason:   deprecatedV1Alpha1Reason,
+		Status:   corev1.ConditionTrue,
+		Severity: apis.ConditionSeverityWarning,
+		Message:  deprecatedV1Alpha1Msg,
+	}
 )
 
 func ToV1beta1PubSubSpec(from duckv1alpha1.PubSubSpec) duckv1beta1.PubSubSpec {
@@ -308,4 +323,16 @@ func FromV1beta1SubscribableSpec(from *eventingduckv1beta1.SubscribableSpec) *ev
 		}
 	}
 	return &to
+}
+
+// A helper function to mark v1alpha1 Deprecated Condition in the Status.
+// We mark the Condition in status during conversion from a higher version to v1alpha1.
+func MarkV1alpha1Deprecated(cs *apis.ConditionSet, s *pkgduckv1.Status) {
+	cs.Manage(s).SetCondition(DeprecatedV1Alpha1Condition)
+}
+
+// A helper function to remove Deprecated Condition from the Status during conversion
+// from v1alpha1 to a higher version.
+func RemoveV1alpha1Deprecated(cs *apis.ConditionSet, s *pkgduckv1.Status) {
+	cs.Manage(s).ClearCondition("Deprecated")
 }

--- a/pkg/apis/convert/conversion_helper_test.go
+++ b/pkg/apis/convert/conversion_helper_test.go
@@ -21,36 +21,13 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/knative-gcp/pkg/apis/convert"
 	gcptesting "github.com/google/knative-gcp/pkg/testing"
-	eventingduckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
-	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
-)
-
-var (
-	trueVal       = true
-	three         = int32(3)
-	backoffPolicy = eventingduckv1beta1.BackoffPolicyExponential
-	backoffDelay  = "backoffDelay"
-
-	completeSubscribable = &eventingduckv1alpha1.Subscribable{
-		Subscribers: []eventingduckv1alpha1.SubscriberSpec{
-			{
-				UID:               "uid-1",
-				Generation:        1,
-				SubscriberURI:     &gcptesting.CompleteURL,
-				ReplyURI:          &gcptesting.CompleteURL,
-				DeadLetterSinkURI: &gcptesting.CompleteURL,
-				Delivery: &eventingduckv1beta1.DeliverySpec{
-					DeadLetterSink: &gcptesting.CompleteDestination,
-					Retry:          &three,
-					BackoffPolicy:  &backoffPolicy,
-					BackoffDelay:   &backoffDelay,
-				},
-			},
-		},
-	}
 )
 
 func TestV1beta1PubSubSpec(t *testing.T) {
@@ -196,7 +173,7 @@ func TestV1AddressStatus(t *testing.T) {
 
 func TestV1beta1SubscribableSpec(t *testing.T) {
 	// DeepCopy because we will edit it below.
-	want := completeSubscribable.DeepCopy()
+	want := gcptesting.CompleteV1alpha1Subscribable.DeepCopy()
 	v1b1 := convert.ToV1beta1SubscribableSpec(want)
 	got := convert.FromV1beta1SubscribableSpec(v1b1)
 
@@ -209,5 +186,22 @@ func TestV1beta1SubscribableSpec(t *testing.T) {
 	ignoreUsername := cmp.AllowUnexported(url.Userinfo{})
 	if diff := cmp.Diff(want, got, ignoreUsername); diff != "" {
 		t.Errorf("Unexpected difference (-want +got): %v", diff)
+	}
+}
+
+func TestV1alpha1Deprecated(t *testing.T) {
+	cs := apis.NewLivingConditionSet()
+	status := duckv1.Status{}
+	convert.MarkV1alpha1Deprecated(&cs, &status)
+	dc := status.GetCondition("Deprecated")
+	if dc == nil {
+		t.Errorf("MarkV1alpha1Deprecated should add a deprecated warning condition but it does not.")
+	} else if diff := cmp.Diff(*dc, convert.DeprecatedV1Alpha1Condition, cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime")); diff != "" {
+		t.Errorf("Failed to verify deprecated condition (-want, + got) = %v", diff)
+	}
+	convert.RemoveV1alpha1Deprecated(&cs, &status)
+	dc = status.GetCondition("Deprecated")
+	if dc != nil {
+		t.Errorf("RemoveV1alpha1Deprecated should remove the deprecated warning condition but it does not.")
 	}
 }

--- a/pkg/apis/events/v1alpha1/cloudauditlogssource_conversion.go
+++ b/pkg/apis/events/v1alpha1/cloudauditlogssource_conversion.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	"context"
-
 	"github.com/google/knative-gcp/pkg/apis/convert"
 	"github.com/google/knative-gcp/pkg/apis/events/v1beta1"
 	"knative.dev/pkg/apis"
@@ -36,6 +35,8 @@ func (source *CloudAuditLogsSource) ConvertTo(ctx context.Context, to apis.Conve
 		sink.Spec.ResourceName = source.Spec.ResourceName
 		sink.Status.PubSubStatus = convert.ToV1beta1PubSubStatus(source.Status.PubSubStatus)
 		sink.Status.StackdriverSink = source.Status.StackdriverSink
+		// Remove v1alpha1 as deprecated from the Status Condition when converting to a higher version.
+		convert.RemoveV1alpha1Deprecated(sink.ConditionSet(), &sink.Status.Status)
 		return nil
 	default:
 		return apis.ConvertToViaProxy(ctx, source, &v1beta1.CloudAuditLogsSource{}, sink)
@@ -54,6 +55,8 @@ func (sink *CloudAuditLogsSource) ConvertFrom(ctx context.Context, from apis.Con
 		sink.Spec.ResourceName = source.Spec.ResourceName
 		sink.Status.PubSubStatus = convert.FromV1beta1PubSubStatus(source.Status.PubSubStatus)
 		sink.Status.StackdriverSink = source.Status.StackdriverSink
+		// Mark v1alpha1 as deprecated as a Status Condition when converting to v1alpha1.
+		convert.MarkV1alpha1Deprecated(sink.ConditionSet(), &sink.Status.Status)
 		return nil
 	default:
 		return apis.ConvertFromViaProxy(ctx, source, &v1beta1.CloudAuditLogsSource{}, sink)

--- a/pkg/apis/events/v1alpha1/cloudauditlogssource_conversion.go
+++ b/pkg/apis/events/v1alpha1/cloudauditlogssource_conversion.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+
 	"github.com/google/knative-gcp/pkg/apis/convert"
 	"github.com/google/knative-gcp/pkg/apis/events/v1beta1"
 	"knative.dev/pkg/apis"

--- a/pkg/apis/events/v1alpha1/cloudauditlogssource_conversion_test.go
+++ b/pkg/apis/events/v1alpha1/cloudauditlogssource_conversion_test.go
@@ -100,7 +100,7 @@ func TestCloudAuditLogsSourceConversionBetweenV1beta1(t *testing.T) {
 
 				// Make sure the Deprecated Condition is added to the Status after converted back to v1alpha1,
 				// We need to ignore the LastTransitionTime as it is set in real time when doing the comparison.
-				dc := got.Status.GetCondition("Deprecated")
+				dc := got.Status.GetCondition(convert.DeprecatedType)
 				if dc == nil {
 					t.Errorf("ConvertFrom() should add a deprecated warning condition but it does not.")
 				} else if diff := cmp.Diff(*dc, convert.DeprecatedV1Alpha1Condition,
@@ -109,7 +109,7 @@ func TestCloudAuditLogsSourceConversionBetweenV1beta1(t *testing.T) {
 				}
 				// Remove the Deprecated Condition from Status to compare the remaining of fields.
 				cs := apis.NewLivingConditionSet()
-				cs.Manage(&got.Status).ClearCondition("Deprecated")
+				cs.Manage(&got.Status).ClearCondition(convert.DeprecatedType)
 				ignoreUsername := cmp.AllowUnexported(url.Userinfo{})
 				if diff := cmp.Diff(test.in, got, ignoreUsername); diff != "" {
 					t.Errorf("roundtrip (-want, +got) = %v", diff)
@@ -156,7 +156,7 @@ func TestCloudAuditLogsSourceConversionBetweenV1(t *testing.T) {
 
 				// Make sure the Deprecated Condition is added to the Status after converted back to v1alpha1,
 				// We need to ignore the LastTransitionTime as it is set in real time when doing the comparison.
-				dc := got.Status.GetCondition("Deprecated")
+				dc := got.Status.GetCondition(convert.DeprecatedType)
 				if dc == nil {
 					t.Errorf("ConvertFrom() should add a deprecated warning condition but it does not.")
 				} else if diff := cmp.Diff(*dc, convert.DeprecatedV1Alpha1Condition,
@@ -165,7 +165,8 @@ func TestCloudAuditLogsSourceConversionBetweenV1(t *testing.T) {
 				}
 				// Remove the Deprecated Condition from Status to compare the remaining of fields.
 				cs := apis.NewLivingConditionSet()
-				cs.Manage(&got.Status).ClearCondition("Deprecated")
+				cs.Manage(&got.Status).ClearCondition(convert.DeprecatedType)
+
 				ignoreUsername := cmp.AllowUnexported(url.Userinfo{})
 				// IdentityStatus.ServiceAccountName in v1alpha1 and v1beta1, it doesn't exist in v1.
 				// So this is not a round trip, the field will be silently removed.

--- a/pkg/apis/events/v1alpha1/cloudauditlogssource_conversion_test.go
+++ b/pkg/apis/events/v1alpha1/cloudauditlogssource_conversion_test.go
@@ -18,6 +18,8 @@ package v1alpha1
 
 import (
 	"context"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/knative-gcp/pkg/apis/convert"
 	"net/url"
 	"testing"
 
@@ -94,6 +96,19 @@ func TestCloudAuditLogsSourceConversionBetweenV1beta1(t *testing.T) {
 				if err := got.ConvertFrom(context.Background(), ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
+
+				// Make sure the Deprecated Condition is added to the Status after converted back to v1alpha1,
+				// We need to ignore the LastTransitionTime as it is set in real time when doing the comparison.
+				dc := got.Status.GetCondition("Deprecated")
+				if dc == nil {
+					t.Errorf("ConvertFrom() should add a deprecated warning condition but it does not.")
+				} else if diff := cmp.Diff(*dc, convert.DeprecatedV1Alpha1Condition,
+					cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime")); diff !="" {
+					t.Errorf("Failed to verify deprecated condition (-want, + got) = %v", diff)
+				}
+				// Remove the Deprecated Condition from Status to compare the remaining of fields.
+				cs := apis.NewLivingConditionSet()
+				cs.Manage(&got.Status).ClearCondition("Deprecated")
 				ignoreUsername := cmp.AllowUnexported(url.Userinfo{})
 				if diff := cmp.Diff(test.in, got, ignoreUsername); diff != "" {
 					t.Errorf("roundtrip (-want, +got) = %v", diff)
@@ -137,6 +152,19 @@ func TestCloudAuditLogsSourceConversionBetweenV1(t *testing.T) {
 				if err := got.ConvertFrom(context.Background(), ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
+
+				// Make sure the Deprecated Condition is added to the Status after converted back to v1alpha1,
+				// We need to ignore the LastTransitionTime as it is set in real time when doing the comparison.
+				dc := got.Status.GetCondition("Deprecated")
+				if dc == nil {
+					t.Errorf("ConvertFrom() should add a deprecated warning condition but it does not.")
+				} else if diff := cmp.Diff(*dc, convert.DeprecatedV1Alpha1Condition,
+					cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime")); diff !="" {
+					t.Errorf("Failed to verify deprecated condition (-want, + got) = %v", diff)
+				}
+				// Remove the Deprecated Condition from Status to compare the remaining of fields.
+				cs := apis.NewLivingConditionSet()
+				cs.Manage(&got.Status).ClearCondition("Deprecated")
 				ignoreUsername := cmp.AllowUnexported(url.Userinfo{})
 				// IdentityStatus.ServiceAccountName in v1alpha1 and v1beta1, it doesn't exist in v1.
 				// So this is not a round trip, the field will be silently removed.

--- a/pkg/apis/events/v1alpha1/cloudauditlogssource_conversion_test.go
+++ b/pkg/apis/events/v1alpha1/cloudauditlogssource_conversion_test.go
@@ -18,10 +18,11 @@ package v1alpha1
 
 import (
 	"context"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/knative-gcp/pkg/apis/convert"
 	"net/url"
 	"testing"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/knative-gcp/pkg/apis/convert"
 
 	"github.com/google/go-cmp/cmp"
 	v1 "github.com/google/knative-gcp/pkg/apis/events/v1"
@@ -103,7 +104,7 @@ func TestCloudAuditLogsSourceConversionBetweenV1beta1(t *testing.T) {
 				if dc == nil {
 					t.Errorf("ConvertFrom() should add a deprecated warning condition but it does not.")
 				} else if diff := cmp.Diff(*dc, convert.DeprecatedV1Alpha1Condition,
-					cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime")); diff !="" {
+					cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime")); diff != "" {
 					t.Errorf("Failed to verify deprecated condition (-want, + got) = %v", diff)
 				}
 				// Remove the Deprecated Condition from Status to compare the remaining of fields.
@@ -159,7 +160,7 @@ func TestCloudAuditLogsSourceConversionBetweenV1(t *testing.T) {
 				if dc == nil {
 					t.Errorf("ConvertFrom() should add a deprecated warning condition but it does not.")
 				} else if diff := cmp.Diff(*dc, convert.DeprecatedV1Alpha1Condition,
-					cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime")); diff !="" {
+					cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime")); diff != "" {
 					t.Errorf("Failed to verify deprecated condition (-want, + got) = %v", diff)
 				}
 				// Remove the Deprecated Condition from Status to compare the remaining of fields.

--- a/pkg/apis/events/v1alpha1/cloudbuildsource_conversion.go
+++ b/pkg/apis/events/v1alpha1/cloudbuildsource_conversion.go
@@ -34,6 +34,8 @@ func (source *CloudBuildSource) ConvertTo(_ context.Context, to apis.Convertible
 		// v1beta1 CloudBuildSource implements duck v1 PubSubable
 		sink.Spec.PubSubSpec = convert.FromV1alpha1ToV1PubSubSpec(source.Spec.PubSubSpec)
 		sink.Status.PubSubStatus = convert.FromV1alpha1ToV1PubSubStatus(source.Status.PubSubStatus)
+		// Remove v1alpha1 as deprecated from the Status Condition when converting to a higher version.
+		convert.RemoveV1alpha1Deprecated(sink.ConditionSet(), &sink.Status.Status)
 		return nil
 	default:
 		return fmt.Errorf("unknown conversion, got: %T", sink)
@@ -50,6 +52,8 @@ func (sink *CloudBuildSource) ConvertFrom(_ context.Context, from apis.Convertib
 		// v1beta1 CloudBuildSource implements duck v1 PubSubable
 		sink.Spec.PubSubSpec = convert.FromV1ToV1alpha1PubSubSpec(source.Spec.PubSubSpec)
 		sink.Status.PubSubStatus = convert.FromV1ToV1alpha1PubSubStatus(source.Status.PubSubStatus)
+		// Mark v1alpha1 as deprecated as a Status Condition when converting to v1alpha1.
+		convert.MarkV1alpha1Deprecated(sink.ConditionSet(), &sink.Status.Status)
 		return nil
 	default:
 		return fmt.Errorf("unknown conversion, got: %T", source)

--- a/pkg/apis/events/v1alpha1/cloudbuildsource_conversion_test.go
+++ b/pkg/apis/events/v1alpha1/cloudbuildsource_conversion_test.go
@@ -21,6 +21,9 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/knative-gcp/pkg/apis/convert"
+
 	"github.com/google/knative-gcp/pkg/apis/events/v1beta1"
 
 	"github.com/google/go-cmp/cmp"
@@ -90,6 +93,20 @@ func TestClouBuildSourceConversion(t *testing.T) {
 				if err := got.ConvertFrom(context.Background(), ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
+
+				// Make sure the Deprecated Condition is added to the Status after converted back to v1alpha1,
+				// We need to ignore the LastTransitionTime as it is set in real time when doing the comparison.
+				dc := got.Status.GetCondition(convert.DeprecatedType)
+				if dc == nil {
+					t.Errorf("ConvertFrom() should add a deprecated warning condition but it does not.")
+				} else if diff := cmp.Diff(*dc, convert.DeprecatedV1Alpha1Condition,
+					cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime")); diff != "" {
+					t.Errorf("Failed to verify deprecated condition (-want, + got) = %v", diff)
+				}
+				// Remove the Deprecated Condition from Status to compare the remaining of fields.
+				cs := apis.NewLivingConditionSet()
+				cs.Manage(&got.Status).ClearCondition(convert.DeprecatedType)
+
 				ignoreUsername := cmp.AllowUnexported(url.Userinfo{})
 				if diff := cmp.Diff(test.in, got, ignoreUsername); diff != "" {
 					t.Errorf("roundtrip (-want, +got) = %v", diff)

--- a/pkg/apis/events/v1alpha1/cloudpubsubsource_conversion.go
+++ b/pkg/apis/events/v1alpha1/cloudpubsubsource_conversion.go
@@ -36,6 +36,8 @@ func (source *CloudPubSubSource) ConvertTo(ctx context.Context, to apis.Converti
 		sink.Spec.RetainAckedMessages = source.Spec.RetainAckedMessages
 		sink.Spec.RetentionDuration = source.Spec.RetentionDuration
 		sink.Status.PubSubStatus = convert.ToV1beta1PubSubStatus(source.Status.PubSubStatus)
+		// Remove v1alpha1 as deprecated from the Status Condition when converting to a higher version.
+		convert.RemoveV1alpha1Deprecated(sink.ConditionSet(), &sink.Status.Status)
 		return nil
 	default:
 		return apis.ConvertToViaProxy(ctx, source, &v1beta1.CloudPubSubSource{}, sink)
@@ -54,6 +56,8 @@ func (sink *CloudPubSubSource) ConvertFrom(ctx context.Context, from apis.Conver
 		sink.Spec.RetainAckedMessages = source.Spec.RetainAckedMessages
 		sink.Spec.RetentionDuration = source.Spec.RetentionDuration
 		sink.Status.PubSubStatus = convert.FromV1beta1PubSubStatus(source.Status.PubSubStatus)
+		// Mark v1alpha1 as deprecated as a Status Condition when converting to v1alpha1.
+		convert.MarkV1alpha1Deprecated(sink.ConditionSet(), &sink.Status.Status)
 		return nil
 	default:
 		return apis.ConvertFromViaProxy(ctx, source, &v1beta1.CloudPubSubSource{}, sink)

--- a/pkg/apis/events/v1alpha1/cloudpubsubsource_conversion_test.go
+++ b/pkg/apis/events/v1alpha1/cloudpubsubsource_conversion_test.go
@@ -21,6 +21,9 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/knative-gcp/pkg/apis/convert"
+
 	"github.com/google/go-cmp/cmp"
 	v1 "github.com/google/knative-gcp/pkg/apis/events/v1"
 	"github.com/google/knative-gcp/pkg/apis/events/v1beta1"
@@ -94,6 +97,20 @@ func TestCloudPubSubSourceConversionBetweenV1beta1(t *testing.T) {
 				if err := got.ConvertFrom(context.Background(), ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
+
+				// Make sure the Deprecated Condition is added to the Status after converted back to v1alpha1,
+				// We need to ignore the LastTransitionTime as it is set in real time when doing the comparison.
+				dc := got.Status.GetCondition(convert.DeprecatedType)
+				if dc == nil {
+					t.Errorf("ConvertFrom() should add a deprecated warning condition but it does not.")
+				} else if diff := cmp.Diff(*dc, convert.DeprecatedV1Alpha1Condition,
+					cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime")); diff != "" {
+					t.Errorf("Failed to verify deprecated condition (-want, + got) = %v", diff)
+				}
+				// Remove the Deprecated Condition from Status to compare the remaining of fields.
+				cs := apis.NewLivingConditionSet()
+				cs.Manage(&got.Status).ClearCondition(convert.DeprecatedType)
+
 				ignoreUsername := cmp.AllowUnexported(url.Userinfo{})
 				if diff := cmp.Diff(test.in, got, ignoreUsername); diff != "" {
 					t.Errorf("roundtrip (-want, +got) = %v", diff)
@@ -137,6 +154,20 @@ func TestCloudPubSubSourceConversionBetweenV1(t *testing.T) {
 				if err := got.ConvertFrom(context.Background(), ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
+
+				// Make sure the Deprecated Condition is added to the Status after converted back to v1alpha1,
+				// We need to ignore the LastTransitionTime as it is set in real time when doing the comparison.
+				dc := got.Status.GetCondition(convert.DeprecatedType)
+				if dc == nil {
+					t.Errorf("ConvertFrom() should add a deprecated warning condition but it does not.")
+				} else if diff := cmp.Diff(*dc, convert.DeprecatedV1Alpha1Condition,
+					cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime")); diff != "" {
+					t.Errorf("Failed to verify deprecated condition (-want, + got) = %v", diff)
+				}
+				// Remove the Deprecated Condition from Status to compare the remaining of fields.
+				cs := apis.NewLivingConditionSet()
+				cs.Manage(&got.Status).ClearCondition(convert.DeprecatedType)
+
 				ignoreUsername := cmp.AllowUnexported(url.Userinfo{})
 				// IdentityStatus.ServiceAccountName in v1alpha1 and v1beta1, it doesn't exist in v1.
 				// So this is not a round trip, the field will be silently removed.

--- a/pkg/apis/events/v1alpha1/cloudschedulersource_conversion.go
+++ b/pkg/apis/events/v1alpha1/cloudschedulersource_conversion.go
@@ -36,6 +36,8 @@ func (source *CloudSchedulerSource) ConvertTo(ctx context.Context, to apis.Conve
 		sink.Spec.Data = source.Spec.Data
 		sink.Status.PubSubStatus = convert.ToV1beta1PubSubStatus(source.Status.PubSubStatus)
 		sink.Status.JobName = source.Status.JobName
+		// Remove v1alpha1 as deprecated from the Status Condition when converting to a higher version.
+		convert.RemoveV1alpha1Deprecated(sink.ConditionSet(), &sink.Status.Status)
 		return nil
 	default:
 		return apis.ConvertToViaProxy(ctx, source, &v1beta1.CloudSchedulerSource{}, sink)
@@ -54,6 +56,8 @@ func (sink *CloudSchedulerSource) ConvertFrom(ctx context.Context, from apis.Con
 		sink.Spec.Data = source.Spec.Data
 		sink.Status.PubSubStatus = convert.FromV1beta1PubSubStatus(source.Status.PubSubStatus)
 		sink.Status.JobName = source.Status.JobName
+		// Mark v1alpha1 as deprecated as a Status Condition when converting to v1alpha1.
+		convert.MarkV1alpha1Deprecated(sink.ConditionSet(), &sink.Status.Status)
 		return nil
 	default:
 		return apis.ConvertFromViaProxy(ctx, source, &v1beta1.CloudSchedulerSource{}, sink)

--- a/pkg/apis/events/v1alpha1/cloudschedulersource_conversion_test.go
+++ b/pkg/apis/events/v1alpha1/cloudschedulersource_conversion_test.go
@@ -21,6 +21,9 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/knative-gcp/pkg/apis/convert"
+
 	"github.com/google/go-cmp/cmp"
 	v1 "github.com/google/knative-gcp/pkg/apis/events/v1"
 	"github.com/google/knative-gcp/pkg/apis/events/v1beta1"
@@ -94,6 +97,20 @@ func TestCloudSchedulerSourceConversionBetweenV1beta1(t *testing.T) {
 				if err := got.ConvertFrom(context.Background(), ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
+
+				// Make sure the Deprecated Condition is added to the Status after converted back to v1alpha1,
+				// We need to ignore the LastTransitionTime as it is set in real time when doing the comparison.
+				dc := got.Status.GetCondition(convert.DeprecatedType)
+				if dc == nil {
+					t.Errorf("ConvertFrom() should add a deprecated warning condition but it does not.")
+				} else if diff := cmp.Diff(*dc, convert.DeprecatedV1Alpha1Condition,
+					cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime")); diff != "" {
+					t.Errorf("Failed to verify deprecated condition (-want, + got) = %v", diff)
+				}
+				// Remove the Deprecated Condition from Status to compare the remaining of fields.
+				cs := apis.NewLivingConditionSet()
+				cs.Manage(&got.Status).ClearCondition(convert.DeprecatedType)
+
 				ignoreUsername := cmp.AllowUnexported(url.Userinfo{})
 				if diff := cmp.Diff(test.in, got, ignoreUsername); diff != "" {
 					t.Errorf("roundtrip (-want, +got) = %v", diff)
@@ -137,6 +154,20 @@ func TestCloudSchedulerSourceConversionBetweenV1(t *testing.T) {
 				if err := got.ConvertFrom(context.Background(), ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
+
+				// Make sure the Deprecated Condition is added to the Status after converted back to v1alpha1,
+				// We need to ignore the LastTransitionTime as it is set in real time when doing the comparison.
+				dc := got.Status.GetCondition(convert.DeprecatedType)
+				if dc == nil {
+					t.Errorf("ConvertFrom() should add a deprecated warning condition but it does not.")
+				} else if diff := cmp.Diff(*dc, convert.DeprecatedV1Alpha1Condition,
+					cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime")); diff != "" {
+					t.Errorf("Failed to verify deprecated condition (-want, + got) = %v", diff)
+				}
+				// Remove the Deprecated Condition from Status to compare the remaining of fields.
+				cs := apis.NewLivingConditionSet()
+				cs.Manage(&got.Status).ClearCondition(convert.DeprecatedType)
+
 				// IdentityStatus.ServiceAccountName in v1alpha1 and v1beta1, it doesn't exist in v1.
 				// So this is not a round trip, the field will be silently removed.
 				in.Status.ServiceAccountName = ""

--- a/pkg/apis/events/v1alpha1/cloudstoragesource_conversion.go
+++ b/pkg/apis/events/v1alpha1/cloudstoragesource_conversion.go
@@ -38,6 +38,8 @@ func (source *CloudStorageSource) ConvertTo(ctx context.Context, to apis.Convert
 		sink.Spec.PayloadFormat = source.Spec.PayloadFormat
 		sink.Status.PubSubStatus = convert.ToV1beta1PubSubStatus(source.Status.PubSubStatus)
 		sink.Status.NotificationID = source.Status.NotificationID
+		// Remove v1alpha1 as deprecated from the Status Condition when converting to a higher version.
+		convert.RemoveV1alpha1Deprecated(sink.ConditionSet(), &sink.Status.Status)
 		return nil
 	default:
 		return apis.ConvertToViaProxy(ctx, source, &v1beta1.CloudStorageSource{}, sink)
@@ -59,6 +61,8 @@ func (sink *CloudStorageSource) ConvertFrom(ctx context.Context, from apis.Conve
 		sink.Spec.PayloadFormat = source.Spec.PayloadFormat
 		sink.Status.PubSubStatus = convert.FromV1beta1PubSubStatus(source.Status.PubSubStatus)
 		sink.Status.NotificationID = source.Status.NotificationID
+		// Mark v1alpha1 as deprecated as a Status Condition when converting to v1alpha1.
+		convert.MarkV1alpha1Deprecated(sink.ConditionSet(), &sink.Status.Status)
 		return nil
 	default:
 		return apis.ConvertFromViaProxy(ctx, source, &v1beta1.CloudStorageSource{}, sink)

--- a/pkg/apis/events/v1alpha1/cloudstoragesource_conversion_test.go
+++ b/pkg/apis/events/v1alpha1/cloudstoragesource_conversion_test.go
@@ -21,6 +21,9 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/knative-gcp/pkg/apis/convert"
+
 	v1 "github.com/google/knative-gcp/pkg/apis/events/v1"
 	"github.com/google/knative-gcp/pkg/apis/events/v1beta1"
 
@@ -96,6 +99,20 @@ func TestCloudStorageSourceConversionBetweenV1beta1(t *testing.T) {
 				if err := got.ConvertFrom(context.Background(), ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
+
+				// Make sure the Deprecated Condition is added to the Status after converted back to v1alpha1,
+				// We need to ignore the LastTransitionTime as it is set in real time when doing the comparison.
+				dc := got.Status.GetCondition(convert.DeprecatedType)
+				if dc == nil {
+					t.Errorf("ConvertFrom() should add a deprecated warning condition but it does not.")
+				} else if diff := cmp.Diff(*dc, convert.DeprecatedV1Alpha1Condition,
+					cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime")); diff != "" {
+					t.Errorf("Failed to verify deprecated condition (-want, + got) = %v", diff)
+				}
+				// Remove the Deprecated Condition from Status to compare the remaining of fields.
+				cs := apis.NewLivingConditionSet()
+				cs.Manage(&got.Status).ClearCondition(convert.DeprecatedType)
+
 				ignoreUsername := cmp.AllowUnexported(url.Userinfo{})
 				if diff := cmp.Diff(test.in, got, ignoreUsername); diff != "" {
 					t.Errorf("roundtrip (-want, +got) = %v", diff)
@@ -139,6 +156,20 @@ func TestCloudStorageSourceConversionBetweenV1(t *testing.T) {
 				if err := got.ConvertFrom(context.Background(), ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
+
+				// Make sure the Deprecated Condition is added to the Status after converted back to v1alpha1,
+				// We need to ignore the LastTransitionTime as it is set in real time when doing the comparison.
+				dc := got.Status.GetCondition(convert.DeprecatedType)
+				if dc == nil {
+					t.Errorf("ConvertFrom() should add a deprecated warning condition but it does not.")
+				} else if diff := cmp.Diff(*dc, convert.DeprecatedV1Alpha1Condition,
+					cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime")); diff != "" {
+					t.Errorf("Failed to verify deprecated condition (-want, + got) = %v", diff)
+				}
+				// Remove the Deprecated Condition from Status to compare the remaining of fields.
+				cs := apis.NewLivingConditionSet()
+				cs.Manage(&got.Status).ClearCondition(convert.DeprecatedType)
+
 				// ServiceAccountName and PayloadFormat only exists in v1alpha1 and v1beta1, they doesn't exist in v1.
 				// So it won't round trip, it will be silently removed.
 				in.Status.ServiceAccountName = ""

--- a/pkg/apis/intevents/v1alpha1/pullsubscription_conversion.go
+++ b/pkg/apis/intevents/v1alpha1/pullsubscription_conversion.go
@@ -46,6 +46,8 @@ func (source *PullSubscription) ConvertTo(ctx context.Context, to apis.Convertib
 		sink.Status.PubSubStatus = convert.ToV1beta1PubSubStatus(source.Status.PubSubStatus)
 		sink.Status.TransformerURI = source.Status.TransformerURI
 		sink.Status.SubscriptionID = source.Status.SubscriptionID
+		// Remove v1alpha1 as deprecated from the Status Condition when converting to a higher version.
+		convert.RemoveV1alpha1Deprecated(sink.ConditionSet(), &sink.Status.Status)
 		return nil
 	default:
 		return apis.ConvertToViaProxy(ctx, source, &v1beta1.PullSubscription{}, sink)
@@ -73,6 +75,8 @@ func (sink *PullSubscription) ConvertFrom(ctx context.Context, from apis.Convert
 		sink.Status.PubSubStatus = convert.FromV1beta1PubSubStatus(source.Status.PubSubStatus)
 		sink.Status.TransformerURI = source.Status.TransformerURI
 		sink.Status.SubscriptionID = source.Status.SubscriptionID
+		// Mark v1alpha1 as deprecated as a Status Condition when converting to v1alpha1.
+		convert.MarkV1alpha1Deprecated(sink.ConditionSet(), &sink.Status.Status)
 		return nil
 	default:
 		return apis.ConvertFromViaProxy(ctx, source, &v1beta1.PullSubscription{}, sink)

--- a/pkg/apis/intevents/v1alpha1/topic_conversion.go
+++ b/pkg/apis/intevents/v1alpha1/topic_conversion.go
@@ -49,6 +49,8 @@ func (source *Topic) ConvertTo(ctx context.Context, to apis.Convertible) error {
 		}
 		sink.Status.ProjectID = source.Status.ProjectID
 		sink.Status.TopicID = source.Status.TopicID
+		// Remove v1alpha1 as deprecated from the Status Condition when converting to a higher version.
+		convert.RemoveV1alpha1Deprecated(sink.ConditionSet(), &sink.Status.Status)
 		return nil
 	default:
 		return apis.ConvertToViaProxy(ctx, source, &v1beta1.Topic{}, sink)
@@ -80,6 +82,8 @@ func (sink *Topic) ConvertFrom(ctx context.Context, from apis.Convertible) error
 		}
 		sink.Status.ProjectID = source.Status.ProjectID
 		sink.Status.TopicID = source.Status.TopicID
+		// Mark v1alpha1 as deprecated as a Status Condition when converting to v1alpha1.
+		convert.MarkV1alpha1Deprecated(sink.ConditionSet(), &sink.Status.Status)
 		return nil
 	default:
 		return apis.ConvertFromViaProxy(ctx, source, &v1beta1.Topic{}, sink)

--- a/pkg/apis/messaging/v1alpha1/channel_conversion.go
+++ b/pkg/apis/messaging/v1alpha1/channel_conversion.go
@@ -47,6 +47,8 @@ func (source *Channel) ConvertTo(ctx context.Context, to apis.Convertible) error
 		source.Status.SubscribableTypeStatus.ConvertTo(ctx, &sink.Status.SubscribableStatus)
 		sink.Status.ProjectID = source.Status.ProjectID
 		sink.Status.TopicID = source.Status.TopicID
+		// Remove v1alpha1 as deprecated from the Status Condition when converting to a higher version.
+		convert.RemoveV1alpha1Deprecated(sink.ConditionSet(), &sink.Status.Status)
 		return nil
 	default:
 		return fmt.Errorf("unknown conversion, got: %T", sink)
@@ -76,6 +78,8 @@ func (sink *Channel) ConvertFrom(ctx context.Context, from apis.Convertible) err
 		}
 		sink.Status.ProjectID = source.Status.ProjectID
 		sink.Status.TopicID = source.Status.TopicID
+		// Mark v1alpha1 as deprecated as a Status Condition when converting to v1alpha1.
+		convert.MarkV1alpha1Deprecated(sink.ConditionSet(), &sink.Status.Status)
 		return nil
 	default:
 		return fmt.Errorf("unknown conversion, got: %T", source)

--- a/pkg/apis/messaging/v1alpha1/channel_conversion_test.go
+++ b/pkg/apis/messaging/v1alpha1/channel_conversion_test.go
@@ -20,165 +20,36 @@ import (
 	"context"
 	"net/url"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
-	duckv1alpha1 "github.com/google/knative-gcp/pkg/apis/duck/v1alpha1"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/knative-gcp/pkg/apis/convert"
 	"github.com/google/knative-gcp/pkg/apis/intevents/v1alpha1"
 	"github.com/google/knative-gcp/pkg/apis/messaging/v1beta1"
-	v1 "k8s.io/api/core/v1"
+	gcptesting "github.com/google/knative-gcp/pkg/testing"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	eventingduckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
-	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/eventing/pkg/apis/messaging"
 	"knative.dev/pkg/apis"
-	pkgduckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 // These variables are used to create a 'complete' version of Channel where every field is filled
 // in.
 var (
-	trueVal       = true
-	seconds       = int64(314)
-	three         = int32(3)
-	backoffPolicy = eventingduckv1beta1.BackoffPolicyExponential
-	backoffDelay  = "backoffDelay"
-
-	completeObjectMeta = metav1.ObjectMeta{
-		Name:            "name",
-		GenerateName:    "generateName",
-		Namespace:       "namespace",
-		SelfLink:        "selfLink",
-		UID:             "uid",
-		ResourceVersion: "resourceVersion",
-		Generation:      2012,
-		CreationTimestamp: metav1.Time{
-			Time: time.Unix(1, 1),
-		},
-		DeletionTimestamp: &metav1.Time{
-			Time: time.Unix(2, 3),
-		},
-		DeletionGracePeriodSeconds: &seconds,
-		Labels:                     map[string]string{"steel": "heart"},
-		Annotations:                map[string]string{"New": "Cago"},
-		OwnerReferences: []metav1.OwnerReference{
-			{
-				APIVersion:         "apiVersion",
-				Kind:               "kind",
-				Name:               "n",
-				UID:                "uid",
-				Controller:         &trueVal,
-				BlockOwnerDeletion: &trueVal,
-			},
-		},
-		Finalizers:  []string{"finalizer-1", "finalizer-2"},
-		ClusterName: "clusterName",
-	}
-
-	completeURL = apis.URL{
-		Scheme:     "scheme",
-		Opaque:     "opaque",
-		User:       url.User("user"),
-		Host:       "host",
-		Path:       "path",
-		RawPath:    "rawPath",
-		ForceQuery: false,
-		RawQuery:   "rawQuery",
-		Fragment:   "fragment",
-	}
-
-	completeDestination = pkgduckv1.Destination{
-		Ref: &pkgduckv1.KReference{
-			APIVersion: "apiVersion",
-			Kind:       "kind",
-			Namespace:  "namespace",
-			Name:       "name",
-		},
-		URI: &completeURL,
-	}
-
-	completeIdentitySpec = duckv1alpha1.IdentitySpec{
-		ServiceAccountName: "k8sServiceAccount",
-	}
-
-	completeSecret = &v1.SecretKeySelector{
-		LocalObjectReference: v1.LocalObjectReference{
-			Name: "name",
-		},
-		Key:      "key",
-		Optional: &trueVal,
-	}
-
-	completeSubscribable = &eventingduckv1alpha1.Subscribable{
-		Subscribers: []eventingduckv1alpha1.SubscriberSpec{
-			{
-				UID:               "uid-1",
-				Generation:        1,
-				SubscriberURI:     &completeURL,
-				ReplyURI:          &completeURL,
-				DeadLetterSinkURI: &completeURL,
-				Delivery: &eventingduckv1beta1.DeliverySpec{
-					DeadLetterSink: &completeDestination,
-					Retry:          &three,
-					BackoffPolicy:  &backoffPolicy,
-					BackoffDelay:   &backoffDelay,
-				},
-			},
-		},
-	}
-
-	completeIdentityStatus = duckv1alpha1.IdentityStatus{
-		Status: pkgduckv1.Status{
-			ObservedGeneration: 7,
-			Conditions: pkgduckv1.Conditions{
-				{
-					Type:   "Ready",
-					Status: "True",
-				},
-			},
-		},
-	}
-
-	completeAddressStatus = pkgduckv1.AddressStatus{
-		Address: &pkgduckv1.Addressable{
-			URL: &completeURL,
-		},
-	}
-
-	completeSubscribableTypeStatus = eventingduckv1alpha1.SubscribableTypeStatus{
-		SubscribableStatus: &eventingduckv1alpha1.SubscribableStatus{
-			Subscribers: []eventingduckv1beta1.SubscriberStatus{
-				{
-					UID:                "uid-1",
-					ObservedGeneration: 1,
-					Ready:              "ready-1",
-					Message:            "message-1",
-				},
-				{
-					UID:                "uid-2",
-					ObservedGeneration: 2,
-					Ready:              "ready-2",
-					Message:            "message-2",
-				},
-			},
-		},
-	}
-
 	// completePullSubscription is a Channel with every field filled in, except TypeMeta. TypeMeta
 	// is excluded because conversions do not convert it and this variable was created to test
 	// conversions.
 	completeChannel = &Channel{
-		ObjectMeta: completeObjectMeta,
+		ObjectMeta: gcptesting.CompleteObjectMeta,
 		Spec: ChannelSpec{
-			IdentitySpec: completeIdentitySpec,
-			Secret:       completeSecret,
+			IdentitySpec: gcptesting.CompleteV1alpha1IdentitySpec,
+			Secret:       gcptesting.CompleteSecret,
 			Project:      "project",
-			Subscribable: completeSubscribable,
+			Subscribable: gcptesting.CompleteV1alpha1Subscribable,
 		},
 		Status: ChannelStatus{
-			IdentityStatus:         completeIdentityStatus,
-			AddressStatus:          completeAddressStatus,
-			SubscribableTypeStatus: completeSubscribableTypeStatus,
+			IdentityStatus:         gcptesting.CompleteV1alpha1IdentityStatus,
+			AddressStatus:          gcptesting.CompleteV1AddressStatus,
+			SubscribableTypeStatus: gcptesting.CompleteV1alpha1SubscribableTypeStatus,
 			ProjectID:              "projectId",
 			TopicID:                "topicID",
 		},
@@ -230,6 +101,8 @@ func TestChannelConversion(t *testing.T) {
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
 				ver := version.version
+				// DeepCopy because we will edit it below.
+				in := test.in.DeepCopy()
 				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
 					t.Errorf("ConvertTo() = %v", err)
 				}
@@ -248,21 +121,37 @@ func TestChannelConversion(t *testing.T) {
 
 				// The duck subscribable version of a v1alpha1 Channel will always be set to
 				// v1alpha1, even if it was not set in the original.
-				if test.in.Annotations == nil {
-					test.in.Annotations = make(map[string]string, 1)
+				if in.Annotations == nil {
+					in.Annotations = make(map[string]string, 1)
 				}
-				test.in.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1alpha1"
+				in.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1alpha1"
 
 				// DeadLetterSinkURI exists exclusively in v1alpha1, it has not yet been promoted to
 				// v1beta1. So it won't round trip, it will be silently removed.
-				if test.in.Spec.Subscribable != nil {
-					for i := range test.in.Spec.Subscribable.Subscribers {
-						test.in.Spec.Subscribable.Subscribers[i].DeadLetterSinkURI = nil
+				if in.Spec.Subscribable != nil {
+					for i := range in.Spec.Subscribable.Subscribers {
+						in.Spec.Subscribable.Subscribers[i].DeadLetterSinkURI = nil
 					}
 				}
 
+				// V1beta1 Channel implements duck v1 identifiable, where ServiceAccountName is removed.
+				// So this is not a round trip, the field will be silently removed.
+				in.Status.ServiceAccountName = ""
+				// Make sure the Deprecated Condition is added to the Status after converted back to v1alpha1,
+				// We need to ignore the LastTransitionTime as it is set in real time when doing the comparison.
+				dc := got.Status.GetCondition(convert.DeprecatedType)
+				if dc == nil {
+					t.Errorf("ConvertFrom() should add a deprecated warning condition but it does not.")
+				} else if diff := cmp.Diff(*dc, convert.DeprecatedV1Alpha1Condition,
+					cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime")); diff != "" {
+					t.Errorf("Failed to verify deprecated condition (-want, + got) = %v", diff)
+				}
+				// Remove the Deprecated Condition from Status to compare the remaining of fields.
+				cs := apis.NewLivingConditionSet()
+				cs.Manage(&got.Status).ClearCondition(convert.DeprecatedType)
+
 				ignoreUsername := cmp.AllowUnexported(url.Userinfo{})
-				if diff := cmp.Diff(test.in, got, ignoreUsername); diff != "" {
+				if diff := cmp.Diff(in, got, ignoreUsername); diff != "" {
 					t.Errorf("roundtrip (-want, +got) = %v", diff)
 				}
 			})


### PR DESCRIPTION
Fixes #1547 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Mark v1alpha1 as deprecated Condition in Status when doing the conversion.
- Refactor channel conversion UTs and nits.

Currently, the behaviours are: 
If describe v1alpha1 source, there will be a deprecated warning condition.
``` 
kubectl describe cloudauditlogssources.v1alpha1.events.cloud.google.com
Name:         cloudauditlogssource-test
Namespace:    default
Labels:       <none>
Annotations:  cluster-name: cluster-4
API Version:  events.cloud.google.com/v1alpha1
Kind:         CloudAuditLogsSource
Metadata:
  Creation Timestamp:  2020-08-07T22:44:24Z
  Finalizers:
    cloudauditlogssources.events.cloud.google.com
  Generation:        1
  Resource Version:  41882670
  Self Link:         /apis/events.cloud.google.com/v1alpha1/namespaces/default/cloudauditlogssources/cloudauditlogssource-test
  UID:               d3209a03-a4d0-476a-8642-7d116018b6b8
Spec: ...
Status:
  Conditions:
    Last Transition Time:  2020-08-07T22:44:54Z
    Message:               V1alpha1 Sources will be deprecated after 0.18 cut.
    Reason:                v1alpha1Deprecated
    Severity:              Warning
    Status:                True
    Type:                  Deprecated
    Last Transition Time:  2020-08-07T22:44:31Z
    Status:                True
    Type:                  PullSubscriptionReady
    Last Transition Time:  2020-08-07T22:44:31Z
    Status:                True
    Type:                  Ready
    Last Transition Time:  2020-08-07T22:44:31Z
    Status:                True
    Type:                  SinkReady
    Last Transition Time:  2020-08-07T22:44:27Z
    Status:                True
    Type:                  TopicReady
  Observed Generation:     1
  Project Id:              danyinggu-knative-dev
  Sink Uri:                http://event-display.default.svc.cluster.local/
  Stackdriver Sink:        cre-src_default_cloudauditlogssource-test_d3209a03-a4d0-476a-8642-7d116018b6b8
  Subscription Id:         cre-src_default_cloudauditlogssource-test_83e47966-abf4-4a51-8f2a-c709a02a1d22
  Topic Id:                cre-src_default_cloudauditlogssource-test_d3209a03-a4d0-476a-8642-7d116018b6b8

```

While, when
```
kubectl describe cloudauditlogssources.v1.events.cloud.google.com
Name:         cloudauditlogssource-test
Namespace:    default
Labels:       <none>
Annotations:  API Version:  events.cloud.google.com/v1
Kind:         CloudAuditLogsSource
Metadata:
  Creation Timestamp:  2020-08-07T22:44:24Z
  Finalizers:
    cloudauditlogssources.events.cloud.google.com
  Generation:        1
  Resource Version:  41882670
  Self Link:         /apis/events.cloud.google.com/v1/namespaces/default/cloudauditlogssources/cloudauditlogssource-test
  UID:               d3209a03-a4d0-476a-8642-7d116018b6b8
Spec:
  Method Name:  google.pubsub.v1.Publisher.CreateTopic
  Secret:
    Key:         key.json
    Name:        google-cloud-key
  Service Name:  pubsub.googleapis.com
  Sink:
    Ref:
      API Version:  v1
      Kind:         Service
      Name:         event-display
Status:
  Conditions:
    Last Transition Time:  2020-08-07T22:44:31Z
    Status:                True
    Type:                  PullSubscriptionReady
    Last Transition Time:  2020-08-07T22:44:31Z
    Status:                True
    Type:                  Ready
 Last Transition Time:  2020-08-07T22:44:31Z
    Status:                True
    Type:                  SinkReady
    Last Transition Time:  2020-08-07T22:44:27Z
    Status:                True
    Type:                  TopicReady
  Observed Generation:     1
```

There is no warning Deprecated condition.


<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
v1alpha1 resources (Source, Topic, PullSubscription and Channel) have been deprecated and will be removed in 0.18.
Please use v1 (v1beta1 for Channel) instead.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
