### PR TITLE
Add util function to ensure that a given environment variable is set and use it for e2e tests

### DIFF
--- a/test/e2e/lib/auditlogs.go
+++ b/test/e2e/lib/auditlogs.go
@@ -19,7 +19,6 @@ package lib
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -133,7 +132,7 @@ func MakeAuditLogsJobOrDie(client *Client, methodName, project, resourceName, se
 func StackdriverSinkExists(t *testing.T, sinkID string) bool {
 	t.Helper()
 	ctx := context.Background()
-	project := os.Getenv(ProwProjectKey)
+	project := GetEnvOrFail(t, ProwProjectKey)
 	opt := option.WithQuotaProject(project)
 	client, err := logadmin.NewClient(ctx, project, opt)
 	if err != nil {

--- a/test/e2e/lib/build.go
+++ b/test/e2e/lib/build.go
@@ -19,7 +19,6 @@ package lib
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	reconcilertestingv1alpha1 "github.com/google/knative-gcp/pkg/reconciler/testing/v1alpha1"
@@ -84,7 +83,7 @@ func MakeBuildTargetJobOrDie(client *Client, images, targetName, eventType strin
 
 func BuildWithConfigFile(t *testing.T, imageName string) string {
 	ctx := context.Background()
-	project := os.Getenv(ProwProjectKey)
+	project := GetEnvOrFail(t, ProwProjectKey)
 	opt := option.WithQuotaProject(project)
 	client, err := cloudbuild.NewClient(ctx, opt)
 	if err != nil {

--- a/test/e2e/lib/pubsub.go
+++ b/test/e2e/lib/pubsub.go
@@ -18,7 +18,6 @@ package lib
 
 import (
 	"net/http"
-	"os"
 	"testing"
 	"time"
 
@@ -103,7 +102,7 @@ func AssertMetrics(t *testing.T, client *Client, topicName, psName string) {
 	time.Sleep(sleepTime)
 
 	// If we reach this point, the projectID should have been set.
-	projectID := os.Getenv(ProwProjectKey)
+	projectID := GetEnvOrFail(t, ProwProjectKey)
 	f := map[string]interface{}{
 		"metric.type":                 EventCountMetricType,
 		"resource.type":               GlobalMetricResourceType,

--- a/test/e2e/lib/scheduler.go
+++ b/test/e2e/lib/scheduler.go
@@ -19,7 +19,6 @@ package lib
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"testing"
 	"time"
 
@@ -123,7 +122,7 @@ func schedulerEventPayload(customData string) string {
 func SchedulerJobExists(t *testing.T, jobName string) bool {
 	t.Helper()
 	ctx := context.Background()
-	project := os.Getenv(ProwProjectKey)
+	project := GetEnvOrFail(t, ProwProjectKey)
 	opt := option.WithQuotaProject(project)
 	client, err := scheduler.NewClient(ctx, opt)
 	if err != nil {

--- a/test/e2e/lib/storage.go
+++ b/test/e2e/lib/storage.go
@@ -19,7 +19,6 @@ package lib
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -166,7 +165,7 @@ func MakeBucket(ctx context.Context, t *testing.T, project string) string {
 
 func DeleteBucket(ctx context.Context, t *testing.T, bucketName string) {
 	t.Helper()
-	project := os.Getenv(ProwProjectKey)
+	project := GetEnvOrFail(t, ProwProjectKey)
 	opt := option.WithQuotaProject(project)
 	client, err := storage.NewClient(ctx, opt)
 	if err != nil {
@@ -210,7 +209,7 @@ func getBucketHandle(ctx context.Context, t *testing.T, bucketName, project stri
 func NotificationExists(t *testing.T, bucketName, notificationID string) bool {
 	t.Helper()
 	ctx := context.Background()
-	project := os.Getenv(ProwProjectKey)
+	project := GetEnvOrFail(t, ProwProjectKey)
 	opt := option.WithQuotaProject(project)
 	client, err := storage.NewClient(ctx, opt)
 	if err != nil {

--- a/test/e2e/lib/subscription.go
+++ b/test/e2e/lib/subscription.go
@@ -18,7 +18,6 @@ package lib
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"cloud.google.com/go/pubsub"
@@ -32,10 +31,7 @@ func SubscriptionExists(t *testing.T, subID string) bool {
 	t.Helper()
 	ctx := context.Background()
 	// Prow sticks the project in this key
-	project := os.Getenv(ProwProjectKey)
-	if project == "" {
-		t.Fatalf("failed to find %q in envvars", ProwProjectKey)
-	}
+	project := GetEnvOrFail(t, ProwProjectKey)
 	opt := option.WithQuotaProject(project)
 	client, err := pubsub.NewClient(ctx, project, opt)
 	if err != nil {

--- a/test/e2e/lib/topics.go
+++ b/test/e2e/lib/topics.go
@@ -18,7 +18,6 @@ package lib
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"cloud.google.com/go/pubsub"
@@ -33,10 +32,7 @@ func MakeTopicOrDie(t *testing.T) (string, func()) {
 	t.Helper()
 	ctx := context.Background()
 	// Prow sticks the project in this key
-	project := os.Getenv(ProwProjectKey)
-	if project == "" {
-		t.Fatalf("failed to find %q in envvars", ProwProjectKey)
-	}
+	project := GetEnvOrFail(t, ProwProjectKey)
 	opt := option.WithQuotaProject(project)
 	client, err := pubsub.NewClient(ctx, project, opt)
 	if err != nil {
@@ -63,10 +59,7 @@ func MakeTopicWithNameOrDie(t *testing.T, topicName string) (string, func()) {
 	t.Helper()
 	ctx := context.Background()
 	// Prow sticks the project in this key
-	project := os.Getenv(ProwProjectKey)
-	if project == "" {
-		t.Fatalf("failed to find %q in envvars", ProwProjectKey)
-	}
+	project := GetEnvOrFail(t, ProwProjectKey)
 	client, err := pubsub.NewClient(ctx, project)
 	if err != nil {
 		t.Fatalf("failed to create pubsub client, %s", err.Error())
@@ -91,10 +84,7 @@ func MakeTopicWithNameIfItDoesNotExist(t *testing.T, topicName string) {
 	t.Helper()
 	ctx := context.Background()
 	// Prow sticks the project in this key
-	project := os.Getenv(ProwProjectKey)
-	if project == "" {
-		t.Fatalf("failed to find %q in envvars", ProwProjectKey)
-	}
+	project := GetEnvOrFail(t, ProwProjectKey)
 	client, err := pubsub.NewClient(ctx, project)
 	if err != nil {
 		t.Fatalf("failed to create pubsub client, %s", err.Error())
@@ -116,10 +106,7 @@ func GetTopic(t *testing.T, topicName string) *pubsub.Topic {
 	t.Helper()
 	ctx := context.Background()
 	// Prow sticks the project in this key
-	project := os.Getenv(ProwProjectKey)
-	if project == "" {
-		t.Fatalf("failed to find %q in envvars", ProwProjectKey)
-	}
+	project := GetEnvOrFail(t, ProwProjectKey)
 	client, err := pubsub.NewClient(ctx, project)
 	if err != nil {
 		t.Fatalf("failed to create pubsub client, %s", err.Error())
@@ -131,10 +118,7 @@ func DeleteTopicOrDie(t *testing.T, topicName string) {
 	t.Helper()
 	ctx := context.Background()
 	// Prow sticks the project in this key.
-	project := os.Getenv(ProwProjectKey)
-	if project == "" {
-		t.Fatalf("failed to find %q in envvars", ProwProjectKey)
-	}
+	project := GetEnvOrFail(t, ProwProjectKey)
 	client, err := pubsub.NewClient(ctx, project)
 	if err != nil {
 		t.Fatalf("failed to create pubsub client, %s", err.Error())
@@ -153,10 +137,7 @@ func TopicExists(t *testing.T, topicID string) bool {
 	t.Helper()
 	ctx := context.Background()
 	// Prow sticks the project in this key
-	project := os.Getenv(ProwProjectKey)
-	if project == "" {
-		t.Fatalf("failed to find %q in envvars", ProwProjectKey)
-	}
+	project := GetEnvOrFail(t, ProwProjectKey)
 	client, err := pubsub.NewClient(ctx, project)
 	if err != nil {
 		t.Fatalf("failed to create pubsub client, %s", err.Error())

--- a/test/e2e/lib/utils.go
+++ b/test/e2e/lib/utils.go
@@ -20,16 +20,15 @@ limitations under the License.
 package lib
 
 import (
-	"fmt"
 	"os"
 	"testing"
 )
 
-// Returns the value of the environment variable if it exists, otherwise exits the test with an error
+// GetEnvOrFail gets the specified environment variable. If the variable is not set, then the test exits with an error.
 func GetEnvOrFail(t *testing.T, key string) string {
 	value, success := os.LookupEnv(key)
 	if !success {
-		t.Fatal(fmt.Sprintf("Environment variable %s not set", key))
+		t.Fatalf("Environment variable %q not set", key)
 	}
 	return value
 }

--- a/test/e2e/lib/utils.go
+++ b/test/e2e/lib/utils.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 Google LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ Utility functions used for testing
+*/
+package lib
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// Returns the value of the environment variable if it exists, otherwise exits the test with an error
+func GetEnvOrFail(t *testing.T, key string) string {
+	value, success := os.LookupEnv(key)
+	if !success {
+		t.Fatal(fmt.Sprintf("Environment variable %s not set", key))
+	}
+	return value
+}

--- a/test/e2e/test_auditlogs.go
+++ b/test/e2e/test_auditlogs.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -39,7 +38,7 @@ func SmokeCloudAuditLogsSourceTestHelper(t *testing.T, authConfig lib.AuthConfig
 	client := lib.Setup(t, true, authConfig.WorkloadIdentity)
 	defer lib.TearDown(client)
 
-	project := os.Getenv(lib.ProwProjectKey)
+	project := lib.GetEnvOrFail(t, lib.ProwProjectKey)
 
 	auditlogsName := helpers.AppendRandomString("auditlogs-e2e-test")
 	svcName := helpers.AppendRandomString(auditlogsName + "-event-display")
@@ -75,7 +74,7 @@ func SmokeCloudAuditLogsSourceWithDeletionTestImpl(t *testing.T, authConfig lib.
 	client := lib.Setup(t, true, authConfig.WorkloadIdentity)
 	defer lib.TearDown(client)
 
-	project := os.Getenv(lib.ProwProjectKey)
+	project := lib.GetEnvOrFail(t, lib.ProwProjectKey)
 
 	auditlogsName := helpers.AppendRandomString("auditlogs-e2e-test")
 	svcName := helpers.AppendRandomString(auditlogsName + "-event-display")
@@ -134,7 +133,7 @@ func SmokeCloudAuditLogsSourceWithDeletionTestImpl(t *testing.T, authConfig lib.
 }
 
 func CloudAuditLogsSourceWithTargetTestImpl(t *testing.T, authConfig lib.AuthConfig) {
-	project := os.Getenv(lib.ProwProjectKey)
+	project := lib.GetEnvOrFail(t, lib.ProwProjectKey)
 
 	auditlogsName := helpers.AppendRandomString("auditlogs-e2e-test")
 	targetName := helpers.AppendRandomString(auditlogsName + "-target")

--- a/test/e2e/test_build.go
+++ b/test/e2e/test_build.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -111,7 +110,7 @@ func CloudBuildSourceWithTargetTestImpl(t *testing.T, authConfig lib.AuthConfig)
 	defer lib.TearDown(client)
 
 	imageName := helpers.AppendRandomString("image")
-	project := os.Getenv(lib.ProwProjectKey)
+	project := lib.GetEnvOrFail(t, lib.ProwProjectKey)
 	images := fmt.Sprintf("[%s]", lib.CloudBuildImage(project, imageName))
 
 	// Create a target Job to receive the events.

--- a/test/e2e/test_gcp_broker.go
+++ b/test/e2e/test_gcp_broker.go
@@ -18,7 +18,6 @@ package e2e
 
 import (
 	"net/url"
-	"os"
 	"testing"
 	"time"
 
@@ -60,7 +59,7 @@ func GCPBrokerTestImpl(t *testing.T, authConfig lib.AuthConfig) {
 }
 
 func GCPBrokerMetricsTestImpl(t *testing.T, authConfig lib.AuthConfig) {
-	projectID := os.Getenv(lib.ProwProjectKey)
+	projectID := lib.GetEnvOrFail(t, lib.ProwProjectKey)
 	client := lib.Setup(t, true, authConfig.WorkloadIdentity)
 	defer lib.TearDown(client)
 	client.SetupStackDriverMetrics(t)
@@ -69,7 +68,7 @@ func GCPBrokerMetricsTestImpl(t *testing.T, authConfig lib.AuthConfig) {
 }
 
 func GCPBrokerTracingTestImpl(t *testing.T, authConfig lib.AuthConfig) {
-	projectID := os.Getenv(lib.ProwProjectKey)
+	projectID := lib.GetEnvOrFail(t, lib.ProwProjectKey)
 	client := lib.Setup(t, true, authConfig.WorkloadIdentity)
 	defer lib.TearDown(client)
 

--- a/test/e2e/test_pubsub.go
+++ b/test/e2e/test_pubsub.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -109,7 +108,7 @@ func SmokeCloudPubSubSourceWithDeletionTestImpl(t *testing.T, authConfig lib.Aut
 // If assertMetrics is set to true, we also assert for StackDriver metrics.
 func CloudPubSubSourceWithTargetTestImpl(t *testing.T, assertMetrics bool, authConfig lib.AuthConfig) {
 	t.Helper()
-	project := os.Getenv(lib.ProwProjectKey)
+	project := lib.GetEnvOrFail(t, lib.ProwProjectKey)
 	topicName, deleteTopic := lib.MakeTopicOrDie(t)
 	defer deleteTopic()
 

--- a/test/e2e/test_pullsubscription.go
+++ b/test/e2e/test_pullsubscription.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"testing"
 
 	"cloud.google.com/go/pubsub"
@@ -65,7 +64,7 @@ func SmokePullSubscriptionTestHelper(t *testing.T, authConfig lib.AuthConfig, pu
 // PullSubscriptionWithTargetTestImpl tests we can receive an event from a PullSubscription.
 func PullSubscriptionWithTargetTestImpl(t *testing.T, authConfig lib.AuthConfig) {
 	t.Helper()
-	project := os.Getenv(lib.ProwProjectKey)
+	project := lib.GetEnvOrFail(t, lib.ProwProjectKey)
 	topicName, deleteTopic := lib.MakeTopicOrDie(t)
 	defer deleteTopic()
 

--- a/test/e2e/test_storage.go
+++ b/test/e2e/test_storage.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"os"
 	"testing"
 	"time"
 
@@ -43,7 +42,7 @@ func SmokeCloudStorageSourceTestHelper(t *testing.T, authConfig lib.AuthConfig, 
 	defer lib.TearDown(client)
 
 	ctx := context.Background()
-	project := os.Getenv(lib.ProwProjectKey)
+	project := lib.GetEnvOrFail(t, lib.ProwProjectKey)
 
 	bucketName := lib.MakeBucket(ctx, t, project)
 	defer lib.DeleteBucket(ctx, t, bucketName)
@@ -76,7 +75,7 @@ func SmokeCloudStorageSourceWithDeletionTestImpl(t *testing.T, authConfig lib.Au
 	defer lib.TearDown(client)
 
 	ctx := context.Background()
-	project := os.Getenv(lib.ProwProjectKey)
+	project := lib.GetEnvOrFail(t, lib.ProwProjectKey)
 
 	bucketName := lib.MakeBucket(ctx, t, project)
 	defer lib.DeleteBucket(ctx, t, bucketName)
@@ -135,7 +134,7 @@ func SmokeCloudStorageSourceWithDeletionTestImpl(t *testing.T, authConfig lib.Au
 func CloudStorageSourceWithTargetTestImpl(t *testing.T, assertMetrics bool, authConfig lib.AuthConfig) {
 	t.Helper()
 	ctx := context.Background()
-	project := os.Getenv(lib.ProwProjectKey)
+	project := lib.GetEnvOrFail(t, lib.ProwProjectKey)
 
 	bucketName := lib.MakeBucket(ctx, t, project)
 	defer lib.DeleteBucket(ctx, t, bucketName)
@@ -202,7 +201,7 @@ func CloudStorageSourceWithTargetTestImpl(t *testing.T, assertMetrics bool, auth
 		time.Sleep(sleepTime)
 
 		// If we reach this point, the projectID should have been set.
-		projectID := os.Getenv(lib.ProwProjectKey)
+		projectID := lib.GetEnvOrFail(t, lib.ProwProjectKey)
 		f := map[string]interface{}{
 			"metric.type":                 lib.EventCountMetricType,
 			"resource.type":               lib.GlobalMetricResourceType,

--- a/test/e2e/test_storage.go
+++ b/test/e2e/test_storage.go
@@ -200,8 +200,6 @@ func CloudStorageSourceWithTargetTestImpl(t *testing.T, assertMetrics bool, auth
 		t.Logf("Sleeping %s to make sure metrics were pushed to stackdriver", sleepTime.String())
 		time.Sleep(sleepTime)
 
-		// If we reach this point, the projectID should have been set.
-		projectID := lib.GetEnvOrFail(t, lib.ProwProjectKey)
 		f := map[string]interface{}{
 			"metric.type":                 lib.EventCountMetricType,
 			"resource.type":               lib.GlobalMetricResourceType,
@@ -218,7 +216,7 @@ func CloudStorageSourceWithTargetTestImpl(t *testing.T, assertMetrics bool, auth
 		filter := metrics.StringifyStackDriverFilter(f)
 		t.Logf("Filter expression: %s", filter)
 
-		actualCount, err := client.StackDriverEventCountMetricFor(client.Namespace, projectID, filter)
+		actualCount, err := client.StackDriverEventCountMetricFor(client.Namespace, project, filter)
 		if err != nil {
 			t.Fatalf("failed to get stackdriver event count metric: %v", err)
 		}


### PR DESCRIPTION
Currently if the environment variable containing the project id for e2e tests (E2E_PROJECT_ID) is not set, the tests still continue to run and fail later with "permission denied error" as an empty project has no permissions to access anything. Instead, we want the test to fail if they are not able to get the required environment variable

## Proposed Changes

- Add util function to ensure that a given environment variable is set
- Modify tests to use that util function instead of os.getEnv (used currently), which succeeds even if the environment variable doesn't exist