### PR TITLE
Eliminate creating a new broker ingress span and add broker ingress attributes to the existing http span

### DIFF
--- a/pkg/broker/ingress/handler.go
+++ b/pkg/broker/ingress/handler.go
@@ -141,6 +141,7 @@ func (h *Handler) ServeHTTP(response nethttp.ResponseWriter, request *nethttp.Re
 	event.SetExtension(EventArrivalTime, cev2.Timestamp{Time: time.Now()})
 
 	span := trace.FromContext(ctx)
+	span.SetName(kntracing.BrokerMessagingDestination(broker))
 	defer span.End()
 	if span.IsRecordingEvents() {
 		span.AddAttributes(

--- a/pkg/broker/ingress/handler.go
+++ b/pkg/broker/ingress/handler.go
@@ -142,7 +142,6 @@ func (h *Handler) ServeHTTP(response nethttp.ResponseWriter, request *nethttp.Re
 
 	span := trace.FromContext(ctx)
 	span.SetName(kntracing.BrokerMessagingDestination(broker))
-	defer span.End()
 	if span.IsRecordingEvents() {
 		span.AddAttributes(
 			append(

--- a/pkg/broker/ingress/handler.go
+++ b/pkg/broker/ingress/handler.go
@@ -140,7 +140,7 @@ func (h *Handler) ServeHTTP(response nethttp.ResponseWriter, request *nethttp.Re
 
 	event.SetExtension(EventArrivalTime, cev2.Timestamp{Time: time.Now()})
 
-	ctx, span := trace.StartSpan(ctx, kntracing.BrokerMessagingDestination(broker))
+	span := trace.FromContext(ctx)
 	defer span.End()
 	if span.IsRecordingEvents() {
 		span.AddAttributes(

--- a/test/e2e/lib/helpers/broker_tracing.go
+++ b/test/e2e/lib/helpers/broker_tracing.go
@@ -242,8 +242,9 @@ func BrokerTestTree(namespace string, brokerName string, trigger string, respTri
 
 func ingressSpan(namespace string, broker string) *SpanMatcher {
 	brokerName := fmt.Sprintf("broker:%s.%s", broker, namespace)
+	spanName := fmt.Sprintf("Recv.%s", brokerName)
 	return &SpanMatcher{
-		Name: brokerName,
+		Name: spanName,
 		Labels: map[string]string{
 			"messaging.system":      "knative",
 			"messaging.destination": brokerName,


### PR DESCRIPTION
Fixes https://github.com/google/knative-gcp/issues/1506

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Reuse http span for broker ingress attributes in broker ingress handler
