### PR TITLE
Add Tracing Cloud Logging fields

### DIFF
--- a/pkg/broker/handler/processors/filter/processor.go
+++ b/pkg/broker/handler/processors/filter/processor.go
@@ -90,7 +90,7 @@ func startSpan(ctx context.Context, trigger types.NamespacedName, event *event.E
 			kntracing.MessagingMessageIDAttribute(event.ID()),
 		)
 	}
-	return ctx, span
+	return tracing.WithLogging(ctx, span), span
 }
 
 func (p *Processor) passFilter(ctx context.Context, attrs map[string]string, event *event.Event) bool {

--- a/pkg/broker/ingress/handler.go
+++ b/pkg/broker/ingress/handler.go
@@ -114,9 +114,7 @@ func (h *Handler) ServeHTTP(response nethttp.ResponseWriter, request *nethttp.Re
 
 	ctx := request.Context()
 	ctx = logging.WithLogger(ctx, h.logger)
-	if span := trace.FromContext(ctx); span != nil {
-		ctx = tracing.WithLogging(ctx, span)
-	}
+	ctx = tracing.WithLogging(ctx, trace.FromContext(ctx))
 	logging.FromContext(ctx).Debug("Serving http", zap.Any("headers", request.Header))
 	if request.Method != nethttp.MethodPost {
 		response.WriteHeader(nethttp.StatusMethodNotAllowed)

--- a/pkg/broker/ingress/handler.go
+++ b/pkg/broker/ingress/handler.go
@@ -113,7 +113,11 @@ func (h *Handler) ServeHTTP(response nethttp.ResponseWriter, request *nethttp.Re
 	}
 
 	ctx := request.Context()
-	h.logger.Debug("Serving http", zap.Any("headers", request.Header))
+	ctx = logging.WithLogger(ctx, h.logger)
+	if span := trace.FromContext(ctx); span != nil {
+		ctx = tracing.WithLogging(ctx, span)
+	}
+	logging.FromContext(ctx).Debug("Serving http", zap.Any("headers", request.Header))
 	if request.Method != nethttp.MethodPost {
 		response.WriteHeader(nethttp.StatusMethodNotAllowed)
 		return
@@ -121,12 +125,12 @@ func (h *Handler) ServeHTTP(response nethttp.ResponseWriter, request *nethttp.Re
 
 	broker, err := ConvertPathToNamespacedName(request.URL.Path)
 	if err != nil {
-		h.logger.Debug("Malformed request path", zap.String("path", request.URL.Path))
+		logging.FromContext(ctx).Debug("Malformed request path", zap.String("path", request.URL.Path))
 		nethttp.Error(response, err.Error(), nethttp.StatusNotFound)
 		return
 	}
 
-	event, err := h.toEvent(request)
+	event, err := h.toEvent(ctx, request)
 	if err != nil {
 		nethttp.Error(response, err.Error(), nethttp.StatusBadRequest)
 		return
@@ -156,7 +160,7 @@ func (h *Handler) ServeHTTP(response nethttp.ResponseWriter, request *nethttp.Re
 	defer cancel()
 	defer func() { h.reportMetrics(request.Context(), broker, event, statusCode) }()
 	if res := h.decouple.Send(ctx, broker, *event); !cev2.IsACK(res) {
-		h.logger.Error("Error publishing to PubSub", zap.String("broker", broker.String()), zap.Error(res))
+		logging.FromContext(ctx).Error("Error publishing to PubSub", zap.String("broker", broker.String()), zap.Error(res))
 		statusCode = nethttp.StatusInternalServerError
 		if errors.Is(res, ErrNotFound) {
 			statusCode = nethttp.StatusNotFound
@@ -171,21 +175,21 @@ func (h *Handler) ServeHTTP(response nethttp.ResponseWriter, request *nethttp.Re
 }
 
 // toEvent converts an http request to an event.
-func (h *Handler) toEvent(request *nethttp.Request) (*cev2.Event, error) {
+func (h *Handler) toEvent(ctx context.Context, request *nethttp.Request) (*cev2.Event, error) {
 	message := http.NewMessageFromHttpRequest(request)
 	defer func() {
 		if err := message.Finish(nil); err != nil {
-			h.logger.Error("Failed to close message", zap.Any("message", message), zap.Error(err))
+			logging.FromContext(ctx).Error("Failed to close message", zap.Any("message", message), zap.Error(err))
 		}
 	}()
 	// If encoding is unknown, the message is not an event.
 	if message.ReadEncoding() == binding.EncodingUnknown {
-		h.logger.Debug("Unknown encoding", zap.Any("request", request))
+		logging.FromContext(ctx).Debug("Unknown encoding", zap.Any("request", request))
 		return nil, errors.New("Unknown encoding. Not a cloud event?")
 	}
 	event, err := binding.ToEvent(request.Context(), message, transformer.AddTimeNow)
 	if err != nil {
-		h.logger.Error("Failed to convert request to event", zap.Error(err))
+		logging.FromContext(ctx).Error("Failed to convert request to event", zap.Error(err))
 		return nil, err
 	}
 	return event, nil
@@ -199,6 +203,6 @@ func (h *Handler) reportMetrics(ctx context.Context, broker types.NamespacedName
 		ResponseCode: statusCode,
 	}
 	if err := h.reporter.ReportEventCount(ctx, args); err != nil {
-		h.logger.Warn("Failed to record metrics.", zap.Any("namespace", broker.Namespace), zap.Any("broker", broker.Name), zap.Error(err))
+		logging.FromContext(ctx).Warn("Failed to record metrics.", zap.Any("namespace", broker.Namespace), zap.Any("broker", broker.Name), zap.Error(err))
 	}
 }

--- a/pkg/tracing/logging.go
+++ b/pkg/tracing/logging.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 Google LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+
+	"go.opencensus.io/trace"
+	"go.uber.org/zap"
+	"knative.dev/eventing/pkg/logging"
+)
+
+const (
+	LoggingTraceKey        = "logging.googleapis.com/trace"
+	LoggingSpanIDKey       = "logging.googleapis.com/spanId"
+	LoggingTraceSampledKey = "logging.googleapis.com/trace_sampled"
+)
+
+func WithLogging(ctx context.Context, span *trace.Span) context.Context {
+	if span == nil {
+		return ctx
+	}
+	sc := span.SpanContext()
+	return logging.With(ctx,
+		zap.Stringer(LoggingTraceKey, sc.TraceID),
+		zap.Stringer(LoggingSpanIDKey, sc.SpanID),
+		zap.Bool(LoggingTraceSampledKey, sc.IsSampled()),
+	)
+}


### PR DESCRIPTION
Fixes #1577

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add trace related Cloud Logging fields. Allows Cloud Logging to associate log entries with traces so that log entries show up in Cloud Trace and conversely Cloud Logging will add tracing information to the log viewer. Trace IDs are logged even when not sampled as this allows the log viewer to filter on the trace ID to display only logs belonging to a given request even when tracing is not enabled for that request.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Broker log messages are now correlated with the event's trace in Cloud Operations.
-->
