### PR TITLE
Add timeout delivery metrics

### DIFF
--- a/pkg/broker/handler/fanout_test.go
+++ b/pkg/broker/handler/fanout_test.go
@@ -334,6 +334,7 @@ func TestFanoutSyncPoolE2E(t *testing.T) {
 		}
 
 		expectMetrics.ExpectProcessing(t, t1.Name)
+		expectMetrics.ExpectTimeout(t, t1.Name)
 		expectMetrics.Expect200(t, t2.Name)
 		expectMetrics.Verify(t)
 	})

--- a/pkg/broker/handler/processors/deliver/processor.go
+++ b/pkg/broker/handler/processors/deliver/processor.go
@@ -164,8 +164,14 @@ func (p *Processor) deliver(ctx context.Context, target *config.Target, broker *
 		}
 	}()
 
+	// Insert status code tag into context.
+	cctx, err := metrics.AddRespStatusCodeTags(ctx, resp.StatusCode)
+	if err != nil {
+		logging.FromContext(ctx).Error("failed to add status code tags to context", zap.Error(err))
+	}
 	// Report event dispatch time with resp status code.
-	p.StatsReporter.ReportEventDispatchTime(metrics.WithRespStatusCode(ctx, resp.StatusCode), time.Since(startTime))
+	p.StatsReporter.ReportEventDispatchTime(cctx, time.Since(startTime))
+
 	if resp.StatusCode/100 != 2 {
 		return fmt.Errorf("event delivery failed: HTTP status code %d", resp.StatusCode)
 	}

--- a/pkg/broker/handler/processors/deliver/processor.go
+++ b/pkg/broker/handler/processors/deliver/processor.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
@@ -149,15 +150,22 @@ func (p *Processor) deliver(ctx context.Context, target *config.Target, broker *
 	// Remove hops from forwarded event.
 	resp, err := p.sendMsg(ctx, target.Address, msg, transformer.DeleteExtension(eventutil.HopsAttribute))
 	if err != nil {
+		var result *url.Error
+		if errors.As(err, &result) && result.Timeout() {
+			// If the delivery is cancelled because of timeout, report event dispatch time without resp status code.
+			p.StatsReporter.ReportEventDispatchTime(ctx, time.Since(startTime))
+		}
 		return err
 	}
+
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
 			logging.FromContext(ctx).Warn("failed to close response body", zap.Error(err))
 		}
 	}()
 
-	p.StatsReporter.ReportEventDispatchTime(ctx, time.Since(startTime), resp.StatusCode)
+	// Report event dispatch time with resp status code.
+	p.StatsReporter.ReportEventDispatchTime(metrics.WithRespStatusCode(ctx, resp.StatusCode), time.Since(startTime))
 	if resp.StatusCode/100 != 2 {
 		return fmt.Errorf("event delivery failed: HTTP status code %d", resp.StatusCode)
 	}

