### PR TITLE
Use wire-gen injection for all controllers

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -65,6 +65,8 @@ func Controllers(
 	channelController channel.Constructor,
 	triggerController trigger.Constructor,
 	brokerController broker.Constructor,
+	deploymentController deployment.Constructor,
+	brokercellController brokercell.Constructor,
 ) []injection.ControllerConstructor {
 	return []injection.ControllerConstructor{
 		injection.ControllerConstructor(auditlogsController),
@@ -78,8 +80,8 @@ func Controllers(
 		injection.ControllerConstructor(channelController),
 		injection.ControllerConstructor(triggerController),
 		injection.ControllerConstructor(brokerController),
-		deployment.NewController,
-		brokercell.NewController,
+		injection.ControllerConstructor(deploymentController),
+		injection.ControllerConstructor(brokercellController),
 	}
 }
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -63,6 +63,8 @@ func Controllers(
 	kedaPullsubscriptionController kedapullsubscription.Constructor,
 	topicController topic.Constructor,
 	channelController channel.Constructor,
+	triggerController trigger.Constructor,
+	brokerController broker.Constructor,
 ) []injection.ControllerConstructor {
 	return []injection.ControllerConstructor{
 		injection.ControllerConstructor(auditlogsController),
@@ -74,9 +76,9 @@ func Controllers(
 		injection.ControllerConstructor(kedaPullsubscriptionController),
 		injection.ControllerConstructor(topicController),
 		injection.ControllerConstructor(channelController),
+		injection.ControllerConstructor(triggerController),
+		injection.ControllerConstructor(brokerController),
 		deployment.NewController,
-		broker.NewController,
-		trigger.NewController,
 		brokercell.NewController,
 	}
 }

--- a/cmd/controller/wire.go
+++ b/cmd/controller/wire.go
@@ -21,6 +21,8 @@ import (
 	"github.com/google/knative-gcp/pkg/apis/configs/dataresidency"
 	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
 	"github.com/google/knative-gcp/pkg/reconciler/broker"
+	"github.com/google/knative-gcp/pkg/reconciler/brokercell"
+	"github.com/google/knative-gcp/pkg/reconciler/deployment"
 	"github.com/google/knative-gcp/pkg/reconciler/events/auditlogs"
 	"github.com/google/knative-gcp/pkg/reconciler/events/build"
 	"github.com/google/knative-gcp/pkg/reconciler/events/pubsub"
@@ -54,5 +56,7 @@ func InitializeControllers(ctx context.Context) ([]injection.ControllerConstruct
 		channel.NewConstructor,
 		trigger.NewConstructor,
 		broker.NewConstructor,
+		deployment.NewConstructor,
+		brokercell.NewConstructor,
 	))
 }

--- a/cmd/controller/wire.go
+++ b/cmd/controller/wire.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/google/knative-gcp/pkg/apis/configs/dataresidency"
 	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
+	"github.com/google/knative-gcp/pkg/reconciler/broker"
 	"github.com/google/knative-gcp/pkg/reconciler/events/auditlogs"
 	"github.com/google/knative-gcp/pkg/reconciler/events/build"
 	"github.com/google/knative-gcp/pkg/reconciler/events/pubsub"
@@ -30,6 +31,7 @@ import (
 	"github.com/google/knative-gcp/pkg/reconciler/intevents/pullsubscription/static"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents/topic"
 	"github.com/google/knative-gcp/pkg/reconciler/messaging/channel"
+	"github.com/google/knative-gcp/pkg/reconciler/trigger"
 	"github.com/google/wire"
 	"knative.dev/pkg/injection"
 )
@@ -50,5 +52,7 @@ func InitializeControllers(ctx context.Context) ([]injection.ControllerConstruct
 		keda.NewConstructor,
 		topic.NewConstructor,
 		channel.NewConstructor,
+		trigger.NewConstructor,
+		broker.NewConstructor,
 	))
 }

