### PR TITLE
Extend tracing test waiting time

### DIFF
--- a/test/e2e/lib/helpers/broker_tracing.go
+++ b/test/e2e/lib/helpers/broker_tracing.go
@@ -33,7 +33,7 @@ func VerifyTrace(t *testing.T, testTree TestSpanTree, projectID string, traceID 
 		t.Error(err)
 		return
 	}
-	timeout := time.After(2 * time.Minute)
+	timeout := time.After(4 * time.Minute)
 	for {
 		err = tryVerifyBrokerTrace(ctx, nil, testTree, client, projectID, traceID)
 		if err == nil {


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Found errors like: https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/google_knative-gcp/1685/pull-google-knative-gcp-wi-tests/1304435131041189888
``` 
broker_tracing.go:45: multiple root spans: 
span_id:16819137463768674004 name:"trigger:resp-broker-gcp-obbmsncg.test-g-c-p-broker-tracing-6q965" start_time:{seconds:1599838202 nanos:914107022} end_time:{seconds:1599838202 nanos:914392873} parent_span_id:10419454865403651873 labels:{key:"g.co/agent" value:"opencensus-go 0.23.0; stackdriver-exporter 0.10.0"} labels:{key:"messaging.destination" value:"trigger:resp-broker-gcp-obbmsncg.test-g-c-p-broker-tracing-6q965"} labels:{key:"messaging.message_id" value:"e2e-dummy-event-id"} labels:{key:"messaging.protocol" value:"Pub/Sub"} labels:{key:"messaging.system" value:"knative"}, 
span_id:9990056078169145754 name:"trigger:trigger-broker-gcp-obbmsncg.test-g-c-p-broker-tracing-6q965" start_time:{seconds:1599838202 nanos:914223065} end_time:{seconds:1599838203 nanos:196056604} parent_span_id:10419454865403651873 labels:{key:"g.co/agent" value:"opencensus-go 0.23.0; stackdriver-exporter 0.10.0"} labels:{key:"messaging.destination" value:"trigger:trigger-broker-gcp-obbmsncg.test-g-c-p-broker-tracing-6q965"} labels:{key:"messaging.message_id" value:"e2e-dummy-event-id"} labels:{key:"messaging.protocol" value:"Pub/Sub"} labels:{key:"messaging.system" value:"knative"}
```
It seems they should come from the same trace tree, but some spans didn't show up, so that they disconnect.

-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
