### PR TITLE
Adjust broker fanout resource requirements to meet default delivery attempts per second target

### DIFF
--- a/cmd/broker/fanout/main.go
+++ b/cmd/broker/fanout/main.go
@@ -52,6 +52,10 @@ type envConfig struct {
 	// continuous sync failures (or no sync at all) to be stale.
 	MaxStaleDuration time.Duration `envconfig:"MAX_STALE_DURATION" default:"1m"`
 
+	// MaxOutstandingBytes is the maximum size of unprocessed messages (unacknowledged but not yet expired).
+	// Default is 800Mb (~763Mi).
+	MaxOutstandingBytes int `envconfig:"OUTSTANDING_BYTES_LIMIT" default:"799999525"`
+
 	// Max to 10m.
 	TimeoutPerEvent time.Duration `envconfig:"TIMEOUT_PER_EVENT"`
 }
@@ -138,6 +142,9 @@ func buildHandlerOptions(env envConfig) []handler.Option {
 	}
 	if env.TimeoutPerEvent > 0 {
 		opts = append(opts, handler.WithTimeoutPerEvent(env.TimeoutPerEvent))
+	}
+	if env.MaxOutstandingBytes > 0 {
+		rs.MaxOutstandingBytes = env.MaxOutstandingBytes
 	}
 	opts = append(opts, handler.WithPubsubReceiveSettings(rs))
 	// The default CeClient is good?

--- a/cmd/broker/fanout/main.go
+++ b/cmd/broker/fanout/main.go
@@ -54,7 +54,7 @@ type envConfig struct {
 
 	// MaxOutstandingBytes is the maximum size of unprocessed messages (unacknowledged but not yet expired).
 	// Default is 800Mb (~763Mi)
-	MaxOutstandingBytes int `envconfig:"MAX_OUTSTANDING_BYTES" default:"799999525"`
+	MaxOutstandingBytes int `envconfig:"MAX_OUTSTANDING_BYTES" default:"800000000"`
 
 	// Max to 10m.
 	TimeoutPerEvent time.Duration `envconfig:"TIMEOUT_PER_EVENT"`

--- a/cmd/broker/fanout/main.go
+++ b/cmd/broker/fanout/main.go
@@ -53,8 +53,8 @@ type envConfig struct {
 	MaxStaleDuration time.Duration `envconfig:"MAX_STALE_DURATION" default:"1m"`
 
 	// MaxOutstandingBytes is the maximum size of unprocessed messages (unacknowledged but not yet expired).
-	// Default is 800Mb (~763Mi).
-	MaxOutstandingBytes int `envconfig:"OUTSTANDING_BYTES_LIMIT" default:"799999525"`
+	// Default is 800Mb (~763Mi)
+	MaxOutstandingBytes int `envconfig:"MAX_OUTSTANDING_BYTES" default:"799999525"`
 
 	// Max to 10m.
 	TimeoutPerEvent time.Duration `envconfig:"TIMEOUT_PER_EVENT"`

--- a/pkg/apis/intevents/v1alpha1/brokercell_defaults.go
+++ b/pkg/apis/intevents/v1alpha1/brokercell_defaults.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	avgCPUUtilizationFanout  int32 = 95
+	avgCPUUtilizationFanout  int32 = 30
 	avgCPUUtilizationIngress int32 = 95
 	avgCPUUtilizationRetry   int32 = 95
 	// The limit we set (for Fanout and Retry) is 3000Mi which is mostly used
@@ -31,7 +31,7 @@ const (
 	// Here we only set half of the limit so that in case of surging memory
 	// usage, HPA could have enough time to kick in.
 	// See: https://github.com/google/knative-gcp/issues/1265
-	avgMemoryUsageFanout  string = "1500Mi"
+	avgMemoryUsageFanout  string = "1000Mi"
 	avgMemoryUsageIngress string = "1500Mi"
 	avgMemoryUsageRetry   string = "1500Mi"
 	cpuRequestFanout      string = "1500m"
@@ -40,7 +40,7 @@ const (
 	cpuLimitFanout        string = ""
 	cpuLimitIngress       string = ""
 	cpuLimitRetry         string = ""
-	memoryRequestFanout   string = "500Mi"
+	memoryRequestFanout   string = "3000Mi"
 	memoryRequestIngress  string = "2000Mi"
 	memoryRequestRetry    string = "500Mi"
 	memoryLimitFanout     string = "3000Mi"

--- a/pkg/apis/intevents/v1alpha1/brokercell_defaults.go
+++ b/pkg/apis/intevents/v1alpha1/brokercell_defaults.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	avgCPUUtilizationFanout  int32 = 30
+	avgCPUUtilizationFanout  int32 = 50
 	avgCPUUtilizationIngress int32 = 95
 	avgCPUUtilizationRetry   int32 = 95
 	// The limit we set (for Fanout and Retry) is 3000Mi which is mostly used

--- a/pkg/reconciler/brokercell/testingdata/fanout_deployment.yaml
+++ b/pkg/reconciler/brokercell/testingdata/fanout_deployment.yaml
@@ -85,7 +85,7 @@ spec:
             memory: 3000Mi
           requests:
             cpu: 1500m
-            memory: 500Mi
+            memory: 3000Mi
         ports:
         - name: metrics
           containerPort: 9090

--- a/pkg/reconciler/brokercell/testingdata/fanout_deployment_with_status.yaml
+++ b/pkg/reconciler/brokercell/testingdata/fanout_deployment_with_status.yaml
@@ -86,7 +86,7 @@ spec:
             memory: 3000Mi
           requests:
             cpu: 1500m
-            memory: 500Mi
+            memory: 3000Mi
         ports:
         - name: metrics
           containerPort: 9090

--- a/pkg/reconciler/brokercell/testingdata/fanout_hpa.yaml
+++ b/pkg/reconciler/brokercell/testingdata/fanout_hpa.yaml
@@ -38,10 +38,10 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 95
+        averageUtilization: 30
   - type: Resource
     resource:
       name: memory
       target:
         type: AverageValue
-        averageValue: 1500Mi
+        averageValue: 1000Mi

--- a/pkg/reconciler/brokercell/testingdata/fanout_hpa.yaml
+++ b/pkg/reconciler/brokercell/testingdata/fanout_hpa.yaml
@@ -38,7 +38,7 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 30
+        averageUtilization: 50
   - type: Resource
     resource:
       name: memory


### PR DESCRIPTION
* Fixes #1713 
* Details are available on the task page and in "Fanout Throughput with Autoscaling" doc.