--- a/cmd/controller/wire_gen.go
+++ b/cmd/controller/wire_gen.go
@@ -11,6 +11,8 @@ import (
 	"github.com/google/knative-gcp/pkg/apis/configs/dataresidency"
 	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
 	"github.com/google/knative-gcp/pkg/reconciler/broker"
+	"github.com/google/knative-gcp/pkg/reconciler/brokercell"
+	"github.com/google/knative-gcp/pkg/reconciler/deployment"
 	"github.com/google/knative-gcp/pkg/reconciler/events/auditlogs"
 	"github.com/google/knative-gcp/pkg/reconciler/events/build"
 	"github.com/google/knative-gcp/pkg/reconciler/events/pubsub"
@@ -54,6 +56,8 @@ func InitializeControllers(ctx context.Context) ([]injection.ControllerConstruct
 	channelConstructor := channel.NewConstructor(iamPolicyManager, storeSingleton)
 	triggerConstructor := trigger.NewConstructor(dataresidencyStoreSingleton)
 	brokerConstructor := broker.NewConstructor(dataresidencyStoreSingleton)
-	v2 := Controllers(constructor, storageConstructor, schedulerConstructor, pubsubConstructor, buildConstructor, staticConstructor, kedaConstructor, topicConstructor, channelConstructor, triggerConstructor, brokerConstructor)
+	deploymentConstructor := deployment.NewConstructor()
+	brokercellConstructor := brokercell.NewConstructor()
+	v2 := Controllers(constructor, storageConstructor, schedulerConstructor, pubsubConstructor, buildConstructor, staticConstructor, kedaConstructor, topicConstructor, channelConstructor, triggerConstructor, brokerConstructor, deploymentConstructor, brokercellConstructor)
 	return v2, nil
 }

--- a/cmd/controller/wire_gen.go
+++ b/cmd/controller/wire_gen.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"github.com/google/knative-gcp/pkg/apis/configs/dataresidency"
 	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
+	"github.com/google/knative-gcp/pkg/reconciler/broker"
 	"github.com/google/knative-gcp/pkg/reconciler/events/auditlogs"
 	"github.com/google/knative-gcp/pkg/reconciler/events/build"
 	"github.com/google/knative-gcp/pkg/reconciler/events/pubsub"
@@ -20,6 +21,7 @@ import (
 	"github.com/google/knative-gcp/pkg/reconciler/intevents/pullsubscription/static"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents/topic"
 	"github.com/google/knative-gcp/pkg/reconciler/messaging/channel"
+	"github.com/google/knative-gcp/pkg/reconciler/trigger"
 	"knative.dev/pkg/injection"
 )
 
@@ -50,6 +52,8 @@ func InitializeControllers(ctx context.Context) ([]injection.ControllerConstruct
 	dataresidencyStoreSingleton := &dataresidency.StoreSingleton{}
 	topicConstructor := topic.NewConstructor(iamPolicyManager, storeSingleton, dataresidencyStoreSingleton)
 	channelConstructor := channel.NewConstructor(iamPolicyManager, storeSingleton)
-	v2 := Controllers(constructor, storageConstructor, schedulerConstructor, pubsubConstructor, buildConstructor, staticConstructor, kedaConstructor, topicConstructor, channelConstructor)
+	triggerConstructor := trigger.NewConstructor(dataresidencyStoreSingleton)
+	brokerConstructor := broker.NewConstructor(dataresidencyStoreSingleton)
+	v2 := Controllers(constructor, storageConstructor, schedulerConstructor, pubsubConstructor, buildConstructor, staticConstructor, kedaConstructor, topicConstructor, channelConstructor, triggerConstructor, brokerConstructor)
 	return v2, nil
 }

--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -59,7 +59,7 @@ func NewConstructor(dataresidencyss *dataresidency.StoreSingleton) Constructor {
 	}
 }
 
