### PR TITLE
Update sender retry configuration

### DIFF
--- a/test/test_images/sender/main.go
+++ b/test/test_images/sender/main.go
@@ -45,10 +45,10 @@ type envConfig struct {
 var defaultRetry = wait.Backoff{
 	Steps:    3,
 	Duration: 30 * time.Second,
-	Factor:   1.0,
+	Factor:   2.0,
 	// The sleep at each iteration is the duration plus an additional
 	// amount chosen uniformly at random from the interval between 0 and jitter*duration.
-	Jitter: 2.0,
+	Jitter: 1.0,
 }
 
 func main() {


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Update retry configuration in sender pod. Sometimes, sender pod will run out of retry times like: https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/google_knative-gcp/1531/pull-google-knative-gcp-wi-tests/1288747214872514560
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
