### PR TITLE
Fix prerequisite links in metrics/REAMD.md and install-gcp-broker.md

### DIFF
--- a/docs/examples/metrics/README.md
+++ b/docs/examples/metrics/README.md
@@ -9,7 +9,7 @@ events to a Broker with an attached Trigger and viewing those metrics with commo
 
 1. [Install Knative-GCP](../../install/install-knative-gcp.md)
 
-2. [Create a Service Account for the Data Plane](../../install/dataplane-service-account.md)
+2. [Installing GCP Broker](../../install/install-gcp-broker.md)
 
 ## Setup
 

--- a/docs/install/install-gcp-broker.md
+++ b/docs/install/install-gcp-broker.md
@@ -10,7 +10,7 @@ Knative Eventing allows different Broker implementations via `BrokerClass`
 annotation. If annotated with
 `"eventing.knative.dev/broker.class": "googlecloud"`, the `Knative-GCP`
 controller will create a GCP Broker. Compared to the default
-[MT Channel Based Broker](https://knative.dev/docs/eventing/broker/mt-channel-based-broker/),
+`MT Channel Based Broker`,
 GCP Broker is more performant and cost-effective by reducing hops and Pub/Sub
 message consumption.
 

--- a/docs/install/install-gcp-broker.md
+++ b/docs/install/install-gcp-broker.md
@@ -18,7 +18,7 @@ message consumption.
 
 1. [Install Knative-GCP](./install-knative-gcp.md).
 
-2. [Create a Service Account for the Data Plane](./dataplane-service-account.md).
+2. [Create a Service Account for the Data Plane](./dataplane-service-account.md#create-a-google-cloud-service-account-to-interact-with-pubsub).
 
 ## Authentication Setup for GCP Broker
 


### PR DESCRIPTION
Fixes #1623 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Metrics Example Prerequisites (2) should point to Installing GCP Broker
-  Installing GCP Broker Prerequisites (2) should directly point the specific section https://github.com/google/knative-gcp/blob/master/docs/install/dataplane-service-account.md#create-a-google-cloud-service-account-to-interact-with-pubsub
