### PR TITLE
webhook reject the request when secret set to be non-nil and service account is non-empty

### DIFF
--- a/pkg/apis/duck/v1/pubsub_defaults.go
+++ b/pkg/apis/duck/v1/pubsub_defaults.go
@@ -20,8 +20,6 @@ import (
 	"context"
 
 	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"knative.dev/eventing/pkg/logging"
 	"knative.dev/pkg/apis"
 )
@@ -33,8 +31,7 @@ func (s *PubSubSpec) SetPubSubDefaults(ctx context.Context) {
 		logging.FromContext(ctx).Error("Failed to get the GCPAuthDefaults")
 		return
 	}
-	if s.ServiceAccountName == "" &&
-		(s.Secret == nil || equality.Semantic.DeepEqual(s.Secret, &corev1.SecretKeySelector{})) {
+	if s.ServiceAccountName == "" && s.Secret == nil {
 		s.ServiceAccountName = ad.KSA(apis.ParentMeta(ctx).Namespace)
 		s.Secret = ad.Secret(apis.ParentMeta(ctx).Namespace)
 	}

--- a/pkg/apis/duck/v1/pubsub_defaults_test.go
+++ b/pkg/apis/duck/v1/pubsub_defaults_test.go
@@ -49,17 +49,12 @@ func TestPubSubSpec_SetPubSubDefaults(t *testing.T) {
 			expected: &PubSubSpec{},
 			ctx:      context.Background(),
 		},
-		"empty defaults": {
+		"empty secret": {
 			orig: &PubSubSpec{
 				Secret: &corev1.SecretKeySelector{},
 			},
 			expected: &PubSubSpec{
-				Secret: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "google-cloud-key",
-					},
-					Key: "key.json",
-				},
+				Secret: &corev1.SecretKeySelector{},
 			},
 			ctx: gcpauthtesthelper.ContextWithDefaults(),
 		},

--- a/pkg/apis/duck/v1alpha1/pubsub_defaults.go
+++ b/pkg/apis/duck/v1alpha1/pubsub_defaults.go
@@ -20,8 +20,6 @@ import (
 	"context"
 
 	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"knative.dev/eventing/pkg/logging"
 	"knative.dev/pkg/apis"
 )
@@ -33,8 +31,7 @@ func (s *PubSubSpec) SetPubSubDefaults(ctx context.Context) {
 		logging.FromContext(ctx).Error("Failed to get the GCPAuthDefaults")
 		return
 	}
-	if s.ServiceAccountName == "" &&
-		(s.Secret == nil || equality.Semantic.DeepEqual(s.Secret, &corev1.SecretKeySelector{})) {
+	if s.ServiceAccountName == "" && s.Secret == nil {
 		s.ServiceAccountName = ad.KSA(apis.ParentMeta(ctx).Namespace)
 		s.Secret = ad.Secret(apis.ParentMeta(ctx).Namespace)
 	}

--- a/pkg/apis/duck/v1alpha1/pubsub_defaults_test.go
+++ b/pkg/apis/duck/v1alpha1/pubsub_defaults_test.go
@@ -49,17 +49,12 @@ func TestPubSubSpec_SetPubSubDefaults(t *testing.T) {
 			expected: &PubSubSpec{},
 			ctx:      context.Background(),
 		},
-		"empty defaults": {
+		"empty secret": {
 			orig: &PubSubSpec{
 				Secret: &corev1.SecretKeySelector{},
 			},
 			expected: &PubSubSpec{
-				Secret: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "google-cloud-key",
-					},
-					Key: "key.json",
-				},
+				Secret: &corev1.SecretKeySelector{},
 			},
 			ctx: gcpauthtesthelper.ContextWithDefaults(),
 		},

--- a/pkg/apis/duck/v1beta1/pubsub_defaults.go
+++ b/pkg/apis/duck/v1beta1/pubsub_defaults.go
@@ -20,8 +20,6 @@ import (
 	"context"
 
 	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"knative.dev/eventing/pkg/logging"
 	"knative.dev/pkg/apis"
 )
@@ -33,8 +31,7 @@ func (s *PubSubSpec) SetPubSubDefaults(ctx context.Context) {
 		logging.FromContext(ctx).Error("Failed to get the GCPAuthDefaults")
 		return
 	}
-	if s.ServiceAccountName == "" &&
-		(s.Secret == nil || equality.Semantic.DeepEqual(s.Secret, &corev1.SecretKeySelector{})) {
+	if s.ServiceAccountName == "" && s.Secret == nil {
 		s.ServiceAccountName = ad.KSA(apis.ParentMeta(ctx).Namespace)
 		s.Secret = ad.Secret(apis.ParentMeta(ctx).Namespace)
 	}

--- a/pkg/apis/duck/v1beta1/pubsub_defaults_test.go
+++ b/pkg/apis/duck/v1beta1/pubsub_defaults_test.go
@@ -49,17 +49,12 @@ func TestPubSubSpec_SetPubSubDefaults(t *testing.T) {
 			expected: &PubSubSpec{},
 			ctx:      context.Background(),
 		},
-		"empty defaults": {
+		"empty secret": {
 			orig: &PubSubSpec{
 				Secret: &corev1.SecretKeySelector{},
 			},
 			expected: &PubSubSpec{
-				Secret: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "google-cloud-key",
-					},
-					Key: "key.json",
-				},
+				Secret: &corev1.SecretKeySelector{},
 			},
 			ctx: gcpauthtesthelper.ContextWithDefaults(),
 		},

--- a/pkg/apis/duck/validations.go
+++ b/pkg/apis/duck/validations.go
@@ -119,12 +119,14 @@ func CheckImmutableAutoscalingClassAnnotations(current *metav1.ObjectMeta, origi
 
 // ValidateCredential checks secret and service account.
 func ValidateCredential(secret *corev1.SecretKeySelector, kServiceAccountName string) *apis.FieldError {
-	if secret != nil && !equality.Semantic.DeepEqual(secret, &corev1.SecretKeySelector{}) && kServiceAccountName != "" {
+	fmt.Printf("secret is empty or not %v", equality.Semantic.DeepEqual(secret, &corev1.SecretKeySelector{}))
+	fmt.Printf("secret is %v", secret)
+	if secret != nil && kServiceAccountName != "" {
 		return &apis.FieldError{
 			Message: "Can't have spec.serviceAccountName and spec.secret at the same time",
 			Paths:   []string{""},
 		}
-	} else if secret != nil && !equality.Semantic.DeepEqual(secret, &corev1.SecretKeySelector{}) {
+	} else if secret != nil {
 		return validateSecret(secret)
 	} else if kServiceAccountName != "" {
 		return validateK8sServiceAccount(kServiceAccountName)

--- a/pkg/apis/duck/validations_test.go
+++ b/pkg/apis/duck/validations_test.go
@@ -335,6 +335,11 @@ func TestValidateCredential(t *testing.T) {
 		secret:         &gcpauthtesthelper.Secret,
 		serviceAccount: "test",
 		wantErr:        true,
+	}, {
+		name:           "empty secret and service account exist at the same time",
+		secret:         &corev1.SecretKeySelector{},
+		serviceAccount: "test",
+		wantErr:        true,
 	}}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fixes #1698

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- webhook reject the request of creating sources when secret set to be non-nil and service account is not empty
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
