### PR TITLE
Reduce Metric test flakiness caused by sender pod retry sending events

### DIFF
--- a/test/e2e/lib/broker.go
+++ b/test/e2e/lib/broker.go
@@ -73,7 +73,7 @@ func (a BrokerMetricAssertion) Assert(client *monitoring.MetricClient) error {
 
 		// Workarounds to reduce test flakiness caused by sender pod retry sending events (which will cause unexpected response code).
 		// We should remove it after https://github.com/google/knative-gcp/issues/1058 lands
-		if code == http.StatusForbidden || code == http.StatusServiceUnavailable || code == http.StatusInternalServerError {
+		if code == http.StatusNotFound || code == http.StatusServiceUnavailable || code == http.StatusInternalServerError {
 			continue
 		}
 

--- a/test/e2e/lib/broker.go
+++ b/test/e2e/lib/broker.go
@@ -71,8 +71,9 @@ func (a BrokerMetricAssertion) Assert(client *monitoring.MetricClient) error {
 			return fmt.Errorf("metric has invalid response code label: %v", ts.GetMetric())
 		}
 
-		// Workarounds to reduce test flakiness caused by sender pod retry sending events (which will cause unexpected response code).
-		// We should remove it after https://github.com/google/knative-gcp/issues/1058 lands
+		// Workarounds to reduce test flakiness caused by sender pod retry sending events (which will cause unexpected response code 404, 503 and 500).
+		// StatusCode 500 is currently for reducing flakiness caused by Workload Identity credential sync up.
+		// We would remove it after https://github.com/google/knative-gcp/issues/1058 lands, as 500 error may indicate bugs in our code.
 		if code == http.StatusNotFound || code == http.StatusServiceUnavailable || code == http.StatusInternalServerError {
 			continue
 		}

--- a/test/e2e/lib/broker.go
+++ b/test/e2e/lib/broker.go
@@ -70,6 +70,13 @@ func (a BrokerMetricAssertion) Assert(client *monitoring.MetricClient) error {
 		if err != nil {
 			return fmt.Errorf("metric has invalid response code label: %v", ts.GetMetric())
 		}
+
+		// Workarounds to reduce test flakiness caused by sender pod retry sending events (which will cause unexpected response code).
+		// We should remove it after https://github.com/google/knative-gcp/issues/1058 lands
+		if code == http.StatusForbidden || code == http.StatusServiceUnavailable || code == http.StatusInternalServerError {
+			continue
+		}
+
 		if code != http.StatusAccepted {
 			return fmt.Errorf("metric has unexpected response code: %v", ts.GetMetric())
 		}

--- a/test/e2e/lib/broker.go
+++ b/test/e2e/lib/broker.go
@@ -71,7 +71,8 @@ func (a BrokerMetricAssertion) Assert(client *monitoring.MetricClient) error {
 			return fmt.Errorf("metric has invalid response code label: %v", ts.GetMetric())
 		}
 
-		// Workarounds to reduce test flakiness caused by sender pod retry sending events (which will cause unexpected response code 404, 503 and 500).
+		// Ignore undesired response code in metric count comparison due to flakiness in broker.
+		// The sender pod will retry StatusCode 404, 503 and 500.
 		// StatusCode 500 is currently for reducing flakiness caused by Workload Identity credential sync up.
 		// We would remove it after https://github.com/google/knative-gcp/issues/1058 lands, as 500 error may indicate bugs in our code.
 		if code == http.StatusNotFound || code == http.StatusServiceUnavailable || code == http.StatusInternalServerError {


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Reduce Metric test flakiness caused by sender pod retry sending events
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
