### PR TITLE
Fix release script which has been breaking auto release

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -62,4 +62,4 @@ function build_release() {
   ARTIFACTS_TO_PUBLISH="${all_yamls[@]}"
 }
 
-main "$@"
+main $@


### PR DESCRIPTION
The quote has caused `test-infra/scripts/release.sh` having issue parsing parameters.

Sample error:

```
+ ./hack/release.sh --auto-release '--release-gcs knative-releases/knative-gcp' '--release-gcr gcr.io/knative-releases' '--github-token /etc/hub-token/token'
error: unknown option --release-gcs knative-releases/knative-gcp
```

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
