### PR TITLE
Extend the ProbeHelper for use with CloudAuditLogsSource probe

### DIFF
--- a/test/test_images/probe_helper/main.go
+++ b/test/test_images/probe_helper/main.go
@@ -59,6 +59,19 @@ The Probe Helper can handle multiple different types of probes.
 		 the object, and waits to tbe notified that the object has been deleted by a
 		 CloudStorageSource.
 
+4. CloudAuditLogsSource Probe
+
+	This probe has two steps in executed in sequence which are intended to test a
+	few of the different events tracked by Cloud AuditLogs. Specifically, this
+	probe tracks the logging of Pub/Sub topic creation and deletion.
+
+	1. The Probe Helper receives an event with a given ID, creates a Pub/Sub topic
+		 named with that ID, and waits to be notified of the topic having been
+		 created by a CloudAuditLogsSource.
+	2. The Probe Helper receives an event with the same ID as in step 1, deletes
+		 the associated Pub/Sub topic, and waits to be notified of the topic having
+		 been deleted by a CloudAuditLogsSource
+
 */
 
 package main

--- a/test/test_images/probe_helper/main.go
+++ b/test/test_images/probe_helper/main.go
@@ -61,9 +61,9 @@ The Probe Helper can handle multiple different types of probes.
 
 4. CloudAuditLogsSource Probe
 
-	This probe has two steps in executed in sequence which are intended to test a
-	few of the different events tracked by Cloud AuditLogs. Specifically, this
-	probe tracks the logging of Pub/Sub topic creation and deletion.
+	This probe has two steps executed in sequence which are intended to test a few
+	of the different events tracked by Cloud AuditLogs. Specifically, this probe
+	tracks the logging of Pub/Sub topic creation and deletion.
 
 	1. The Probe Helper receives an event with a given ID, creates a Pub/Sub topic
 		 named with that ID, and waits to be notified of the topic having been

--- a/test/test_images/probe_helper/probe_helper.go
+++ b/test/test_images/probe_helper/probe_helper.go
@@ -436,6 +436,8 @@ func (ph *ProbeHelper) receiveEvent(ctx context.Context) cloudEventsFunc {
 				//     methodname: google.pubsub.v1.Publisher.DeleteTopic
 				//     resourcename: projects/project-id/topics/cloudauditlogssource-probe-914e5946-5e27-4bde-a455-7cfbae1c8539
 				//     servicename: pubsub.googleapis.com
+				//   Data,
+				//     { ... }
 				channelID = sepSub[4] + "-" + CloudAuditLogsSourceProbeDeleteSubject
 			default:
 				return logACK(ctx, "Unrecognized CloudEvent methodname extension: %v", event.Extensions()["methodname"])

--- a/test/test_images/probe_helper/probe_helper.go
+++ b/test/test_images/probe_helper/probe_helper.go
@@ -185,6 +185,7 @@ func (ph *ProbeHelper) forwardFromProbe(ctx context.Context) cloudEventsFunc {
 			return logNACK(ctx, "Probe forwarding failed, unrecognized probe event type and subject: type=%v, subject=%v", event.Type(), event.Subject())
 		}
 
+		// The CloudSchedulerSource probe is not channel-based.
 		if event.Type() != CloudSchedulerSourceProbeEventType {
 			// Create channel on which to wait for event to be received once forwarded.
 			channelID = event.ID()
@@ -468,6 +469,16 @@ func (ph *ProbeHelper) receiveEvent(ctx context.Context) cloudEventsFunc {
 			// Refresh the last received event timestamp from the CloudSchedulerSource.
 			//
 			// Example:
+			//   Context Attributes,
+			//     specversion: 1.0
+			//     type: google.cloud.scheduler.job.v1.executed
+			//     source: //cloudscheduler.googleapis.com/projects/project-id/locations/location/jobs/cre-scheduler-9af24c86-8ba9-4688-80d0-e527678a6a63
+			//     id: 1533039115503825
+			//     time: 2020-09-15T20:12:00.14Z
+			//     dataschema: https://raw.githubusercontent.com/googleapis/google-cloudevents/master/proto/google/events/cloud/scheduler/v1/data.proto
+			//     datacontenttype: application/json
+			//   Data,
+			//     { ... }
 			ph.lastCloudSchedulerEventTimestamp.setNow()
 		default:
 			return logACK(ctx, "Unrecognized event type: %v", event.Type())


### PR DESCRIPTION
Extended the Probe Helper to work with the CloudAuditLogsSource probe.

## Proposed Changes
- The Probe Helper can now receive events of type cloudauditlogssource-probe
- The Probe Helper can now handle events sourced from a CloudAuditLogsSource
- Added a test for the CloudAuditLogsSource probe
