### PR TITLE
Setup performance test to evaluate max throughput

### DIFF
--- a/test/performance/benchmarks/broker-gcp/100-broker-gcp-setup.yaml
+++ b/test/performance/benchmarks/broker-gcp/100-broker-gcp-setup.yaml
@@ -23,6 +23,27 @@ spec: {}
 
 ---
 
+apiVersion: internal.events.cloud.google.com/v1alpha1
+kind: BrokerCell
+metadata:
+  annotations:
+    internal.events.cloud.google.com/creator: googlecloud
+  name: default
+  namespace: cloud-run-events
+spec:
+  components:
+    fanout:
+      minReplicas: 1
+      maxReplicas: 2
+    ingress:
+      minReplicas: 1
+      maxReplicas: 2
+    retry:
+      minReplicas: 1
+      maxReplicas: 2
+
+---
+
 apiVersion: eventing.knative.dev/v1beta1
 kind: Trigger
 metadata:

--- a/test/performance/benchmarks/broker-gcp/100-broker-gcp-setup.yaml
+++ b/test/performance/benchmarks/broker-gcp/100-broker-gcp-setup.yaml
@@ -23,27 +23,6 @@ spec: {}
 
 ---
 
-apiVersion: internal.events.cloud.google.com/v1alpha1
-kind: BrokerCell
-metadata:
-  annotations:
-    internal.events.cloud.google.com/creator: googlecloud
-  name: default
-  namespace: cloud-run-events
-spec:
-  components:
-    fanout:
-      minReplicas: 1
-      maxReplicas: 2
-    ingress:
-      minReplicas: 1
-      maxReplicas: 2
-    retry:
-      minReplicas: 1
-      maxReplicas: 2
-
----
-
 apiVersion: eventing.knative.dev/v1beta1
 kind: Trigger
 metadata:

--- a/test/performance/benchmarks/broker-gcp/continuous/100-broker-gcp-setup.yaml
+++ b/test/performance/benchmarks/broker-gcp/continuous/100-broker-gcp-setup.yaml
@@ -34,13 +34,13 @@ spec:
   components:
     fanout:
       minReplicas: 1
-      maxReplicas: 2
+      maxReplicas: 1
     ingress:
       minReplicas: 1
-      maxReplicas: 2
+      maxReplicas: 1
     retry:
       minReplicas: 1
-      maxReplicas: 2
+      maxReplicas: 1
 
 ---
 

--- a/test/performance/benchmarks/broker-gcp/continuous/200-broker-gcp.yaml
+++ b/test/performance/benchmarks/broker-gcp/continuous/200-broker-gcp.yaml
@@ -45,7 +45,7 @@ spec:
               - "--roles=sender,receiver"
               - "--sink=http://default-brokercell-ingress.cloud-run-events.svc.cluster.local/default/gcp"
               - "--aggregator=broker-gcp-aggregator:10000"
-              - "--pace=100:10,200:20,400:30,500:60,600:60"
+              - "--pace=100:10,600:40,800:120,1000:120,1400:120,2200:120,2800:120"
             env:
               - name: POD_NAME
                 valueFrom:


### PR DESCRIPTION
Context: https://docs.google.com/document/d/1GWtAEegoz5F3ex0mok9liboGyeYFr0H54YsAa4r87BE/edit#heading=h.7bl2ddeqn7ur

- Increase pace and decrease number of replicas for gcp-broker performance benchmark.
- Results in dev setup indicate this configuration can yield more reliable results wrt max throughput
- Pace might need to be slightly adjusted in an upcoming PR (there are variations between dev and prod mako setups)