### PR TITLE
Added liveness probe to Probe Helper pod

### DIFF
--- a/test/test_images/probe_helper/probe_helper.go
+++ b/test/test_images/probe_helper/probe_helper.go
@@ -39,7 +39,7 @@ const (
 	BrokerE2EDeliveryProbeEventType = "broker-e2e-delivery-probe"
 	CloudPubSubSourceProbeEventType = "cloudpubsubsource-probe"
 
-	maxStaleTime = 60 * time.Second
+	maxStaleTime = 3 * time.Minute
 )
 
 var (
@@ -90,7 +90,7 @@ func forwardFromProbe(ctx context.Context, brokerClient cloudevents.Client, pubs
 		var err error
 		var receiverChannel chan bool
 		log.Printf("Received probe request: %+v \n", event)
-		lastSenderEventTimestamp = event.Time()
+		lastSenderEventTimestamp = time.Now()
 
 		ctx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Minute)
 		defer cancel()
@@ -136,7 +136,7 @@ func receiveEvent(receivedEvents *receivedEventsMap) cloudEventsFunc {
 	return func(event cloudevents.Event) protocol.Result {
 		var eventID string
 		log.Printf("Received event: %+v \n", event)
-		lastReceiverEventTimestamp = event.Time()
+		lastReceiverEventTimestamp = time.Now()
 
 		switch event.Type() {
 		case BrokerE2EDeliveryProbeEventType:

--- a/test/test_images/probe_helper/probe_helper.yaml
+++ b/test/test_images/probe_helper/probe_helper.yaml
@@ -52,8 +52,6 @@ spec:
             httpGet:
               path: /healthz
               port: 8060
-            initialDelaySeconds: 3
-            periodSeconds: 3
       volumes:
       - name: probe-helper-key
         secret:

--- a/test/test_images/probe_helper/probe_helper.yaml
+++ b/test/test_images/probe_helper/probe_helper.yaml
@@ -48,6 +48,12 @@ spec:
           volumeMounts:
           - name: probe-helper-key
             mountPath: /var/secrets/google
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8060
+            initialDelaySeconds: 3
+            periodSeconds: 3
       volumes:
       - name: probe-helper-key
         secret:

--- a/test/test_images/probe_helper/probe_helper.yaml
+++ b/test/test_images/probe_helper/probe_helper.yaml
@@ -49,9 +49,14 @@ spec:
           - name: probe-helper-key
             mountPath: /var/secrets/google
           livenessProbe:
+            failureThreshold: 3
             httpGet:
               path: /healthz
               port: 8060
+            initialDelaySeconds: 5
+            periodSeconds: 125
+            successThreshold: 1
+            timeoutSeconds: 10
       volumes:
       - name: probe-helper-key
         secret:


### PR DESCRIPTION
Fixes #1613 

Checks staleness by keeping track of last received/forwarded event times and comparing the delay to a staleness limit.