### PR TITLE
Update v1alpha1 deprecated message to be removed in  0.19

### DIFF
--- a/pkg/apis/convert/conversion_helper.go
+++ b/pkg/apis/convert/conversion_helper.go
@@ -34,7 +34,7 @@ import (
 const (
 	DeprecatedType           = "Deprecated"
 	deprecatedV1Alpha1Reason = "v1alpha1Deprecated"
-	deprecatedV1Alpha1Msg    = "V1alpha1 has been deprecated and will be removed in 0.18."
+	deprecatedV1Alpha1Msg    = "V1alpha1 has been deprecated and will be removed in 0.19."
 )
 
 var (
@@ -329,14 +329,14 @@ func FromV1beta1SubscribableSpec(from *eventingduckv1beta1.SubscribableSpec) *ev
 
 // A helper function to mark v1alpha1 Deprecated Condition in the Status.
 // We mark the Condition in status during conversion from a higher version to v1alpha1.
-// TODO: remove after the 0.17 cut.
+// TODO(https://github.com/google/knative-gcp/issues/1544): remove after the 0.18 cut.
 func MarkV1alpha1Deprecated(cs *apis.ConditionSet, s *pkgduckv1.Status) {
 	cs.Manage(s).SetCondition(DeprecatedV1Alpha1Condition)
 }
 
 // A helper function to remove Deprecated Condition from the Status during conversion
 // from v1alpha1 to a higher version.
-// TODO: remove after the 0.17 cut.
+// TODO(https://github.com/google/knative-gcp/issues/1544): remove after the 0.18 cut.
 func RemoveV1alpha1Deprecated(cs *apis.ConditionSet, s *pkgduckv1.Status) {
 	cs.Manage(s).ClearCondition(DeprecatedType)
 }


### PR DESCRIPTION
Due to https://github.com/google/knative-gcp/issues/1544#issuecomment-683882784, we will delay the deprecation of v1alpha1 to 0.19.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Update v1alpha1 deprecated message to be removed in  0.19
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
v1alpha1 sources and channels will be removed in 0.19.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
