### PR TITLE
Finalize resource as best effort and always mark topic as ready

### DIFF
--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -121,7 +121,14 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *brokerv1beta1.Trigger
 		// TODO(https://github.com/knative/pkg/issues/1149) Add a FilterKind to genreconciler so it will
 		// skip a trigger if it's not pointed to a gcp broker and doesn't have googlecloud finalizer string.
 		t.Status.MarkTopicReady()
-		return event
+
+		if event == nil {
+			return nil
+		} else if reconcilerEvent, ok := event.(*pkgreconciler.ReconcilerEvent); ok && reconcilerEvent.EventType == corev1.EventTypeNormal {
+			return event
+		} else {
+			return fmt.Errorf("Controller won't retry to handle the error/warning and user will need to address it manually: %w", event)
+		}
 	}
 
 	return r.reconcile(ctx, t, b)

--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -122,11 +122,12 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *brokerv1beta1.Trigger
 		// skip a trigger if it's not pointed to a gcp broker and doesn't have googlecloud finalizer string.
 		t.Status.MarkTopicReady()
 		var reconcilerEvent *pkgreconciler.ReconcilerEvent
-		if event == nil {
+		switch {
+		case event == nil:
 			return nil
-		} else if pkgreconciler.EventAs(event, &reconcilerEvent) {
+		case pkgreconciler.EventAs(event, &reconcilerEvent):
 			return event
-		} else {
+		default:
 			return fmt.Errorf("Error won't be retried, please manually delete PubSub resources:: %w", event)
 		}
 	}

--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -121,13 +121,13 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *brokerv1beta1.Trigger
 		// TODO(https://github.com/knative/pkg/issues/1149) Add a FilterKind to genreconciler so it will
 		// skip a trigger if it's not pointed to a gcp broker and doesn't have googlecloud finalizer string.
 		t.Status.MarkTopicReady()
-
+		var reconcilerEvent *pkgreconciler.ReconcilerEvent
 		if event == nil {
 			return nil
-		} else if reconcilerEvent, ok := event.(*pkgreconciler.ReconcilerEvent); ok && reconcilerEvent.EventType == corev1.EventTypeNormal {
+		} else if pkgreconciler.EventAs(event, &reconcilerEvent) {
 			return event
 		} else {
-			return fmt.Errorf("Controller won't retry to handle the error/warning and user will need to address it manually: %w", event)
+			return fmt.Errorf("Error won't be retried, please manually delete PubSub resources:: %w", event)
 		}
 	}
 

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -238,6 +238,18 @@ func TestAllCasesTrigger(t *testing.T) {
 					TopicAndSub("cre-tgr_testnamespace_test-trigger_abc123", "cre-tgr_testnamespace_test-trigger_abc123"),
 				},
 			},
+			// This WantStatusUpdates should be deleted once the following TODO is finished.
+			// TODO(https://github.com/knative/pkg/issues/1149) Add a FilterKind to genreconciler so it will
+			// skip a trigger if it's not pointed to a gcp broker and doesn't have googlecloud finalizer string.
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewTrigger(triggerName, testNS, brokerName,
+					WithTriggerUID(testUID),
+					WithTriggerFinalizers(finalizerName),
+					WithTriggerSetDefaults,
+					WithInitTriggerConditions,
+					WithTriggerTopicReady,
+				),
+			}},
 		},
 		{
 			Name: "Broker is not ready",


### PR DESCRIPTION
Fixes #1583 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-  For a trigger pointing to brokerclass other than `googlecloud`, finalize it as a best effort and always mark the trigger ready

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**
<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
Before this change, a non GCP trigger readiness can be blocked by `TopicReady: Unknown` . With the change, the trigger readiness won't be blocked anymore.

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
