### PR TITLE
Increase sleep time for deletion test

### DIFF
--- a/test/e2e/lib/resources/constants.go
+++ b/test/e2e/lib/resources/constants.go
@@ -63,8 +63,9 @@ const (
 
 const (
 	// Tried with 20 seconds but the test has been quite flaky.
+	// Increase from 40 seconds to 60 seconds, for issue: https://github.com/google/knative-gcp/issues/1568.
 	// WaitDeletionTime for deleting resources
-	WaitDeletionTime = 40 * time.Second
+	WaitDeletionTime = 60 * time.Second
 	// WaitCALTime for time needed to wait to fire an event after CAL Source is ready
 	// Tried with 45 seconds but the test has been quite flaky.
 	// Tried with 90 seconds but the test has been quite flaky.

--- a/test/e2e/test_auditlogs.go
+++ b/test/e2e/test_auditlogs.go
@@ -114,7 +114,7 @@ func SmokeCloudAuditLogsSourceWithDeletionTestImpl(t *testing.T, authConfig lib.
 		t.Errorf("Expected subscription %q to exist", subID)
 	}
 	client.DeleteAuditLogsOrFail(auditlogsName)
-	//Wait for 40 seconds for topic, subscription and notification to get deleted in gcp
+	//Wait for 60 seconds for topic, subscription and notification to get deleted in gcp
 	time.Sleep(resources.WaitDeletionTime)
 
 	deletedSinkExists := lib.StackdriverSinkExists(t, sinkID)

--- a/test/e2e/test_build.go
+++ b/test/e2e/test_build.go
@@ -90,7 +90,7 @@ func SmokeCloudBuildSourceWithDeletionTestImpl(t *testing.T, authConfig lib.Auth
 	}
 
 	client.DeleteBuildOrFail(buildName)
-	//Wait for 40 seconds for subscription to get deleted in gcp
+	//Wait for 60 seconds for subscription to get deleted in gcp
 	time.Sleep(resources.WaitDeletionTime)
 	deletedSubExists := lib.SubscriptionExists(t, subID)
 	if deletedSubExists {

--- a/test/e2e/test_gcp_broker.go
+++ b/test/e2e/test_gcp_broker.go
@@ -147,7 +147,7 @@ func SmokeGCPBrokerTestImpl(t *testing.T, authConfig lib.AuthConfig) {
 	}
 
 	client.DeleteGCPBrokerOrFail(brokerName)
-	//Wait for 40 seconds for subscription to get deleted in gcp
+	//Wait for 60 seconds for subscription to get deleted in gcp
 	time.Sleep(knativegcptestresources.WaitDeletionTime)
 
 	deletedTopicExists := lib.TopicExists(t, topicID)

--- a/test/e2e/test_pubsub.go
+++ b/test/e2e/test_pubsub.go
@@ -97,7 +97,7 @@ func SmokeCloudPubSubSourceWithDeletionTestImpl(t *testing.T, authConfig lib.Aut
 	}
 
 	client.DeletePubSubOrFail(psName)
-	//Wait for 40 seconds for subscription to get deleted in gcp
+	//Wait for 60 seconds for subscription to get deleted in gcp
 	time.Sleep(resources.WaitDeletionTime)
 	deletedSubExists := lib.SubscriptionExists(t, subID)
 	if deletedSubExists {

--- a/test/e2e/test_scheduler.go
+++ b/test/e2e/test_scheduler.go
@@ -99,7 +99,7 @@ func SmokeCloudSchedulerSourceWithDeletionTestImpl(t *testing.T, authConfig lib.
 		t.Errorf("Expected subscription %q to exist", subID)
 	}
 	client.DeleteSchedulerOrFail(schedulerName)
-	//Wait for 40 seconds for topic, subscription and job to get deleted in gcp
+	//Wait for 60 seconds for topic, subscription and job to get deleted in gcp
 	time.Sleep(resources.WaitDeletionTime)
 
 	deletedJobExists := lib.SchedulerJobExists(t, jobName)

--- a/test/e2e/test_storage.go
+++ b/test/e2e/test_storage.go
@@ -113,7 +113,7 @@ func SmokeCloudStorageSourceWithDeletionTestImpl(t *testing.T, authConfig lib.Au
 		t.Errorf("Expected subscription %q to exist", subID)
 	}
 	client.DeleteStorageOrFail(storageName)
-	//Wait for 40 seconds for topic, subscription and notification to get deleted in gcp
+	//Wait for 60 seconds for topic, subscription and notification to get deleted in gcp
 	time.Sleep(resources.WaitDeletionTime)
 
 	deletedNotificationExists := lib.NotificationExists(t, bucketName, notificationID)


### PR DESCRIPTION
Fixes #1568 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- According to PubSub SLO, 99% admin operations (like create/delete) will finish in 60s. Try 60s for the sleep time
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
