### PR TITLE
Use custom equality tester for TargetsConfig in ConfigMap reconciler

### DIFF
--- a/pkg/reconciler/brokercell/broker_targets_config.go
+++ b/pkg/reconciler/brokercell/broker_targets_config.go
@@ -140,8 +140,7 @@ func (r *Reconciler) updateTargetsConfig(ctx context.Context, bc *intv1alpha1.Br
 		UpdateFunc: func(oldObj, newObj interface{}) { r.refreshPodVolume(ctx, bc) },
 		DeleteFunc: nil,
 	}
-
-	_, err = r.cmRec.ReconcileConfigMap(bc, desired, handlerFuncs)
+	_, err = r.cmRec.ReconcileConfigMap(bc, desired, resources.TargetsConfigMapEqual, handlerFuncs)
 	return err
 }
 

--- a/pkg/reconciler/brokercell/resources/configmap_test.go
+++ b/pkg/reconciler/brokercell/resources/configmap_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/knative-gcp/pkg/broker/config"
+	"github.com/google/knative-gcp/pkg/broker/config/memory"
+	. "github.com/google/knative-gcp/pkg/reconciler/testing"
+	"google.golang.org/protobuf/proto"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	_ "knative.dev/pkg/system/testing"
+)
+
+func testConfigMap(names []string, namespace string) *corev1.ConfigMap {
+	brokerMap := make(map[string]*config.Broker)
+	for _, name := range names {
+		brokerMap[fmt.Sprintf("%s/%s", namespace, name)] = &config.Broker{
+			Name:      name,
+			Namespace: namespace,
+		}
+	}
+	targets := &config.TargetsConfig{
+		Brokers: brokerMap,
+	}
+	targetsBytes, _ := proto.Marshal(targets)
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: targetsCMName},
+		BinaryData: map[string][]byte{targetsCMKey: targetsBytes},
+	}
+}
+
+func TestTargetsConfigMapEqual(t *testing.T) {
+	var (
+		targetsCm1            = testConfigMap([]string{"broker1"}, "ns")
+		targetsCm2            = testConfigMap([]string{"broker2"}, "ns")
+		invalidProtoTargetsCm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: targetsCMName},
+			BinaryData: map[string][]byte{targetsCMKey: {'b'}},
+		}
+		notTargetsCm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: targetsCMName},
+			BinaryData: map[string][]byte{"some-key": nil},
+		}
+		orderTargetsCm1 = testConfigMap([]string{"broker1", "broker2"}, "ns")
+		orderTargetsCm2 = testConfigMap([]string{"broker2", "broker1"}, "ns")
+	)
+	var tests = []struct {
+		name   string
+		cm1    *corev1.ConfigMap
+		cm2    *corev1.ConfigMap
+		wantEq bool
+	}{
+		{
+			name:   "same targets config",
+			cm1:    targetsCm1,
+			cm2:    targetsCm1,
+			wantEq: true,
+		},
+		{
+			name:   "different targets config",
+			cm1:    targetsCm1,
+			cm2:    targetsCm2,
+			wantEq: false,
+		},
+		{
+			name:   "invalid proto bytes",
+			cm1:    invalidProtoTargetsCm,
+			cm2:    invalidProtoTargetsCm,
+			wantEq: false,
+		},
+		{
+			name:   "not targets config",
+			cm1:    notTargetsCm,
+			cm2:    notTargetsCm,
+			wantEq: false,
+		},
+		{
+			name:   "unequal bytes, same proto",
+			cm1:    orderTargetsCm1,
+			cm2:    orderTargetsCm2,
+			wantEq: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if res := TargetsConfigMapEqual(test.cm1, test.cm2); res != test.wantEq {
+				t.Errorf("Unexpected equality result %t between ConfigMaps, wanted %t; diff: %s", res, test.wantEq, cmp.Diff(test.cm1, test.cm2))
+			}
+		})
+	}
+}
+
+func TestMakeTargetsConfig(t *testing.T) {
+	_, err := MakeTargetsConfig(NewBrokerCell("name", "ns"), memory.NewEmptyTargets())
+	if err != nil {
+		t.Errorf("Error making TargetsConfig: %v", err)
+	}
+}

