### PR TITLE
Change EventType of CloudBuildSource

### DIFF
--- a/config/core/resources/cloudbuildsource.yaml
+++ b/config/core/resources/cloudbuildsource.yaml
@@ -22,7 +22,7 @@ metadata:
   annotations:
     registry.knative.dev/eventTypes: |
       [
-        { "type": "com.google.cloud.build.event", "description": "This event is sent when your build's state changes, such as when your build is created, when your build transitions to a working state, and when your build completes."}
+        { "type": "google.cloud.cloudbuild.build.v1.statusChanged", "description": "This event is sent when your build's state changes, such as when your build is created, when your build transitions to a working state, and when your build completes."}
       ]
   name: cloudbuildsources.events.cloud.google.com
 spec:

--- a/config/core/resources/cloudbuildsource.yaml
+++ b/config/core/resources/cloudbuildsource.yaml
@@ -22,7 +22,11 @@ metadata:
   annotations:
     registry.knative.dev/eventTypes: |
       [
-        { "type": "google.cloud.cloudbuild.build.v1.statusChanged", "description": "This event is sent when your build's state changes, such as when your build is created, when your build transitions to a working state, and when your build completes."}
+        {
+          "type": "google.cloud.cloudbuild.build.v1.statusChanged",
+          "schema": "https://raw.githubusercontent.com/googleapis/google-cloudevents/master/proto/google/events/cloud/cloudbuild/v1/data.proto",
+          "description": "This event is sent when your build's state changes, such as when your build is created, when your build transitions to a working state, and when your build completes."
+        }
       ]
   name: cloudbuildsources.events.cloud.google.com
 spec:

--- a/docs/examples/cloudbuildsource/README.md
+++ b/docs/examples/cloudbuildsource/README.md
@@ -90,7 +90,7 @@ by looking at the logs of the service that this CloudBuildSource sinks to.
 Validation: valid
 Context Attributes,
   specversion: 1.0
-  type: com.google.cloud.build.event
+  type: google.cloud.cloudbuild.build.v1.statusChanged
   source: //cloudbuild.googleapis.com/projects/PROJECT_ID/builds/BUILD_ID
   subject: SUCCESS
   id: 1085069104560583

--- a/docs/examples/cloudbuildsource/README.md
+++ b/docs/examples/cloudbuildsource/README.md
@@ -95,7 +95,7 @@ Context Attributes,
   subject: SUCCESS
   id: 1085069104560583
   time: 2020-04-03T23:51:29.811Z
-  dataschema: https://github.com/googleapis/google-cloudevents/blob/master/proto/google/events/cloud/scheduler/v1/data.proto
+  dataschema: https://raw.githubusercontent.com/googleapis/google-cloudevents/master/proto/google/events/cloud/cloudbuild/v1/data.proto
   datacontenttype: application/json
 Extensions,
   buildid: BUILD_ID

--- a/docs/examples/cloudbuildsource/README.md
+++ b/docs/examples/cloudbuildsource/README.md
@@ -95,7 +95,7 @@ Context Attributes,
   subject: SUCCESS
   id: 1085069104560583
   time: 2020-04-03T23:51:29.811Z
-  dataschema: https://raw.githubusercontent.com/google/knative-gcp/master/schemas/build/schema.json
+  dataschema: https://github.com/googleapis/google-cloudevents/blob/master/proto/google/events/cloud/scheduler/v1/data.proto
   datacontenttype: application/json
 Extensions,
   buildid: BUILD_ID

--- a/pkg/apis/events/v1alpha1/cloudbuildsource_types.go
+++ b/pkg/apis/events/v1alpha1/cloudbuildsource_types.go
@@ -66,15 +66,6 @@ type CloudBuildSourceSpec struct {
 	Topic *string `json:"topic,omitempty"`
 }
 
