### PR TITLE
Add Channel and CloudBuildSource to the migration tool of storage version v1beta1

### DIFF
--- a/config/pre-install/v0.18.0/channel.yaml
+++ b/config/pre-install/v0.18.0/channel.yaml
@@ -1,0 +1,255 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: channels.messaging.cloud.google.com
+  labels:
+    events.cloud.google.com/release: devel
+    events.cloud.google.com/crd-install: "true"
+    messaging.knative.dev/subscribable: "true"
+    duck.knative.dev/addressable: "true"
+spec:
+  group: messaging.cloud.google.com
+  names:
+    kind: Channel
+    plural: channels
+    singular: channel
+    categories:
+    - all
+    - knative
+    - pubsub
+    - messaging
+    - channel
+    shortNames:
+      - pschan
+  scope: Namespaced
+  preserveUnknownFields: false
+  conversion:
+    strategy: Webhook
+    webhook:
+      # conversionReviewVersions indicates what ConversionReview versions are understood/preferred by the webhook.
+      # The first version in the list understood by the API server is sent to the webhook.
+      # The webhook must respond with a ConversionReview object in the same version it received.
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: webhook
+          namespace: cloud-run-events
+  versions:
+  - &version
+    name: v1alpha1
+    # TODO: Flip served bit of v1alpha1 in https://github.com/google/knative-gcp/issues/1544.
+    served: true
+    storage: false
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    - name: Address
+      type: string
+      jsonPath: .status.address.url
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    schema:
+      openAPIV3Schema: &openAPIV3Schema
+        type: object
+        properties: &properties
+          spec: &spec
+            type: object
+            properties:
+              serviceAccountName: &serviceAccountName
+                type: string
+                description: >
+                  k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
+                  The value of the k8s service account must be a valid DNS subdomain name.
+                  (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
+              secret: &secret
+                type: object
+                description: >
+                  Credential to use to manage Cloud Pub/Sub. The value of the secret entry must be a service
+                  account key in the JSON format (see
+                  https://cloud.google.com/iam/docs/creating-managing-service-account-keys). Defaults to
+                  secret.name of 'google-cloud-key' and secret.key of 'key.json'.
+                properties:
+                  name:
+                    type: string
+                  key:
+                    type: string
+                  optional:
+                    type: boolean
+              project: &project
+                type: string
+                description: >
+                  ID of the Google Cloud Project to own the Pub/Sub credentials. E.g.
+                  'my-project-1234' rather than its display name, 'My Project' or its number
+                  '1234567890'. If omitted uses the Project ID from the GKE cluster metadata service.
+              subscribable:
+                type: object
+                properties:
+                  subscribers: &subscribers
+                    type: array
+                    items: &items
+                      type: object
+                      required:
+                        - uid
+                      properties: &subscribersProperties
+                        uid: &uid
+                          type: string
+                          minLength: 1
+                        generation: &generation
+                          type: integer
+                        subscriberURI: &subscriberURI
+                          type: string
+                        replyURI: &replyURI
+                          type: string
+                        deadLetterSink:
+                          type: string
+                        delivery: &delivery
+                          type: object
+                          properties:
+                            deadLetterSink:
+                              type: object
+                              properties:
+                                ref:
+                                  type: object
+                                  properties:
+                                    kind:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                    name:
+                                      type: string
+                                    apiVersion:
+                                      type: string
+                                uri:
+                                  type: string
+                            retry:
+                              type: integer
+                            backoffPolicy:
+                              type: string
+                            backoffDelay:
+                              type: string
+          status: &status
+            type: object
+            properties: &statusProperties
+              observedGeneration: &observedGeneration
+                type: integer
+                format: int64
+              conditions: &conditions
+                type: array
+                items:
+                  type: object
+                  properties:
+                    lastTransitionTime:
+                      # We use a string in the stored object but a wrapper object at runtime.
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    severity:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                    - type
+                    - status
+              serviceAccountName:
+                type: string
+              address: &address
+                type: object
+                properties:
+                  url:
+                    type: string
+              subscribableStatus:
+                type: object
+                properties:
+                  subscribers: &statusSubscribers
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        uid:
+                          type: string
+                        observedGeneration:
+                          type: integer
+                          format: int64
+                        ready:
+                          type: string
+                        message:
+                          type: string
+              projectId: &projectId
+                type: string
+              subscriptionId: &subscriptionId
+                type: string
+  - <<: *version
+    name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        <<: *openAPIV3Schema
+        properties:
+          spec:
+            <<: *spec
+            properties:
+              # No subscribable in v1beta1
+              serviceAccountName:
+                <<: *serviceAccountName
+              secret:
+                <<: *secret
+              project:
+                <<: *project
+              subscribers:
+                <<: *subscribers
+                items:
+                  <<: *items
+                  properties:
+                    # No deadLetterSink in subscribers properties in v1beta1
+                    uid:
+                      <<: *uid
+                    generation:
+                      <<: *generation
+                    subscriberUri:
+                      <<: *subscriberURI
+                    replyUri:
+                      <<: *replyURI
+                    delivery:
+                      <<: *delivery
+          status:
+            <<: *status
+            properties:
+              # No subscribable in v1beta1
+              observedGeneration:
+                <<: *observedGeneration
+              conditions:
+                <<: *conditions
+              address:
+                <<: *address
+              subscribers:
+                <<: *statusSubscribers
+              projectId:
+                <<: *projectId
+              subscriptionId:
+                <<: *subscriptionId

--- a/config/pre-install/v0.18.0/cloudbuildsource.yaml
+++ b/config/pre-install/v0.18.0/cloudbuildsource.yaml
@@ -1,0 +1,204 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    duck.knative.dev/source: "true"
+    events.cloud.google.com/release: devel
+    events.cloud.google.com/crd-install: "true"
+  annotations:
+    registry.knative.dev/eventTypes: |
+      [
+        {
+          "type": "google.cloud.cloudbuild.build.v1.statusChanged",
+          "schema": "https://raw.githubusercontent.com/googleapis/google-cloudevents/master/proto/google/events/cloud/cloudbuild/v1/data.proto",
+          "description": "This event is sent when your build's state changes, such as when your build is created, when your build transitions to a working state, and when your build completes."
+        }
+      ]
+  name: cloudbuildsources.events.cloud.google.com
+spec:
+  group: events.cloud.google.com
+  names:
+    categories:
+      - all
+      - knative
+      - cloudbuildsource
+      - sources
+    kind: CloudBuildSource
+    plural: cloudbuildsources
+  scope: Namespaced
+  preserveUnknownFields: false
+  conversion:
+    strategy: Webhook
+    webhook:
+      # conversionReviewVersions indicates what ConversionReview versions are understood/preferred by the webhook.
+      # The first version in the list understood by the API server is sent to the webhook.
+      # The webhook must respond with a ConversionReview object in the same version it received.
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: webhook
+          namespace: cloud-run-events
+  versions:
+    - &version
+      name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      # We remove status.ServiceAccountName from the schema in v1.
+      schema:
+        openAPIV3Schema: &openAPIV3Schema
+          type: object
+          properties: &properties
+            spec:
+              type: object
+              required:
+                - sink
+              properties:
+                sink:
+                  type: object
+                  description: >
+                    Sink which receives the notifications.
+                  properties:
+                    uri:
+                      type: string
+                      minLength: 1
+                    ref:
+                      type: object
+                      required:
+                        - apiVersion
+                        - kind
+                        - name
+                      properties:
+                        apiVersion:
+                          type: string
+                          minLength: 1
+                        kind:
+                          type: string
+                          minLength: 1
+                        namespace:
+                          type: string
+                        name:
+                          type: string
+                          minLength: 1
+                ceOverrides:
+                  type: object
+                  description: >
+                    Defines overrides to control modifications of the event sent to the sink.
+                  properties:
+                    extensions:
+                      type: object
+                      description: >
+                        Extensions specify what attribute are added or overridden on the outbound event. Each
+                        `Extensions` key-value pair are set on the event as an attribute extension independently.
+                      x-kubernetes-preserve-unknown-fields: true
+                serviceAccountName:
+                  type: string
+                  description: >
+                    Kubernetes service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
+                    The value of the Kubernetes service account must be a valid DNS subdomain name.
+                    (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
+                secret:
+                  type: object
+                  description: >
+                    Credential used to poll the Cloud Pub/Sub Subscription. It is not used to create or delete the
+                    Subscription, only to poll it. The value of the secret entry must be a service account key in
+                    the JSON format (see https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
+                    Defaults to secret.name of 'google-cloud-key' and secret.key of 'key.json'.
+                  properties:
+                    name:
+                      type: string
+                    key:
+                      type: string
+                    optional:
+                      type: boolean
+                project:
+                  type: string
+                  description: >
+                    Google Cloud Project ID of the project into which the topic should be created. If omitted uses
+                    the Project ID from the GKE cluster metadata service.
+            status: &status
+              type: object
+              properties: &statusProperties
+                observedGeneration:
+                  type: integer
+                  format: int64
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      lastTransitionTime:
+                        # We use a string in the stored object but a wrapper object at runtime.
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      severity:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - type
+                      - status
+                sinkUri:
+                  type: string
+                ceAttributes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      source:
+                        type: string
+                projectId:
+                  type: string
+                topicId:
+                  type: string
+                subscriptionId:
+                  type: string
+    - <<: *version
+      name: v1alpha1
+      # TODO: Flip served bit of v1alpha1 in https://github.com/google/knative-gcp/issues/1544.
+      served: true
+      storage: false
+      # v1alpha1 have status.properties.serviceAccountName in the schema
+      schema:
+        openAPIV3Schema:
+          <<: *openAPIV3Schema
+          properties:
+            <<: *properties
+            status:
+              <<: *status
+              properties:
+                <<: *statusProperties
+                serviceAccountName:
+                  type: string

--- a/config/pre-install/v0.18.0/clusterrole.yaml
+++ b/config/pre-install/v0.18.0/clusterrole.yaml
@@ -39,6 +39,7 @@ rules:
       - "cloudpubsubsources"
       - "cloudauditlogssources"
       - "cloudschedulersources"
+      - "cloudbuildsources"
     verbs: &everything
       - "get"
       - "list"
@@ -52,4 +53,9 @@ rules:
     resources:
       - "pullsubscriptions"
       - "topics"
+    verbs: *everything
+  - apiGroups:
+      - "messaging.cloud.google.com"
+    resources:
+      - "channels"
     verbs: *everything

--- a/config/pre-install/v0.18.0/storage-version-migration.yaml
+++ b/config/pre-install/v0.18.0/storage-version-migration.yaml
@@ -38,6 +38,8 @@ spec:
           # and substituted here.
           image: ko://github.com/google/knative-gcp/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate
           args:
+            - "channels.messaging.cloud.google.com"
+            - "cloudbuildsources.events.cloud.google.com"
             - "cloudauditlogssources.events.cloud.google.com"
             - "cloudpubsubsources.events.cloud.google.com"
             - "cloudstoragesources.events.cloud.google.com"


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Due to https://github.com/google/knative-gcp/issues/1544#issuecomment-683882784, we will need to migrate the storage version of CloudBuildSource and Channel to v1beta1 first before we remove v1alpha1 supports. 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- Since we will remove v1alpha1 in 0.19, please make sure the below resources are migrated to storage version v1beta1:
            - "channels.messaging.cloud.google.com"
            - "cloudbuildsources.events.cloud.google.com"

action required: You must run pre-install job.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
