### PR TITLE
Remove unnecessary pin of github.com/blang/semver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,8 +46,6 @@ replace (
 
 // The following packages were pinned as part of the go module transition and should eventually be
 // unpinned.
-replace github.com/blang/semver => github.com/blang/semver v1.1.1-0.20190414102917-ba2c2ddd8906
-
 replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 
 replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.7

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,10 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb/go.mod h1:PkYb9DJNAwrSvRx5DYA+gUcOIgTGVMNkfSCbZM8cWpI=
-github.com/blang/semver v1.1.1-0.20190414102917-ba2c2ddd8906 h1:/HvlpHir75MQ1/grQRJMu8xFDhvHY7VSnY6wO/crzS8=
-github.com/blang/semver v1.1.1-0.20190414102917-ba2c2ddd8906/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b h1:AP/Y7sqYicnjGDfD5VcY4CIfh1hRXBUavxrvELjTiOE=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=

--- a/vendor/github.com/blang/semver/.travis.yml
+++ b/vendor/github.com/blang/semver/.travis.yml
@@ -1,14 +1,10 @@
 language: go
 matrix:
   include:
-  - go: 1.4.x
-  - go: 1.5.x
-  - go: 1.6.x
-  - go: 1.7.x
-  - go: 1.8.x
-  - go: 1.9.x
-  - go: 1.10.x
-  - go: 1.11.x
+  - go: 1.4.3
+  - go: 1.5.4
+  - go: 1.6.3
+  - go: 1.7
   - go: tip
   allow_failures:
   - go: tip
@@ -17,7 +13,7 @@ install:
 - go get github.com/mattn/goveralls
 script:
 - echo "Test and track coverage" ; $HOME/gopath/bin/goveralls -package "." -service=travis-ci
-  -repotoken=$COVERALLS_TOKEN
+  -repotoken $COVERALLS_TOKEN
 - echo "Build examples" ; cd examples && go build
 - echo "Check if gofmt'd" ; diff -u <(echo -n) <(gofmt -d -s .)
 env:

--- a/vendor/github.com/blang/semver/README.md
+++ b/vendor/github.com/blang/semver/README.md
@@ -1,4 +1,4 @@
-semver for golang [![Build Status](https://travis-ci.org/blang/semver.svg?branch=master)](https://travis-ci.org/blang/semver) [![GoDoc](https://godoc.org/github.com/blang/semver?status.svg)](https://godoc.org/github.com/blang/semver) [![Coverage Status](https://img.shields.io/coveralls/blang/semver.svg)](https://coveralls.io/r/blang/semver?branch=master) [![Go Report Card](https://goreportcard.com/badge/github.com/blang/semver)](https://goreportcard.com/report/github.com/blang/semver)
+semver for golang [![Build Status](https://travis-ci.org/blang/semver.svg?branch=master)](https://travis-ci.org/blang/semver) [![GoDoc](https://godoc.org/github.com/blang/semver?status.png)](https://godoc.org/github.com/blang/semver) [![Coverage Status](https://img.shields.io/coveralls/blang/semver.svg)](https://coveralls.io/r/blang/semver?branch=master)
 ======
 
 semver is a [Semantic Versioning](http://semver.org/) library written in golang. It fully covers spec version `2.0.0`.
@@ -83,8 +83,8 @@ Range usage:
 
 ```
 v, err := semver.Parse("1.2.3")
-expectedRange, err := semver.ParseRange(">1.0.0 <2.0.0 || >=3.0.0")
-if expectedRange(v) {
+range, err := semver.ParseRange(">1.0.0 <2.0.0 || >=3.0.0")
+if range(v) {
     //valid
 }
 

--- a/vendor/github.com/blang/semver/go.mod
+++ b/vendor/github.com/blang/semver/go.mod
@@ -1,1 +1,0 @@
-module github.com/blang/semver

--- a/vendor/github.com/blang/semver/range.go
+++ b/vendor/github.com/blang/semver/range.go
@@ -327,7 +327,7 @@ func expandWildcardVersion(parts [][]string) ([][]string, error) {
 	for _, p := range parts {
 		var newParts []string
 		for _, ap := range p {
-			if strings.Contains(ap, "x") {
+			if strings.Index(ap, "x") != -1 {
 				opStr, vStr, err := splitComparatorVersion(ap)
 				if err != nil {
 					return nil, err

--- a/vendor/github.com/blang/semver/semver.go
+++ b/vendor/github.com/blang/semver/semver.go
@@ -26,7 +26,7 @@ type Version struct {
 	Minor uint64
 	Patch uint64
 	Pre   []PRVersion
-	Build []string //No Precedence
+	Build []string //No Precendence
 }
 
 // Version to string
@@ -161,36 +161,6 @@ func (v Version) Compare(o Version) int {
 
 }
 
-// IncrementPatch increments the patch version
-func (v *Version) IncrementPatch() error {
-	if v.Major == 0 {
-		return fmt.Errorf("Patch version can not be incremented for %q", v.String())
-	}
-	v.Patch += 1
-	return nil
-}
-
-// IncrementMinor increments the minor version
-func (v *Version) IncrementMinor() error {
-	if v.Major == 0 {
-		return fmt.Errorf("Minor version can not be incremented for %q", v.String())
-	}
-	v.Minor += 1
-	v.Patch = 0
-	return nil
-}
-
-// IncrementMajor increments the major version
-func (v *Version) IncrementMajor() error {
-	if v.Major == 0 {
-		return fmt.Errorf("Major version can not be incremented for %q", v.String())
-	}
-	v.Major += 1
-	v.Minor = 0
-	v.Patch = 0
-	return nil
-}
-
 // Validate validates v and returns error in case
 func (v Version) Validate() error {
 	// Major, Minor, Patch already validated using uint64
@@ -232,21 +202,14 @@ func Make(s string) (Version, error) {
 
 // ParseTolerant allows for certain version specifications that do not strictly adhere to semver
 // specs to be parsed by this library. It does so by normalizing versions before passing them to
-// Parse(). It currently trims spaces, removes a "v" prefix, adds a 0 patch number to versions
-// with only major and minor components specified, and removes leading 0s.
+// Parse(). It currently trims spaces, removes a "v" prefix, and adds a 0 patch number to versions
+// with only major and minor components specified
 func ParseTolerant(s string) (Version, error) {
 	s = strings.TrimSpace(s)
 	s = strings.TrimPrefix(s, "v")
 
 	// Split into major.minor.(patch+pr+meta)
 	parts := strings.SplitN(s, ".", 3)
-	// Remove leading zeros.
-	for i, p := range parts {
-		if len(p) > 1 {
-			parts[i] = strings.TrimPrefix(p, "0")
-		}
-	}
-	// Fill up shortened versions.
 	if len(parts) < 3 {
 		if strings.ContainsAny(parts[len(parts)-1], "+-") {
 			return Version{}, errors.New("Short version cannot contain PreRelease/Build meta data")
@@ -254,8 +217,8 @@ func ParseTolerant(s string) (Version, error) {
 		for len(parts) < 3 {
 			parts = append(parts, "0")
 		}
+		s = strings.Join(parts, ".")
 	}
-	s = strings.Join(parts, ".")
 
 	return Parse(s)
 }

--- a/vendor/github.com/blang/semver/sql.go
+++ b/vendor/github.com/blang/semver/sql.go
@@ -14,7 +14,7 @@ func (v *Version) Scan(src interface{}) (err error) {
 	case []byte:
 		str = string(src)
 	default:
-		return fmt.Errorf("version.Scan: cannot convert %T to string", src)
+		return fmt.Errorf("Version.Scan: cannot convert %T to string.", src)
 	}
 
 	if t, err := Parse(str); err == nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -95,7 +95,7 @@ github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
-# github.com/blang/semver v3.5.1+incompatible => github.com/blang/semver v1.1.1-0.20190414102917-ba2c2ddd8906
+# github.com/blang/semver v3.5.1+incompatible
 github.com/blang/semver
 # github.com/census-instrumentation/opencensus-proto v0.2.1
 github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1
@@ -1311,7 +1311,6 @@ sigs.k8s.io/yaml
 # k8s.io/client-go => k8s.io/client-go v0.18.8
 # k8s.io/code-generator => k8s.io/code-generator v0.18.8
 # k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20190918143330-0270cf2f1c1d
-# github.com/blang/semver => github.com/blang/semver v1.1.1-0.20190414102917-ba2c2ddd8906
 # github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 # github.com/json-iterator/go => github.com/json-iterator/go v1.1.7
 # github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742


### PR DESCRIPTION
This upgrades semver to v3.5.1.