-const (
-	// CloudBuildSource CloudEvent type
-	CloudBuildSourceEvent = "google.cloud.cloudbuild.build.v1.statusChanged"
-	// CloudBuildSourceBuildId is the Pub/Sub message attribute key with the CloudBuildSource's buildId.
-	CloudBuildSourceBuildId = "buildId"
-	// CloudBuildSourceBuildStatus is the Pub/Sub message attribute key with the CloudBuildSource's build status.
-	CloudBuildSourceBuildStatus = "status"
-)
-
 // CloudBuildSourceEventSource returns the Cloud Build CloudEvent source value.
 func CloudBuildSourceEventSource(googleCloudProject, buildId string) string {
 	return fmt.Sprintf("//cloudbuild.googleapis.com/projects/%s/builds/%s", googleCloudProject, buildId)

--- a/pkg/apis/events/v1alpha1/cloudbuildsource_types.go
+++ b/pkg/apis/events/v1alpha1/cloudbuildsource_types.go
@@ -68,7 +68,7 @@ type CloudBuildSourceSpec struct {
 
 const (
 	// CloudBuildSource CloudEvent type
-	CloudBuildSourceEvent = "com.google.cloud.build.event"
+	CloudBuildSourceEvent = "google.cloud.cloudbuild.build.v1.statusChanged"
 	// CloudBuildSourceBuildId is the Pub/Sub message attribute key with the CloudBuildSource's buildId.
 	CloudBuildSourceBuildId = "buildId"
 	// CloudBuildSourceBuildStatus is the Pub/Sub message attribute key with the CloudBuildSource's build status.

--- a/pkg/pubsub/adapter/converters/build.go
+++ b/pkg/pubsub/adapter/converters/build.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	buildSchemaUrl = "https://raw.githubusercontent.com/googleapis/google-cloudevents/master/proto/google/events/cloud/build/v1/data.proto"
+	buildSchemaUrl = "https://raw.githubusercontent.com/googleapis/google-cloudevents/master/proto/google/events/cloud/cloudbuild/v1/data.proto"
 )
 
 func convertCloudBuild(ctx context.Context, msg *pubsub.Message) (*cev2.Event, error) {

--- a/pkg/pubsub/adapter/converters/build.go
+++ b/pkg/pubsub/adapter/converters/build.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	buildSchemaUrl = "https://raw.githubusercontent.com/google/knative-gcp/master/schemas/build/schema.json"
+	buildSchemaUrl = "https://raw.githubusercontent.com/googleapis/google-cloudevents/master/proto/google/events/cloud/build/v1/data.proto"
 )
 
 func convertCloudBuild(ctx context.Context, msg *pubsub.Message) (*cev2.Event, error) {

--- a/pkg/schemas/v1/build.go
+++ b/pkg/schemas/v1/build.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// CloudBuildSource CloudEvent type
-	CloudBuildSourceEventType = "com.google.cloud.build.event"
+	CloudBuildSourceEventType = "google.cloud.cloudbuild.build.v1.statusChanged"
 	// CloudBuildSourceBuildId is the Pub/Sub message attribute key with the CloudBuildSource's buildId.
 	CloudBuildSourceBuildId = "buildId"
 	// CloudBuildSourceBuildStatus is the Pub/Sub message attribute key with the CloudBuildSource's build status.


### PR DESCRIPTION
Fixes https://github.com/google/knative-gcp/issues/1608

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Change CE type of CloudBuildSource from `com.google.cloud.build.event` to `google.cloud.cloudbuild.build.v1.statusChanged`
- Update CloudBuildSource data schema

**Release Note**
```release-note
BREAKING CHANGES

- CloudBuildSource type is updated to match event types in googleapis/google-cloudevents

ACTION REQUIRED

- Users who depend on the CloudBuildSource "type" value in the trigger filters can create new triggers with new filter value (see details below)

DETAILED CHANGES

1. CloudBuildSource event type was updated to be compliant with https://github.com/googleapis/google-cloudevents/tree/master/proto/google/events/cloud. CloudBuildSource data schema was updated to be https://github.com/googleapis/google-cloudevents/blob/master/proto/google/events/cloud/scheduler/v1/data.proto 
2. Type changes:
   CloudBuildSource: was "com.google.cloud.build.event" => now "google.cloud.cloudbuild.build.v1.statusChanged"
