### PR TITLE
[WIP] Return status 200 when events knockdown the target

### DIFF
--- a/test/test_images/internal/knockdown/knockdown.go
+++ b/test/test_images/internal/knockdown/knockdown.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/cloudevents/sdk-go/v2/protocol"
 	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 )
@@ -98,17 +97,17 @@ type Receiver interface {
 	Knockdown(event cloudevents.Event) bool
 }
 
-func (r *receiver) Receive(event cloudevents.Event) (*event.Event, protocol.Result) {
+func (r *receiver) Receive(event cloudevents.Event) protocol.Result {
 	done := r.kdr.Knockdown(event)
 	if done {
 		if err := r.writeSuccessfulTerminationMessage(); err != nil {
 			fmt.Printf("Failed to write termination message, %s.\n", err.Error())
 		}
 		r.cancel()
-		return nil, cehttp.NewResult(http.StatusOK, "OK")
+		return cehttp.NewResult(http.StatusOK, "OK")
 	}
 	fmt.Printf("Event did not knockdown the process.")
-	return nil, cehttp.NewResult(http.StatusNotFound, "Event did not knockdown the process, return 404")
+	return cehttp.NewResult(http.StatusNotFound, "Event did not knockdown the process, return 404")
 }
 
 // writeSuccessfulTerminationMessage should be called to indicate this knock down process received


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Found two metrics flakiness cases which might relate to knockdown function doesn't return any protocol result.
- In metric test, we go as: sender pod -> broker -> receiver Pod (intentionally return status code 400 two times) -> broker -> target Pod
- From the failure test log ([summary](https://docs.google.com/spreadsheets/d/1foMAzCFvOk07SEvp0uD9lsm4OC-cMJInC3wDndkf7LI/edit#gid=0)), the target Pod received the event, however, the broker didn't get the status code 200, so it will continue run the handler until EOF, and we miss a metric record.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
