### PR TITLE
Use no authentication in Probe Helper test storage client

### DIFF
--- a/test/test_images/probe_helper/probe_helper_test.go
+++ b/test/test_images/probe_helper/probe_helper_test.go
@@ -305,7 +305,7 @@ func testStorageClient(ctx context.Context, t *testing.T) (*storage.Client, chan
 		gotRequest <- r
 		w.Write([]byte("{}"))
 	}))
-	c, err := storage.NewClient(ctx, option.WithEndpoint(srv.URL))
+	c, err := storage.NewClient(ctx, option.WithoutAuthentication(), option.WithEndpoint(srv.URL))
 	if err != nil {
 		t.Fatalf("Failed to create test storage client: %v", err)
 	}


### PR DESCRIPTION
Fixes #1757 

Before this fix, the probe helper unit tests will fail if run without being connected to the internet. So they always succeed on prow but may fail locally.

## Proposed Changes

- Use no authentication in Probe Helper test storage client