### PR TITLE
Adding schema to PubSub Source

### DIFF
--- a/docs/examples/cloudpubsubsource/README.md
+++ b/docs/examples/cloudpubsubsource/README.md
@@ -85,6 +85,7 @@ Context Attributes,
   source: //pubsub.googleapis.com/projects/test-project/topics/testing
   id: 1314133748793931
   time: 2020-06-30T16:32:57.012Z
+  dataschema: https://raw.githubusercontent.com/googleapis/google-cloudevents/master/proto/google/events/cloud/pubsub/v1/data.proto
   datacontenttype: application/json
 Extensions,
   knativearrivaltime: 2020-06-30T16:32:58.016175839Z

--- a/pkg/pubsub/adapter/converters/pubsub.go
+++ b/pkg/pubsub/adapter/converters/pubsub.go
@@ -41,7 +41,7 @@ func convertCloudPubSub(ctx context.Context, msg *pubsub.Message) (*cev2.Event, 
 
 	event.SetSource(schemasv1.CloudPubSubEventSource(project, topic))
 	event.SetType(schemasv1.CloudPubSubMessagePublishedEventType)
-
+	event.SetDataSchema(schemasv1.CloudPubSubEventDataSchema)
 	subscription, err := GetSubscriptionKey(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/pubsub/adapter/converters/pubsub_test.go
+++ b/pkg/pubsub/adapter/converters/pubsub_test.go
@@ -110,6 +110,7 @@ func pubSubCloudEvent(attributes map[string]string, data string) *cev2.Event {
 	s := fmt.Sprintf(`{"subscription":"testsubscription","message":{"messageId":"id","data":%s,%s"publishTime":"0001-01-01T00:00:00Z"}}`, data, at)
 	e.SetData(cev2.ApplicationJSON, []byte(s))
 	e.SetType(schemasv1.CloudPubSubMessagePublishedEventType)
+	e.SetDataSchema(schemasv1.CloudPubSubEventDataSchema)
 	e.DataBase64 = false
 	return &e
 }

--- a/test/e2e/lib/constants.go
+++ b/test/e2e/lib/constants.go
@@ -34,6 +34,7 @@ const (
 
 	EventType          = "type"
 	EventSource        = "source"
+	EventDataSchema    = "dataschema"
 	EventSubject       = "subject"
 	EventSubjectPrefix = "subject-prefix"
 	EventID            = "id"

--- a/test/e2e/lib/helpers/broker_event_transformation_test_with_source.go
+++ b/test/e2e/lib/helpers/broker_event_transformation_test_with_source.go
@@ -263,7 +263,7 @@ func BrokerEventTransformationTestWithPubSubSourceHelper(client *lib.Client, aut
 	source := schemasv1.CloudPubSubEventSource(project, topicName)
 
 	// Create a target PubSub Job to receive the events.
-	lib.MakePubSubTargetJobOrDie(client, source, targetName, lib.E2EPubSubRespEventType)
+	lib.MakePubSubTargetJobOrDie(client, source, targetName, lib.E2EPubSubRespEventType /*empty schema*/, "")
 	// Create the Knative Service.
 	kserviceName := CreateKService(client, "pubsub_receiver")
 

--- a/test/e2e/lib/pubsub.go
+++ b/test/e2e/lib/pubsub.go
@@ -78,7 +78,7 @@ func MakePubSubV1alpha1OrDie(client *Client, config PubSubConfig) {
 	client.Core.WaitForResourceReadyOrFail(config.PubSubName, CloudPubSubSourceV1alpha1TypeMeta)
 }
 
-func MakePubSubTargetJobOrDie(client *Client, source, targetName, eventType string) {
+func MakePubSubTargetJobOrDie(client *Client, source, targetName, eventType string, schema string) {
 	client.T.Helper()
 	job := resources.PubSubTargetJob(targetName, []v1.EnvVar{
 		{
@@ -91,7 +91,11 @@ func MakePubSubTargetJobOrDie(client *Client, source, targetName, eventType stri
 		}, {
 			Name:  "TIME",
 			Value: "6m",
-		}})
+		}, {
+			Name:  "SCHEMA",
+			Value: schema,
+		},
+	})
 	client.CreateJobOrFail(job, WithServiceForJob(targetName))
 }
 

--- a/test/e2e/test_pubsub.go
+++ b/test/e2e/test_pubsub.go
@@ -124,7 +124,7 @@ func CloudPubSubSourceWithTargetTestImpl(t *testing.T, assertMetrics bool, authC
 	defer lib.TearDown(client)
 
 	// Create a target Job to receive the events.
-	lib.MakePubSubTargetJobOrDie(client, source, targetName, schemasv1.CloudPubSubMessagePublishedEventType)
+	lib.MakePubSubTargetJobOrDie(client, source, targetName, schemasv1.CloudPubSubMessagePublishedEventType, schemasv1.CloudPubSubEventDataSchema)
 
 	// Create the PubSub source.
 	lib.MakePubSubOrDie(client, lib.PubSubConfig{

--- a/test/e2e/test_pullsubscription.go
+++ b/test/e2e/test_pullsubscription.go
@@ -77,7 +77,7 @@ func PullSubscriptionWithTargetTestImpl(t *testing.T, authConfig lib.AuthConfig)
 	defer lib.TearDown(client)
 
 	// Create a target Job to receive the events.
-	lib.MakePubSubTargetJobOrDie(client, source, targetName, schemasv1.CloudPubSubMessagePublishedEventType)
+	lib.MakePubSubTargetJobOrDie(client, source, targetName, schemasv1.CloudPubSubMessagePublishedEventType /*empty schema*/, "")
 
 	// Create PullSubscription.
 	lib.MakePullSubscriptionOrDie(client, lib.PullSubscriptionConfig{

--- a/test/test_images/pubsub_target/main.go
+++ b/test/test_images/pubsub_target/main.go
@@ -21,7 +21,6 @@ import (
 	"os"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	schemasv1 "github.com/google/knative-gcp/pkg/schemas/v1"
 	"github.com/google/knative-gcp/test/e2e/lib"
 	"github.com/google/knative-gcp/test/test_images/internal/knockdown"
 	"github.com/kelseyhightower/envconfig"
@@ -45,6 +44,7 @@ type pubsubReceiver struct {
 	knockdown.Config
 	Type   string `envconfig:"TYPE" required:"true"`
 	Source string `envconfig:"SOURCE" required:"true"`
+	Schema string `envconfig:"SCHEMA" required:"false"`
 }
 
 func (r *pubsubReceiver) Knockdown(event cloudevents.Event) bool {
@@ -65,8 +65,8 @@ func (r *pubsubReceiver) Knockdown(event cloudevents.Event) bool {
 	}
 
 	// Check schema
-	if event.DataSchema() != schemasv1.CloudPubSubEventDataSchema {
-		incorrectAttributes[lib.EventDataSchema] = lib.PropPair{Expected: schemasv1.CloudPubSubEventDataSchema, Received: event.DataSchema()}
+	if event.DataSchema() != r.Schema {
+		incorrectAttributes[lib.EventDataSchema] = lib.PropPair{Expected: r.Schema, Received: event.DataSchema()}
 	}
 
 	if len(incorrectAttributes) == 0 {

--- a/test/test_images/pubsub_target/main.go
+++ b/test/test_images/pubsub_target/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	schemasv1 "github.com/google/knative-gcp/pkg/schemas/v1"
 	"github.com/google/knative-gcp/test/e2e/lib"
 	"github.com/google/knative-gcp/test/test_images/internal/knockdown"
 	"github.com/kelseyhightower/envconfig"
@@ -61,6 +62,11 @@ func (r *pubsubReceiver) Knockdown(event cloudevents.Event) bool {
 	// Check source
 	if event.Source() != r.Source {
 		incorrectAttributes[lib.EventSource] = lib.PropPair{Expected: r.Source, Received: event.Source()}
+	}
+
+	// Check schema
+	if event.DataSchema() != schemasv1.CloudPubSubEventDataSchema {
+		incorrectAttributes[lib.EventDataSchema] = lib.PropPair{Expected: schemasv1.CloudPubSubEventDataSchema, Received: event.DataSchema()}
 	}
 
 	if len(incorrectAttributes) == 0 {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🐛 Adding missing dataschema attribute to PubSub


<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
CloudPubSubSource now populates the dataschema CloudEvent attribute. The value is: https://raw.githubusercontent.com/googleapis/google-cloudevents/master/proto/google/events/cloud/pubsub/v1/data.proto
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
