### PR TITLE
Add GoogleServiceAccount field to IdentityStatus

### DIFF
--- a/pkg/apis/duck/v1beta1/identity_types.go
+++ b/pkg/apis/duck/v1beta1/identity_types.go
@@ -34,6 +34,10 @@ type IdentityStatus struct {
 	duckv1.Status `json:",inline"`
 	// ServiceAccountName is the k8s service account associated with Google service account.
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+	// GoogleServiceAccount is the google service account associated with the
+	// k8s service account when using workload identity.
+	// +optional
+	GoogleServiceAccount string `json:"googleServiceAccount,omitempty"`
 }
 
 const (


### PR DESCRIPTION
Fixes #1447 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add GoogleServiceAccount field to IdentityStatus.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->
