### PR TITLE
Fix wrong status message by changing `%w` to `%v`.

### DIFF
--- a/pkg/pubsub/adapter/adapter.go
+++ b/pkg/pubsub/adapter/adapter.go
@@ -136,7 +136,7 @@ func (a *Adapter) Stop() {
 func (a *Adapter) receive(ctx context.Context, msg *pubsub.Message) {
 	event, err := a.converter.Convert(ctx, msg, a.args.ConverterType)
 	if err != nil {
-		a.logger.Debug("Failed to convert received message to an event, check the msg format: %w", zap.Error(err))
+		a.logger.Debug("Failed to convert received message to an event, check the msg format: %v", zap.Error(err))
 		// Ack the message so it won't be retried, we consider all errors to be non-retryable.
 		msg.Ack()
 		return

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -112,8 +112,8 @@ func (r *Reconciler) reconcileDecouplingTopicAndSubscription(ctx context.Context
 	projectID, err := utils.ProjectID(r.projectID, metadataClient.NewDefaultMetadataClient())
 	if err != nil {
 		logger.Error("Failed to find project id", zap.Error(err))
-		b.Status.MarkTopicUnknown("ProjectIdNotFound", "Failed to find project id: %w", err)
-		b.Status.MarkSubscriptionUnknown("ProjectIdNotFound", "Failed to find project id: %w", err)
+		b.Status.MarkTopicUnknown("ProjectIdNotFound", "Failed to find project id: %v", err)
+		b.Status.MarkSubscriptionUnknown("ProjectIdNotFound", "Failed to find project id: %v", err)
 		return err
 	}
 	// Set the projectID in the status.
@@ -126,8 +126,8 @@ func (r *Reconciler) reconcileDecouplingTopicAndSubscription(ctx context.Context
 		client, err = pubsub.NewClient(ctx, projectID)
 		if err != nil {
 			logger.Error("Failed to create Pub/Sub client", zap.Error(err))
-			b.Status.MarkTopicUnknown("PubSubClientCreationFailed", "Failed to create Pub/Sub client: %w", err)
-			b.Status.MarkSubscriptionUnknown("PubSubClientCreationFailed", "Failed to create Pub/Sub client: %w", err)
+			b.Status.MarkTopicUnknown("PubSubClientCreationFailed", "Failed to create Pub/Sub client: %v", err)
+			b.Status.MarkSubscriptionUnknown("PubSubClientCreationFailed", "Failed to create Pub/Sub client: %v", err)
 			return err
 		}
 		defer client.Close()
@@ -181,8 +181,8 @@ func (r *Reconciler) deleteDecouplingTopicAndSubscription(ctx context.Context, b
 	projectID, err := utils.ProjectID(r.projectID, metadataClient.NewDefaultMetadataClient())
 	if err != nil {
 		logger.Error("Failed to find project id", zap.Error(err))
-		b.Status.MarkTopicUnknown("FinalizeTopicProjectIdNotFound", "Failed to find project id: %w", err)
-		b.Status.MarkSubscriptionUnknown("FinalizeSubscriptionProjectIdNotFound", "Failed to find project id: %w", err)
+		b.Status.MarkTopicUnknown("FinalizeTopicProjectIdNotFound", "Failed to find project id: %v", err)
+		b.Status.MarkSubscriptionUnknown("FinalizeSubscriptionProjectIdNotFound", "Failed to find project id: %v", err)
 		return err
 	}
 
@@ -191,8 +191,8 @@ func (r *Reconciler) deleteDecouplingTopicAndSubscription(ctx context.Context, b
 		client, err := pubsub.NewClient(ctx, projectID)
 		if err != nil {
 			logger.Error("Failed to create Pub/Sub client", zap.Error(err))
-			b.Status.MarkTopicUnknown("FinalizeTopicPubSubClientCreationFailed", "Failed to create Pub/Sub client: %w", err)
-			b.Status.MarkSubscriptionUnknown("FinalizeSubscriptionPubSubClientCreationFailed", "Failed to create Pub/Sub client: %w", err)
+			b.Status.MarkTopicUnknown("FinalizeTopicPubSubClientCreationFailed", "Failed to create Pub/Sub client: %v", err)
+			b.Status.MarkSubscriptionUnknown("FinalizeSubscriptionPubSubClientCreationFailed", "Failed to create Pub/Sub client: %v", err)
 			return err
 		}
 		defer client.Close()

--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -191,8 +191,8 @@ func (r *Reconciler) reconcileRetryTopicAndSubscription(ctx context.Context, tri
 	projectID, err := utils.ProjectID(r.projectID, metadataClient.NewDefaultMetadataClient())
 	if err != nil {
 		logger.Error("Failed to find project id", zap.Error(err))
-		trig.Status.MarkTopicUnknown("ProjectIdNotFound", "Failed to find project id: %w", err)
-		trig.Status.MarkSubscriptionUnknown("ProjectIdNotFound", "Failed to find project id: %w", err)
+		trig.Status.MarkTopicUnknown("ProjectIdNotFound", "Failed to find project id: %v", err)
+		trig.Status.MarkSubscriptionUnknown("ProjectIdNotFound", "Failed to find project id: %v", err)
 		return err
 	}
 	// Set the projectID in the status.
@@ -204,8 +204,8 @@ func (r *Reconciler) reconcileRetryTopicAndSubscription(ctx context.Context, tri
 		client, err := pubsub.NewClient(ctx, projectID)
 		if err != nil {
 			logger.Error("Failed to create Pub/Sub client", zap.Error(err))
-			trig.Status.MarkTopicUnknown("PubSubClientCreationFailed", "Failed to create Pub/Sub client: %w", err)
-			trig.Status.MarkSubscriptionUnknown("PubSubClientCreationFailed", "Failed to create Pub/Sub client: %w", err)
+			trig.Status.MarkTopicUnknown("PubSubClientCreationFailed", "Failed to create Pub/Sub client: %v", err)
+			trig.Status.MarkSubscriptionUnknown("PubSubClientCreationFailed", "Failed to create Pub/Sub client: %v", err)
 			return err
 		}
 		defer client.Close()
@@ -298,8 +298,8 @@ func (r *Reconciler) deleteRetryTopicAndSubscription(ctx context.Context, trig *
 	projectID, err := utils.ProjectID(r.projectID, metadataClient.NewDefaultMetadataClient())
 	if err != nil {
 		logger.Error("Failed to find project id", zap.Error(err))
-		trig.Status.MarkTopicUnknown("FinalizeTopicProjectIdNotFound", "Failed to find project id: %w", err)
-		trig.Status.MarkSubscriptionUnknown("FinalizeSubscriptionProjectIdNotFound", "Failed to find project id: %w", err)
+		trig.Status.MarkTopicUnknown("FinalizeTopicProjectIdNotFound", "Failed to find project id: %v", err)
+		trig.Status.MarkSubscriptionUnknown("FinalizeSubscriptionProjectIdNotFound", "Failed to find project id: %v", err)
 		return err
 	}
 
@@ -308,8 +308,8 @@ func (r *Reconciler) deleteRetryTopicAndSubscription(ctx context.Context, trig *
 		client, err := pubsub.NewClient(ctx, projectID)
 		if err != nil {
 			logger.Error("Failed to create Pub/Sub client", zap.Error(err))
-			trig.Status.MarkTopicUnknown("FinalizeTopicPubSubClientCreationFailed", "Failed to create Pub/Sub client: %w", err)
-			trig.Status.MarkSubscriptionUnknown("FinalizeSubscriptionPubSubClientCreationFailed", "Failed to create Pub/Sub client: %w", err)
+			trig.Status.MarkTopicUnknown("FinalizeTopicPubSubClientCreationFailed", "Failed to create Pub/Sub client: %v", err)
+			trig.Status.MarkSubscriptionUnknown("FinalizeSubscriptionPubSubClientCreationFailed", "Failed to create Pub/Sub client: %v", err)
 			return err
 		}
 		defer client.Close()

--- a/pkg/reconciler/utils/pubsub/subscription.go
+++ b/pkg/reconciler/utils/pubsub/subscription.go
@@ -41,7 +41,7 @@ func (r *Reconciler) ReconcileSubscription(ctx context.Context, id string, subCo
 	subExists, err := sub.Exists(ctx)
 	if err != nil {
 		logger.Error("Failed to verify Pub/Sub subscription exists", zap.Error(err))
-		updater.MarkSubscriptionUnknown("SubscriptionVerificationFailed", "Failed to verify Pub/Sub subscription exists: %w", err)
+		updater.MarkSubscriptionUnknown("SubscriptionVerificationFailed", "Failed to verify Pub/Sub subscription exists: %v", err)
 		return nil, err
 	}
 
@@ -50,7 +50,7 @@ func (r *Reconciler) ReconcileSubscription(ctx context.Context, id string, subCo
 		config, err := sub.Config(ctx)
 		if err != nil {
 			logger.Error("Failed to get Pub/Sub subscription Config", zap.Error(err))
-			updater.MarkSubscriptionUnknown("SubscriptionConfigUnknown", "Failed to get Pub/Sub subscription Config: %w", err)
+			updater.MarkSubscriptionUnknown("SubscriptionConfigUnknown", "Failed to get Pub/Sub subscription Config: %v", err)
 			return nil, err
 		}
 		if config.Topic != nil && config.Topic.String() == deletedTopic {
@@ -79,12 +79,12 @@ func (r *Reconciler) DeleteSubscription(ctx context.Context, id string, obj runt
 	exists, err := sub.Exists(ctx)
 	if err != nil {
 		logger.Error("Failed to verify Pub/Sub subscription exists", zap.Error(err))
-		updater.MarkSubscriptionUnknown("FinalizeSubscriptionVerificationFailed", "failed to verify Pub/Sub subscription exists: %w", err)
+		updater.MarkSubscriptionUnknown("FinalizeSubscriptionVerificationFailed", "failed to verify Pub/Sub subscription exists: %v", err)
 		return err
 	}
 	if exists {
 		if err = r.deleteSubscription(ctx, sub, obj); err != nil {
-			updater.MarkSubscriptionUnknown("FinalizeSubscriptionDeletionFailed", "failed to delete Pub/Sub subscription: %w", err)
+			updater.MarkSubscriptionUnknown("FinalizeSubscriptionDeletionFailed", "failed to delete Pub/Sub subscription: %v", err)
 			return err
 		}
 	}
@@ -108,7 +108,7 @@ func (r *Reconciler) createSubscription(ctx context.Context, id string, subConfi
 	sub, err := r.client.CreateSubscription(ctx, id, subConfig)
 	if err != nil {
 		logger.Error("Failed to create subscription", zap.Error(err))
-		updater.MarkSubscriptionFailed("SubscriptionCreationFailed", "Subscription creation failed: %w", err)
+		updater.MarkSubscriptionFailed("SubscriptionCreationFailed", "Subscription creation failed: %v", err)
 		return nil, err
 	}
 	logger.Info("Created PubSub subscription", zap.String("name", sub.ID()))

--- a/pkg/reconciler/utils/pubsub/topic.go
+++ b/pkg/reconciler/utils/pubsub/topic.go
@@ -39,7 +39,7 @@ func (r *Reconciler) ReconcileTopic(ctx context.Context, id string, topicConfig 
 	exists, err := topic.Exists(ctx)
 	if err != nil {
 		logger.Error("Failed to verify Pub/Sub topic exists", zap.Error(err))
-		updater.MarkTopicUnknown("TopicVerificationFailed", "Failed to verify Pub/Sub topic exists: %w", err)
+		updater.MarkTopicUnknown("TopicVerificationFailed", "Failed to verify Pub/Sub topic exists: %v", err)
 		return nil, err
 	}
 	if exists {
@@ -52,7 +52,7 @@ func (r *Reconciler) ReconcileTopic(ctx context.Context, id string, topicConfig 
 	topic, err = r.client.CreateTopicWithConfig(ctx, id, topicConfig)
 	if err != nil {
 		logger.Error("Failed to create Pub/Sub topic", zap.Error(err))
-		updater.MarkTopicFailed("TopicCreationFailed", "Topic creation failed: %w", err)
+		updater.MarkTopicFailed("TopicCreationFailed", "Topic creation failed: %v", err)
 		return nil, err
 	}
 	logger.Info("Created PubSub topic", zap.String("name", topic.ID()))
@@ -71,13 +71,13 @@ func (r *Reconciler) DeleteTopic(ctx context.Context, id string, obj runtime.Obj
 	exists, err := topic.Exists(ctx)
 	if err != nil {
 		logger.Error("Failed to verify Pub/Sub topic exists", zap.Error(err))
-		updater.MarkTopicUnknown("FinalizeTopicVerificationFailed", "failed to verify Pub/Sub topic exists: %w", err)
+		updater.MarkTopicUnknown("FinalizeTopicVerificationFailed", "failed to verify Pub/Sub topic exists: %v", err)
 		return err
 	}
 	if exists {
 		if err := topic.Delete(ctx); err != nil {
 			logger.Error("Failed to delete Pub/Sub topic", zap.Error(err))
-			updater.MarkTopicUnknown("FinalizeTopicDeletionFailed", "failed to delete Pub/Sub topic: %w", err)
+			updater.MarkTopicUnknown("FinalizeTopicDeletionFailed", "failed to delete Pub/Sub topic: %v", err)
 			return err
 		}
 		logger.Info("Deleted PubSub topic", zap.String("name", topic.ID()))


### PR DESCRIPTION
Experiment shows that `%w` does not invoke the `Error() string` method
that the error type provides for proper struct formatting. When using
it in status message or logger, we will get sth like:
```
- lastTransitionTime: "2020-09-09T13:23:24Z"
    message: 'Failed to verify Pub/Sub topic exists: %!w(*status.Error=&{0xc0024ffe60})'
    reason: TopicVerificationFailed
```

After the fix, it will show as:

```
- lastTransitionTime: "2020-09-09T14:13:41Z"
    message: |-
      Failed to verify Pub/Sub topic exists: rpc error: code = Unauthenticated desc = transport: oauth2: cannot fetch token: 400 Bad Request
      Response: {"error":"invalid_grant","error_description":"Invalid JWT Signature."}
    reason: TopicVerificationFailed
```

Fixes #1672

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Replace `%w` with `%v` in status message and logging
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug status messag showing error
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
