### PR TITLE
Update broker deployments spec for better availability during upgrades

### DIFF
--- a/pkg/reconciler/brokercell/resources/deployments.go
+++ b/pkg/reconciler/brokercell/resources/deployments.go
@@ -44,7 +44,7 @@ func MakeIngressDeployment(args IngressArgs) *appsv1.Deployment {
 			},
 		},
 		FailureThreshold: 5,
-		PeriodSeconds:    2,
+		PeriodSeconds:    15,
 		SuccessThreshold: 1,
 		TimeoutSeconds:   5,
 	}
@@ -57,8 +57,8 @@ func MakeIngressDeployment(args IngressArgs) *appsv1.Deployment {
 			},
 		},
 		FailureThreshold:    5,
-		InitialDelaySeconds: 5,
-		PeriodSeconds:       2,
+		InitialDelaySeconds: 15,
+		PeriodSeconds:       15,
 		SuccessThreshold:    1,
 		TimeoutSeconds:      5,
 	}
@@ -135,6 +135,13 @@ func deploymentTemplate(args Args, containers []corev1.Container) *appsv1.Deploy
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: Labels(args.BrokerCell.Name, args.ComponentName)},
+			Strategy: appsv1.DeploymentStrategy{
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxSurge:       &intstr.IntOrString{IntVal: 1},
+					MaxUnavailable: &intstr.IntOrString{IntVal: 0},
+				},
+			},
+			MinReadySeconds: 60,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: Labels(args.BrokerCell.Name, args.ComponentName),

--- a/pkg/reconciler/brokercell/resources/deployments.go
+++ b/pkg/reconciler/brokercell/resources/deployments.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/system"
 )
 
@@ -161,7 +162,8 @@ func deploymentTemplate(args Args, containers []corev1.Container) *appsv1.Deploy
 							VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "google-broker-key", Optional: &optionalSecretVolume}},
 						},
 					},
-					Containers: containers,
+					Containers:                    containers,
+					TerminationGracePeriodSeconds: ptr.Int64(60),
 				},
 			},
 		},

--- a/pkg/reconciler/brokercell/testingdata/fanout_deployment.yaml
+++ b/pkg/reconciler/brokercell/testingdata/fanout_deployment.yaml
@@ -44,6 +44,7 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: broker
+      terminationGracePeriodSeconds: 60
       containers:
       - name: fanout
         image: fanout

--- a/pkg/reconciler/brokercell/testingdata/fanout_deployment.yaml
+++ b/pkg/reconciler/brokercell/testingdata/fanout_deployment.yaml
@@ -32,6 +32,11 @@ spec:
       app: cloud-run-events
       brokerCell: test-brokercell
       role: fanout
+  minReadySeconds: 60
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   template:
     metadata:
       labels: *labels

--- a/pkg/reconciler/brokercell/testingdata/fanout_deployment_with_status.yaml
+++ b/pkg/reconciler/brokercell/testingdata/fanout_deployment_with_status.yaml
@@ -45,6 +45,7 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: broker
+      terminationGracePeriodSeconds: 60
       containers:
       - name: fanout
         image: fanout

--- a/pkg/reconciler/brokercell/testingdata/fanout_deployment_with_status.yaml
+++ b/pkg/reconciler/brokercell/testingdata/fanout_deployment_with_status.yaml
@@ -33,6 +33,11 @@ spec:
       app: cloud-run-events
       brokerCell: test-brokercell
       role: fanout
+  minReadySeconds: 60
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   template:
     metadata:
       labels: *labels

--- a/pkg/reconciler/brokercell/testingdata/ingress_deployment.yaml
+++ b/pkg/reconciler/brokercell/testingdata/ingress_deployment.yaml
@@ -32,6 +32,11 @@ spec:
       app: cloud-run-events
       brokerCell: test-brokercell
       role: ingress
+  minReadySeconds: 60
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   template:
     metadata:
       labels: *labels
@@ -48,8 +53,8 @@ spec:
             path: /healthz
             port: 8080
             scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 2
+          initialDelaySeconds: 15
+          periodSeconds: 15
           successThreshold: 1
           timeoutSeconds: 5
         readinessProbe:
@@ -58,7 +63,7 @@ spec:
             path: /healthz
             port: 8080
             scheme: HTTP
-          periodSeconds: 2
+          periodSeconds: 15
           successThreshold: 1
           timeoutSeconds: 5
         env:

--- a/pkg/reconciler/brokercell/testingdata/ingress_deployment.yaml
+++ b/pkg/reconciler/brokercell/testingdata/ingress_deployment.yaml
@@ -44,6 +44,7 @@ spec:
         sidecar.istio.io/inject: "true"
     spec:
       serviceAccountName: broker
+      terminationGracePeriodSeconds: 60
       containers:
       - name: ingress
         image: ingress