-func newController(ctx context.Context, cmw configmap.Watcher, dataresidencyss *dataresidency.Store) *controller.Impl {
+func newController(ctx context.Context, cmw configmap.Watcher, drs *dataresidency.Store) *controller.Impl {
 	brokerInformer := brokerinformer.Get(ctx)
 	bcInformer := brokercellinformer.Get(ctx)
 
@@ -88,7 +88,7 @@ func newController(ctx context.Context, cmw configmap.Watcher, dataresidencyss *
 		Base:               reconciler.NewBase(ctx, controllerAgentName, cmw),
 		brokerCellLister:   bcInformer.Lister(),
 		pubsubClient:       client,
-		dataresidencyStore: dataresidencyss,
+		dataresidencyStore: drs,
 	}
 
 	impl := brokerreconciler.NewImpl(ctx, r, brokerv1beta1.BrokerClass)

--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -52,7 +52,7 @@ const (
 
 type Constructor injection.ControllerConstructor
 
-// NewConstructor creates a constructor to make a Topic controller.
+// NewConstructor creates a constructor to make a Broker controller.
 func NewConstructor(dataresidencyss *dataresidency.StoreSingleton) Constructor {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		return newController(ctx, cmw, dataresidencyss.Store(ctx, cmw))

--- a/pkg/reconciler/broker/controller_test.go
+++ b/pkg/reconciler/broker/controller_test.go
@@ -38,9 +38,7 @@ import (
 func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
-	dataresidencySs := &dataresidency.StoreSingleton{}
-
-	ctor := NewConstructor(dataresidencySs)
+	ctor := NewConstructor(&dataresidency.StoreSingleton{})
 
 	c := ctor(ctx, configmap.NewStaticWatcher(
 		&corev1.ConfigMap{

--- a/pkg/reconciler/broker/controller_test.go
+++ b/pkg/reconciler/broker/controller_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/google/knative-gcp/pkg/apis/configs/dataresidency"
-	reconcilertesting "github.com/google/knative-gcp/pkg/reconciler/testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,7 +38,11 @@ import (
 func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
-	c := newController(ctx, configmap.NewStaticWatcher(
+	dataresidencySs := &dataresidency.StoreSingleton{}
+
+	ctor := NewConstructor(dataresidencySs)
+
+	c := ctor(ctx, configmap.NewStaticWatcher(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      logging.ConfigMapName(),
@@ -68,7 +71,7 @@ func TestNew(t *testing.T) {
 			},
 			Data: map[string]string{},
 		},
-	), reconcilertesting.NewDataresidencyTestStore(t, nil))
+	))
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")

--- a/pkg/reconciler/broker/controller_test.go
+++ b/pkg/reconciler/broker/controller_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/knative-gcp/pkg/apis/configs/dataresidency"
+	reconcilertesting "github.com/google/knative-gcp/pkg/reconciler/testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +39,7 @@ import (
 func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
-	c := NewController(ctx, configmap.NewStaticWatcher(
+	c := newController(ctx, configmap.NewStaticWatcher(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      logging.ConfigMapName(),
@@ -67,7 +68,7 @@ func TestNew(t *testing.T) {
 			},
 			Data: map[string]string{},
 		},
-	))
+	), reconcilertesting.NewDataresidencyTestStore(t, nil))
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")

--- a/pkg/reconciler/broker/controller_test.go
+++ b/pkg/reconciler/broker/controller_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/knative-gcp/pkg/apis/configs/dataresidency"
+	. "github.com/google/knative-gcp/pkg/reconciler/testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,9 +39,7 @@ import (
 func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
-	ctor := NewConstructor(&dataresidency.StoreSingleton{})
-
-	c := ctor(ctx, configmap.NewStaticWatcher(
+	c := NewConstructor(&dataresidency.StoreSingleton{})(ctx, configmap.NewStaticWatcher(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      logging.ConfigMapName(),
@@ -62,13 +61,7 @@ func TestNew(t *testing.T) {
 			},
 			Data: map[string]string{},
 		},
-		&corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      dataresidency.ConfigMapName(),
-				Namespace: system.Namespace(),
-			},
-			Data: map[string]string{},
-		},
+		NewDataresidencyConfigMapFromRegions([]string{}),
 	))
 
 	if c == nil {

--- a/pkg/reconciler/brokercell/controller.go
+++ b/pkg/reconciler/brokercell/controller.go
@@ -46,6 +46,7 @@ import (
 	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
 	"knative.dev/pkg/system"
 )
 
@@ -54,6 +55,15 @@ const (
 	// itself when creating events.
 	controllerAgentName = "brokercell-controller"
 )
+
+type Constructor injection.ControllerConstructor
+
+// NewConstructor creates a constructor to make a BrokerCell controller.
+func NewConstructor() Constructor {
+	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+		return NewController(ctx, cmw)
+	}
+}
 
 // NewController creates a Reconciler for BrokerCell and returns the result of NewImpl.
 func NewController(

--- a/pkg/reconciler/brokercell/controller_test.go
+++ b/pkg/reconciler/brokercell/controller_test.go
@@ -48,7 +48,9 @@ func TestNew(t *testing.T) {
 
 	setReconcilerEnv()
 
-	c := NewController(ctx, configmap.NewStaticWatcher(
+	ctor := NewConstructor()
+
+	c := ctor(ctx, configmap.NewStaticWatcher(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      logging.ConfigMapName(),

--- a/pkg/reconciler/brokercell/controller_test.go
+++ b/pkg/reconciler/brokercell/controller_test.go
@@ -48,9 +48,7 @@ func TestNew(t *testing.T) {
 
 	setReconcilerEnv()
 
-	ctor := NewConstructor()
-
-	c := ctor(ctx, configmap.NewStaticWatcher(
+	c := NewConstructor()(ctx, configmap.NewStaticWatcher(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      logging.ConfigMapName(),

--- a/pkg/reconciler/deployment/controller.go
+++ b/pkg/reconciler/deployment/controller.go
@@ -26,6 +26,7 @@ import (
 	"knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
 
 	"github.com/google/knative-gcp/pkg/apis/duck"
 	"github.com/google/knative-gcp/pkg/reconciler"
@@ -44,6 +45,15 @@ const (
 	deploymentName = "controller"
 	envKey         = "GOOGLE_APPLICATION_CREDENTIALS"
 )
+
+type Constructor injection.ControllerConstructor
+
+// NewConstructor creates a constructor to make a Deployment controller.
+func NewConstructor() Constructor {
+	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+		return NewController(ctx, cmw)
+	}
+}
 
 // NewController initializes the controller and is called by the generated code
 // Registers event handlers to enqueue events.

--- a/pkg/reconciler/deployment/controller_test.go
+++ b/pkg/reconciler/deployment/controller_test.go
@@ -31,9 +31,7 @@ import (
 func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
-	ctor := NewConstructor()
-
-	c := ctor(ctx, configmap.NewStaticWatcher())
+	c := NewConstructor()(ctx, configmap.NewStaticWatcher())
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")

--- a/pkg/reconciler/deployment/controller_test.go
+++ b/pkg/reconciler/deployment/controller_test.go
@@ -31,7 +31,9 @@ import (
 func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
-	c := NewController(ctx, configmap.NewStaticWatcher())
+	ctor := NewConstructor()
+
+	c := ctor(ctx, configmap.NewStaticWatcher())
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")

--- a/pkg/reconciler/trigger/controller.go
+++ b/pkg/reconciler/trigger/controller.go
@@ -65,7 +65,7 @@ type envConfig struct {
 
 type Constructor injection.ControllerConstructor
 
-// NewConstructor creates a constructor to make a Topic controller.
+// NewConstructor creates a constructor to make a Trigger controller.
 func NewConstructor(dataresidencyss *dataresidency.StoreSingleton) Constructor {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		return newController(ctx, cmw, dataresidencyss.Store(ctx, cmw))

--- a/pkg/reconciler/trigger/controller.go
+++ b/pkg/reconciler/trigger/controller.go
@@ -34,6 +34,7 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	pkgcontroller "knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
 
@@ -62,7 +63,16 @@ type envConfig struct {
 	ProjectID string `envconfig:"PROJECT_ID"`
 }
 
-func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+type Constructor injection.ControllerConstructor
+
+// NewConstructor creates a constructor to make a Topic controller.
+func NewConstructor(dataresidencyss *dataresidency.StoreSingleton) Constructor {
+	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+		return newController(ctx, cmw, dataresidencyss.Store(ctx, cmw))
+	}
+}
+
+func newController(ctx context.Context, cmw configmap.Watcher, dataresidencyss *dataresidency.Store) *controller.Impl {
 	var env envConfig
 	if err := envconfig.Process("", &env); err != nil {
 		logging.FromContext(ctx).Fatal("Failed to process env var", zap.Error(err))
@@ -91,13 +101,12 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 			client.Close()
 		}()
 	}
-	dataresidencySingleton := &dataresidency.StoreSingleton{}
 	r := &Reconciler{
 		Base:               reconciler.NewBase(ctx, controllerAgentName, cmw),
 		brokerLister:       brokerinformer.Get(ctx).Lister(),
 		pubsubClient:       client,
 		projectID:          projectID,
-		dataresidencyStore: dataresidencySingleton.Store(ctx, cmw),
+		dataresidencyStore: dataresidencyss,
 	}
 
 	impl := triggerreconciler.NewImpl(ctx, r, withAgentAndFinalizer)

--- a/pkg/reconciler/trigger/controller.go
+++ b/pkg/reconciler/trigger/controller.go
@@ -72,7 +72,7 @@ func NewConstructor(dataresidencyss *dataresidency.StoreSingleton) Constructor {
 	}
 }
 
-func newController(ctx context.Context, cmw configmap.Watcher, dataresidencyss *dataresidency.Store) *controller.Impl {
+func newController(ctx context.Context, cmw configmap.Watcher, drs *dataresidency.Store) *controller.Impl {
 	var env envConfig
 	if err := envconfig.Process("", &env); err != nil {
 		logging.FromContext(ctx).Fatal("Failed to process env var", zap.Error(err))
@@ -106,7 +106,7 @@ func newController(ctx context.Context, cmw configmap.Watcher, dataresidencyss *
 		brokerLister:       brokerinformer.Get(ctx).Lister(),
 		pubsubClient:       client,
 		projectID:          projectID,
-		dataresidencyStore: dataresidencyss,
+		dataresidencyStore: drs,
 	}
 
 	impl := triggerreconciler.NewImpl(ctx, r, withAgentAndFinalizer)

--- a/pkg/reconciler/trigger/controller_test.go
+++ b/pkg/reconciler/trigger/controller_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/google/knative-gcp/pkg/apis/configs/dataresidency"
 	_ "github.com/google/knative-gcp/pkg/client/injection/informers/broker/v1beta1/broker/fake"
 	_ "github.com/google/knative-gcp/pkg/client/injection/informers/broker/v1beta1/trigger/fake"
-	reconcilertesting "github.com/google/knative-gcp/pkg/reconciler/testing"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/conditions/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
@@ -45,7 +44,11 @@ import (
 func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
-	c := newController(ctx, configmap.NewStaticWatcher(
+	dataresidencySs := &dataresidency.StoreSingleton{}
+
+	ctor := NewConstructor(dataresidencySs)
+
+	c := ctor(ctx, configmap.NewStaticWatcher(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      logging.ConfigMapName(),
@@ -74,7 +77,7 @@ func TestNew(t *testing.T) {
 			},
 			Data: map[string]string{},
 		},
-	), reconcilertesting.NewDataresidencyTestStore(t, nil))
+	))
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")

--- a/pkg/reconciler/trigger/controller_test.go
+++ b/pkg/reconciler/trigger/controller_test.go
@@ -44,9 +44,7 @@ import (
 func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
-	dataresidencySs := &dataresidency.StoreSingleton{}
-
-	ctor := NewConstructor(dataresidencySs)
+	ctor := NewConstructor(&dataresidency.StoreSingleton{})
 
 	c := ctor(ctx, configmap.NewStaticWatcher(
 		&corev1.ConfigMap{

--- a/pkg/reconciler/trigger/controller_test.go
+++ b/pkg/reconciler/trigger/controller_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/knative-gcp/pkg/apis/configs/dataresidency"
 	_ "github.com/google/knative-gcp/pkg/client/injection/informers/broker/v1beta1/broker/fake"
 	_ "github.com/google/knative-gcp/pkg/client/injection/informers/broker/v1beta1/trigger/fake"
+	reconcilertesting "github.com/google/knative-gcp/pkg/reconciler/testing"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/conditions/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
@@ -44,7 +45,7 @@ import (
 func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
-	c := NewController(ctx, configmap.NewStaticWatcher(
+	c := newController(ctx, configmap.NewStaticWatcher(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      logging.ConfigMapName(),
@@ -73,7 +74,7 @@ func TestNew(t *testing.T) {
 			},
 			Data: map[string]string{},
 		},
-	))
+	), reconcilertesting.NewDataresidencyTestStore(t, nil))
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")

--- a/pkg/reconciler/trigger/controller_test.go
+++ b/pkg/reconciler/trigger/controller_test.go
@@ -28,8 +28,10 @@ import (
 	"knative.dev/pkg/system"
 	tracingconfig "knative.dev/pkg/tracing/config"
 
-	// Fake injection informers
 	"github.com/google/knative-gcp/pkg/apis/configs/dataresidency"
+	. "github.com/google/knative-gcp/pkg/reconciler/testing"
+
+	// Fake injection informers
 	_ "github.com/google/knative-gcp/pkg/client/injection/informers/broker/v1beta1/broker/fake"
 	_ "github.com/google/knative-gcp/pkg/client/injection/informers/broker/v1beta1/trigger/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
@@ -44,9 +46,7 @@ import (
 func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
-	ctor := NewConstructor(&dataresidency.StoreSingleton{})
-
-	c := ctor(ctx, configmap.NewStaticWatcher(
+	c := NewConstructor(&dataresidency.StoreSingleton{})(ctx, configmap.NewStaticWatcher(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      logging.ConfigMapName(),
@@ -68,13 +68,7 @@ func TestNew(t *testing.T) {
 			},
 			Data: map[string]string{},
 		},
-		&corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      dataresidency.ConfigMapName(),
-				Namespace: system.Namespace(),
-			},
-			Data: map[string]string{},
-		},
+		NewDataresidencyConfigMapFromRegions([]string{}),
 	))
 
 	if c == nil {


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

Currently some controllers are not using wire-gen. By changing all controller to the same style we can achieve:
1. consistent coding style for all controllers
2. easy to support new singleton configuration maps
3. use same singleton object from the top level.

This PR will be rebased after merge of #1681 

## Proposed Changes

- Use wire-gen to generate all controllers.
-
-
