### PR TITLE
set empty secret to nil

### DIFF
--- a/pkg/apis/duck/v1/pubsub_defaults.go
+++ b/pkg/apis/duck/v1/pubsub_defaults.go
@@ -33,8 +33,10 @@ func (s *PubSubSpec) SetPubSubDefaults(ctx context.Context) {
 		logging.FromContext(ctx).Error("Failed to get the GCPAuthDefaults")
 		return
 	}
-	if s.ServiceAccountName == "" &&
-		(s.Secret == nil || equality.Semantic.DeepEqual(s.Secret, &corev1.SecretKeySelector{})) {
+	if equality.Semantic.DeepEqual(s.Secret, &corev1.SecretKeySelector{}) {
+		s.Secret = nil
+	}
+	if s.ServiceAccountName == "" && s.Secret == nil {
 		s.ServiceAccountName = ad.KSA(apis.ParentMeta(ctx).Namespace)
 		s.Secret = ad.Secret(apis.ParentMeta(ctx).Namespace)
 	}

--- a/pkg/apis/duck/v1/pubsub_defaults_test.go
+++ b/pkg/apis/duck/v1/pubsub_defaults_test.go
@@ -120,6 +120,16 @@ func TestPubSubSpec_SetPubSubDefaults(t *testing.T) {
 			},
 			ctx: gcpauthtesthelper.ContextWithDefaults(),
 		},
+		"empty secret and non-empty serviceAccountName": {
+			orig: &PubSubSpec{
+				Secret:       &corev1.SecretKeySelector{},
+				IdentitySpec: IdentitySpec{ServiceAccountName: "k8sServiceAccount"},
+			},
+			expected: &PubSubSpec{IdentitySpec: IdentitySpec{
+				ServiceAccountName: "k8sServiceAccount"},
+			},
+			ctx: gcpauthtesthelper.ContextWithDefaults(),
+		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {

--- a/pkg/apis/duck/v1alpha1/pubsub_defaults.go
+++ b/pkg/apis/duck/v1alpha1/pubsub_defaults.go
@@ -33,8 +33,10 @@ func (s *PubSubSpec) SetPubSubDefaults(ctx context.Context) {
 		logging.FromContext(ctx).Error("Failed to get the GCPAuthDefaults")
 		return
 	}
-	if s.ServiceAccountName == "" &&
-		(s.Secret == nil || equality.Semantic.DeepEqual(s.Secret, &corev1.SecretKeySelector{})) {
+	if equality.Semantic.DeepEqual(s.Secret, &corev1.SecretKeySelector{}) {
+		s.Secret = nil
+	}
+	if s.ServiceAccountName == "" && s.Secret == nil {
 		s.ServiceAccountName = ad.KSA(apis.ParentMeta(ctx).Namespace)
 		s.Secret = ad.Secret(apis.ParentMeta(ctx).Namespace)
 	}

--- a/pkg/apis/duck/v1alpha1/pubsub_defaults_test.go
+++ b/pkg/apis/duck/v1alpha1/pubsub_defaults_test.go
@@ -120,6 +120,16 @@ func TestPubSubSpec_SetPubSubDefaults(t *testing.T) {
 			},
 			ctx: gcpauthtesthelper.ContextWithDefaults(),
 		},
+		"empty secret and non-empty serviceAccountName": {
+			orig: &PubSubSpec{
+				Secret:       &corev1.SecretKeySelector{},
+				IdentitySpec: IdentitySpec{ServiceAccountName: "k8sServiceAccount"},
+			},
+			expected: &PubSubSpec{IdentitySpec: IdentitySpec{
+				ServiceAccountName: "k8sServiceAccount"},
+			},
+			ctx: gcpauthtesthelper.ContextWithDefaults(),
+		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {

--- a/pkg/apis/duck/v1beta1/pubsub_defaults.go
+++ b/pkg/apis/duck/v1beta1/pubsub_defaults.go
@@ -33,8 +33,10 @@ func (s *PubSubSpec) SetPubSubDefaults(ctx context.Context) {
 		logging.FromContext(ctx).Error("Failed to get the GCPAuthDefaults")
 		return
 	}
-	if s.ServiceAccountName == "" &&
-		(s.Secret == nil || equality.Semantic.DeepEqual(s.Secret, &corev1.SecretKeySelector{})) {
+	if equality.Semantic.DeepEqual(s.Secret, &corev1.SecretKeySelector{}) {
+		s.Secret = nil
+	}
+	if s.ServiceAccountName == "" && s.Secret == nil {
 		s.ServiceAccountName = ad.KSA(apis.ParentMeta(ctx).Namespace)
 		s.Secret = ad.Secret(apis.ParentMeta(ctx).Namespace)
 	}

--- a/pkg/apis/duck/v1beta1/pubsub_defaults_test.go
+++ b/pkg/apis/duck/v1beta1/pubsub_defaults_test.go
@@ -120,6 +120,16 @@ func TestPubSubSpec_SetPubSubDefaults(t *testing.T) {
 			},
 			ctx: gcpauthtesthelper.ContextWithDefaults(),
 		},
+		"empty secret and non-empty serviceAccountName": {
+			orig: &PubSubSpec{
+				Secret:       &corev1.SecretKeySelector{},
+				IdentitySpec: IdentitySpec{ServiceAccountName: "k8sServiceAccount"},
+			},
+			expected: &PubSubSpec{IdentitySpec: IdentitySpec{
+				ServiceAccountName: "k8sServiceAccount"},
+			},
+			ctx: gcpauthtesthelper.ContextWithDefaults(),
+		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {

--- a/pkg/apis/duck/validations.go
+++ b/pkg/apis/duck/validations.go
@@ -27,7 +27,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
@@ -119,12 +118,12 @@ func CheckImmutableAutoscalingClassAnnotations(current *metav1.ObjectMeta, origi
 
 // ValidateCredential checks secret and service account.
 func ValidateCredential(secret *corev1.SecretKeySelector, kServiceAccountName string) *apis.FieldError {
-	if secret != nil && !equality.Semantic.DeepEqual(secret, &corev1.SecretKeySelector{}) && kServiceAccountName != "" {
+	if secret != nil && kServiceAccountName != "" {
 		return &apis.FieldError{
 			Message: "Can't have spec.serviceAccountName and spec.secret at the same time",
 			Paths:   []string{""},
 		}
-	} else if secret != nil && !equality.Semantic.DeepEqual(secret, &corev1.SecretKeySelector{}) {
+	} else if secret != nil {
 		return validateSecret(secret)
 	} else if kServiceAccountName != "" {
 		return validateK8sServiceAccount(kServiceAccountName)


### PR DESCRIPTION
Fixes #1698 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Webhook will set empty secret to nil
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