--- a/pkg/metrics/delivery_reporter.go
+++ b/pkg/metrics/delivery_reporter.go
@@ -129,8 +129,8 @@ func WithRespStatusCode(ctx context.Context, responseCode int) context.Context {
 
 // ReportEventDispatchTime captures dispatch times.
 func (r *DeliveryReporter) ReportEventDispatchTime(ctx context.Context, d time.Duration) {
-	responseCode, err := getRespStatusCode(ctx)
-	if err != nil {
+	responseCode, haveCode := getRespStatusCode(ctx)
+	if !haveCode {
 		// convert time.Duration in nanoseconds to milliseconds.
 		// If status code doesn't present, report metrics record without status code.
 		metrics.Record(ctx, r.dispatchTimeInMsecM.M(float64(d/time.Millisecond)))
@@ -199,10 +199,10 @@ func getStartDeliveryProcessingTime(ctx context.Context) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("missing or invalid start time: %v", v)
 }
 
-func getRespStatusCode(ctx context.Context) (int, error) {
+func getRespStatusCode(ctx context.Context) (int, bool) {
 	v := ctx.Value(respStatusCode)
 	if statusCode, ok := v.(int); ok {
-		return statusCode, nil
+		return statusCode, true
 	}
-	return 0, fmt.Errorf("missing or invalid status code: %v", v)
+	return 0, false
 }

--- a/pkg/metrics/delivery_reporter_test.go
+++ b/pkg/metrics/delivery_reporter_test.go
@@ -64,11 +64,11 @@ func TestReportEventDispatchTime(t *testing.T) {
 		t.Fatal(err)
 	}
 	reportertest.ExpectMetrics(t, func() error {
-		r.ReportEventDispatchTime(ctx, 1100*time.Millisecond, 202)
+		r.ReportEventDispatchTime(WithRespStatusCode(ctx, 202), 1100*time.Millisecond)
 		return nil
 	})
 	reportertest.ExpectMetrics(t, func() error {
-		r.ReportEventDispatchTime(ctx, 9100*time.Millisecond, 202)
+		r.ReportEventDispatchTime(WithRespStatusCode(ctx, 202), 9100*time.Millisecond)
 		return nil
 	})
 	metricstest.CheckCountData(t, "event_count", wantTags, 2)
@@ -120,8 +120,17 @@ func TestReportEventProcessingTime(t *testing.T) {
 	reportertest.ExpectMetrics(t, func() error {
 		return r.reportEventProcessingTime(ctx, startTime.Add(9100*time.Millisecond))
 	})
-
+	// Test report event dispatch time without status code.
+	reportertest.ExpectMetrics(t, func() error {
+		r.ReportEventDispatchTime(ctx, 1100*time.Millisecond)
+		return nil
+	})
+	reportertest.ExpectMetrics(t, func() error {
+		r.ReportEventDispatchTime(ctx, 9100*time.Millisecond)
+		return nil
+	})
 	metricstest.CheckDistributionData(t, "event_processing_latencies", wantTags, 2, 1100.0, 9100.0)
+	metricstest.CheckDistributionData(t, "event_dispatch_latencies", wantTags, 2, 1100.0, 9100.0)
 }
 
 func TestMetricsWithEmptySourceAndTypeFilter(t *testing.T) {
@@ -156,7 +165,7 @@ func TestMetricsWithEmptySourceAndTypeFilter(t *testing.T) {
 	}
 
 	reportertest.ExpectMetrics(t, func() error {
-		r.ReportEventDispatchTime(ctx, 1100*time.Millisecond, 202)
+		r.ReportEventDispatchTime(WithRespStatusCode(ctx, 202), 1100*time.Millisecond)
 		return nil
 	})
 	metricstest.CheckCountData(t, "event_count", wantTags, 1)

--- a/pkg/metrics/delivery_reporter_test.go
+++ b/pkg/metrics/delivery_reporter_test.go
@@ -63,12 +63,13 @@ func TestReportEventDispatchTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	cctx, _ := AddRespStatusCodeTags(ctx, 202)
 	reportertest.ExpectMetrics(t, func() error {
-		r.ReportEventDispatchTime(WithRespStatusCode(ctx, 202), 1100*time.Millisecond)
+		r.ReportEventDispatchTime(cctx, 1100*time.Millisecond)
 		return nil
 	})
 	reportertest.ExpectMetrics(t, func() error {
-		r.ReportEventDispatchTime(WithRespStatusCode(ctx, 202), 9100*time.Millisecond)
+		r.ReportEventDispatchTime(cctx, 9100*time.Millisecond)
 		return nil
 	})
 	metricstest.CheckCountData(t, "event_count", wantTags, 2)
@@ -163,9 +164,9 @@ func TestMetricsWithEmptySourceAndTypeFilter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	cctx, _ := AddRespStatusCodeTags(ctx, 202)
 	reportertest.ExpectMetrics(t, func() error {
-		r.ReportEventDispatchTime(WithRespStatusCode(ctx, 202), 1100*time.Millisecond)
+		r.ReportEventDispatchTime(cctx, 1100*time.Millisecond)
 		return nil
 	})
 	metricstest.CheckCountData(t, "event_count", wantTags, 1)


### PR DESCRIPTION
Fixes #1522

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-  If the delivery is cancelled because of timeout, report event dispatch time without resp status code. In metric explorer, the dispatch time will look like: (trigger-actor-0 only has timeout event, trigger-actor-1 only has 2xx event)
![Screen Shot 2020-08-13 at 9 53 40 AM](https://user-images.githubusercontent.com/52978759/90167520-9844f680-dd50-11ea-8e87-b2c4b43c1bf1.png)

- Add and update some UT
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