--- a/pkg/reconciler/brokercell/testingdata/ingress_deployment_with_status.yaml
+++ b/pkg/reconciler/brokercell/testingdata/ingress_deployment_with_status.yaml
@@ -33,6 +33,11 @@ spec:
       app: cloud-run-events
       brokerCell: test-brokercell
       role: ingress
+  minReadySeconds: 60
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   template:
     metadata:
       labels: *labels
@@ -49,8 +54,8 @@ spec:
             path: /healthz
             port: 8080
             scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 2
+          initialDelaySeconds: 15
+          periodSeconds: 15
           successThreshold: 1
           timeoutSeconds: 5
         readinessProbe:
@@ -59,7 +64,7 @@ spec:
             path: /healthz
             port: 8080
             scheme: HTTP
-          periodSeconds: 2
+          periodSeconds: 15
           successThreshold: 1
           timeoutSeconds: 5
         env:

--- a/pkg/reconciler/brokercell/testingdata/ingress_deployment_with_status.yaml
+++ b/pkg/reconciler/brokercell/testingdata/ingress_deployment_with_status.yaml
@@ -45,6 +45,7 @@ spec:
         sidecar.istio.io/inject: "true"
     spec:
       serviceAccountName: broker
+      terminationGracePeriodSeconds: 60
       containers:
       - name: ingress
         image: ingress

--- a/pkg/reconciler/brokercell/testingdata/retry_deployment.yaml
+++ b/pkg/reconciler/brokercell/testingdata/retry_deployment.yaml
@@ -32,6 +32,11 @@ spec:
       app: cloud-run-events
       brokerCell: test-brokercell
       role: retry
+  minReadySeconds: 60
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   template:
     metadata:
       labels: *labels

--- a/pkg/reconciler/brokercell/testingdata/retry_deployment.yaml
+++ b/pkg/reconciler/brokercell/testingdata/retry_deployment.yaml
@@ -44,6 +44,7 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: broker
+      terminationGracePeriodSeconds: 60
       containers:
       - name: retry
         image: retry

--- a/pkg/reconciler/brokercell/testingdata/retry_deployment_with_status.yaml
+++ b/pkg/reconciler/brokercell/testingdata/retry_deployment_with_status.yaml
@@ -45,6 +45,7 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: broker
+      terminationGracePeriodSeconds: 60
       containers:
       - name: retry
         image: retry

--- a/pkg/reconciler/brokercell/testingdata/retry_deployment_with_status.yaml
+++ b/pkg/reconciler/brokercell/testingdata/retry_deployment_with_status.yaml
@@ -33,6 +33,11 @@ spec:
       app: cloud-run-events
       brokerCell: test-brokercell
       role: retry
+  minReadySeconds: 60
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   template:
     metadata:
       labels: *labels

--- a/pkg/reconciler/utils/deployment.go
+++ b/pkg/reconciler/utils/deployment.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	"k8s.io/client-go/tools/record"
+	"knative.dev/pkg/ptr"
 )
 
 const (
@@ -53,6 +54,10 @@ func (r *DeploymentReconciler) ReconcileDeployment(obj runtime.Object, d *appsv1
 	}
 	if err != nil {
 		return nil, err
+	}
+	// Don't reconcile on replica difference.
+	if current.Spec.Replicas != nil {
+		d.Spec.Replicas = ptr.Int32(*current.Spec.Replicas)
 	}
 	if !equality.Semantic.DeepDerivative(d.Spec, current.Spec) {
 		// Don't modify the informers copy.

--- a/pkg/reconciler/utils/deployment_test.go
+++ b/pkg/reconciler/utils/deployment_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
+	"knative.dev/pkg/ptr"
 	pkgreconcilertesting "knative.dev/pkg/reconciler/testing"
 )
 
@@ -40,6 +41,10 @@ var (
 	deploymentDifferentSpec = &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
 		Spec:       appsv1.DeploymentSpec{MinReadySeconds: 20},
+	}
+	deploymentWithReplicas = &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+		Spec:       appsv1.DeploymentSpec{MinReadySeconds: 10, Replicas: ptr.Int32(3)},
 	}
 
 	deploymentCreateFailure = pkgreconcilertesting.InduceFailure("create", "deployments")
@@ -93,6 +98,14 @@ func TestDeploymentReconciler(t *testing.T) {
 				wantErr:   true,
 			},
 			in: deployment,
+		},
+		{
+			commonCase: commonCase{
+				name:     "deployment exists with different replicas",
+				existing: []runtime.Object{deploymentWithReplicas},
+			},
+			in:   deployment,
+			want: deploymentWithReplicas,
 		},
 	}
 


### PR DESCRIPTION
Fixes https://github.com/google/knative-gcp/issues/611

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add `MinReadySeconds=60s` for broker deployments
- Add a safer rolling update strategy
- Relax probe period

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Update broker deployments spec for better availability during upgrades
- Add `MinReadySeconds=60s` for broker deployments
- Add a safer rolling update strategy
- Relax probe period
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