--- a/pkg/reconciler/helper_test.go
+++ b/pkg/reconciler/helper_test.go
@@ -247,20 +247,22 @@ func TestServiceReconciler(t *testing.T) {
 func TestConfigMapReconciler(t *testing.T) {
 	var tests = []struct {
 		commonCase
-		in   *corev1.ConfigMap
-		want *corev1.ConfigMap
+		in     *corev1.ConfigMap
+		want   *corev1.ConfigMap
+		eqFunc func(*corev1.ConfigMap, *corev1.ConfigMap) bool
 	}{
 		{
 			commonCase: commonCase{
 				name:     "configmap exists, nothing to do",
 				existing: []runtime.Object{cm},
 			},
-			in:   cm,
-			want: cm,
+			in:     cm,
+			want:   cm,
+			eqFunc: DefaultConfigMapEqual,
 		},
 		{
 			commonCase: commonCase{
-				name:       "cofigmap created",
+				name:       "configmap created",
 				wantEvents: []string{configmapCreatedEvent},
 			},
 			in:   cm,
@@ -272,25 +274,18 @@ func TestConfigMapReconciler(t *testing.T) {
 				reactions: []clientgotesting.ReactionFunc{configmapCreateFailure},
 				wantErr:   true,
 			},
-			in: cm,
+			in:     cm,
+			eqFunc: DefaultConfigMapEqual,
 		},
 		{
 			commonCase: commonCase{
-				name:       "cofigmap updated - different data",
+				name:       "configmap updated - different data",
 				existing:   []runtime.Object{cmDifferentData},
 				wantEvents: []string{configmapUpdatedEvent},
 			},
-			in:   cm,
-			want: cm,
-		},
-		{
-			commonCase: commonCase{
-				name:       "cofigmap updated - different binary data",
-				existing:   []runtime.Object{cmDifferentBinaryData},
-				wantEvents: []string{configmapUpdatedEvent},
-			},
-			in:   cm,
-			want: cm,
+			in:     cm,
+			want:   cm,
+			eqFunc: DefaultConfigMapEqual,
 		},
 		{
 			commonCase: commonCase{
@@ -298,6 +293,38 @@ func TestConfigMapReconciler(t *testing.T) {
 				reactions: []clientgotesting.ReactionFunc{configmapUpdateFailure},
 				existing:  []runtime.Object{cmDifferentData},
 				wantErr:   true,
+			},
+			in:     cm,
+			eqFunc: DefaultConfigMapEqual,
+		},
+		{
+			commonCase: commonCase{
+				name:       "configmap custom eqFunc, force update",
+				existing:   []runtime.Object{cm},
+				wantEvents: []string{configmapUpdatedEvent},
+			},
+			in:   cm,
+			want: cm,
+			eqFunc: func(cm1, cm2 *corev1.ConfigMap) bool {
+				return false
+			},
+		},
+		{
+			commonCase: commonCase{
+				name:     "configmap custom eqFunc, nothing to do",
+				existing: []runtime.Object{cmDifferentData},
+			},
+			in:   cm,
+			want: cmDifferentData,
+			eqFunc: func(cm1, cm2 *corev1.ConfigMap) bool {
+				return true
+			},
+		},
+		{
+			commonCase: commonCase{
+				name:     "eqFunc missing error",
+				existing: []runtime.Object{cm},
+				wantErr:  true,
 			},
 			in: cm,
 		},
@@ -312,7 +339,7 @@ func TestConfigMapReconciler(t *testing.T) {
 				Lister:     tr.listers.GetConfigMapLister(),
 				Recorder:   tr.recorder,
 			}
-			out, err := rec.ReconcileConfigMap(obj, test.in)
+			out, err := rec.ReconcileConfigMap(obj, test.in, test.eqFunc)
 
 			tr.verify(t, test.commonCase, err)
 


### PR DESCRIPTION
Backport of #1660

* use custom equality tester in configmap reconciler to safely compare serialized data

* address PR comments

* renaming for consistency

* another typo

* moved broker-targets equality tester to resources; specialized broker-targets equality tester

* removed custom eqFunc from configmap test; added targetsconfig tests

* cleaned tests; added test for unequal bytes, same proto
