### PR TITLE
Fix misspellings and update-codegen

### DIFF
--- a/config/core/configmaps/br-delivery.yaml
+++ b/config/core/configmaps/br-delivery.yaml
@@ -18,7 +18,7 @@ metadata:
   name: config-br-delivery
   namespace: cloud-run-events
   annotations:
-    knative.dev/example-checksum: "8a0f7eaf"
+    knative.dev/example-checksum: "a7f41751"
 data:
   default-br-delivery-config: |
     clusterDefaults:
@@ -43,7 +43,7 @@ data:
     # default-br-delivery-config is the configuration for determining the default
     # Broker delivery settings to apply on all GCP Brokers created within a scope.
     #
-    # When determing the defaults to use for a custom object in a specific
+    # When determining the defaults to use for a custom object in a specific
     # namespace, the precedence rules are:
     # If the Broker's spec specifies the delivery settings to use, use that.
     # If not and that namespace is in the `namespaceDefaults` key, then use the

--- a/config/core/configmaps/gcp-auth.yaml
+++ b/config/core/configmaps/gcp-auth.yaml
@@ -21,7 +21,7 @@ metadata:
     events.cloud.google.com/release: devel
   annotations:
     events.cloud.google.com/initialized: "false"
-    knative.dev/example-checksum: 6642f8a8
+    knative.dev/example-checksum: 529ddd38
 data:
   default-auth-config: |
     clusterDefaults:
@@ -48,7 +48,7 @@ data:
     # GCP auth to apply to all objects that require GCP auth but,
     # do not specify it. This is expected to be Channels and Sources.
     #
-    # When determing the defaults to use for a custom object in a specific
+    # When determining the defaults to use for a custom object in a specific
     # namespace, the precedence rules are:
     # If the custom object's spec specifies the GCP auth to use, use that.
     # If not and that namespace is in the `namespaceDefaults` key, then use the

--- a/docs/examples/gcpbroker/README.md
+++ b/docs/examples/gcpbroker/README.md
@@ -28,7 +28,7 @@ The yamls create the following resources:
 - 2 Triggers `hello-display` and `goodbye-display` that points to the 2
   consumers, respectively. `hello-display` filters events with `type: greeting`
   attribute and `goodbye-display` filters events with `source: sendoff`
-  atribute.
+  attribute.
 
 Verify the broker is ready:
 

--- a/docs/install/install-gcp-broker.md
+++ b/docs/install/install-gcp-broker.md
@@ -164,14 +164,14 @@ All GCP Brokers share the following data plane components:
     [main.go](https://github.com/google/knative-gcp/blob/master/cmd/broker/ingress/main.go)
   - Deployment: It contains a Service and Deployment, both called
     `broker-ingress` in the `cloud-run-events` namespace.
-- Fanout. Fanout continously pull events from decouple topics for all Brokers,
+- Fanout. Fanout continuously pull events from decouple topics for all Brokers,
   applies Trigger filters, and sends events to consumers. For failed deliveries,
   it sends the events to the corresponding retry topic.
   - Code:
     [main.go](https://github.com/google/knative-gcp/blob/master/cmd/broker/fanout/main.go)
   - Deployment: It a deployment called `broker-fanout` in the `cloud-run-events`
     namespace.
-- Retry. Retry continously resends events that have failed in delivery to the
+- Retry. Retry continuously resends events that have failed in delivery to the
   consumers.
   - Code:
     [main.go](https://github.com/google/knative-gcp/blob/master/cmd/broker/retry/main.go)

--- a/pkg/apis/configs/broker/testdata/config-br-delivery.yaml
+++ b/pkg/apis/configs/broker/testdata/config-br-delivery.yaml
@@ -17,8 +17,6 @@ kind: ConfigMap
 metadata:
   name: config-br-delivery
   namespace: cloud-run-events
-  annotations:
-    knative.dev/example-checksum: "8a0f7eaf"
 data:
   default-br-delivery-config: |
     clusterDefaults:

--- a/pkg/apis/configs/broker/testdata/config-br-delivery.yaml
+++ b/pkg/apis/configs/broker/testdata/config-br-delivery.yaml
@@ -43,7 +43,7 @@ data:
     # default-br-delivery-config is the configuration for determining the default
     # Broker delivery settings to apply on all GCP Brokers created within a scope.
     #
-    # When determing the defaults to use for a custom object in a specific
+    # When determining the defaults to use for a custom object in a specific
     # namespace, the precedence rules are:
     # If the Broker's spec specifies the delivery settings to use, use that.
     # If not and that namespace is in the `namespaceDefaults` key, then use the

--- a/pkg/apis/configs/gcpauth/testdata/config-gcp-auth.yaml
+++ b/pkg/apis/configs/gcpauth/testdata/config-gcp-auth.yaml
@@ -46,7 +46,7 @@ data:
     # GCP auth to apply to all objects that require GCP auth but,
     # do not specify it. This is expected to be Channels and Sources.
     #
-    # When determing the defaults to use for a custom object in a specific
+    # When determining the defaults to use for a custom object in a specific
     # namespace, the precedence rules are:
     # If the custom object's spec specifies the GCP auth to use, use that.
     # If not and that namespace is in the `namespaceDefaults` key, then use the

--- a/pkg/reconciler/identity/testdata/config-gcp-auth-empty.yaml
+++ b/pkg/reconciler/identity/testdata/config-gcp-auth-empty.yaml
@@ -46,7 +46,7 @@ data:
     # GCP auth to apply to all objects that require GCP auth but,
     # do not specify it. This is expected to be Channels and Sources.
     #
-    # When determing the defaults to use for a custom object in a specific
+    # When determining the defaults to use for a custom object in a specific
     # namespace, the precedence rules are:
     # If the custom object's spec specifies the GCP auth to use, use that.
     # If not and that namespace is in the `namespaceDefaults` key, then use the

--- a/pkg/reconciler/identity/testdata/config-gcp-auth.yaml
+++ b/pkg/reconciler/identity/testdata/config-gcp-auth.yaml
@@ -46,7 +46,7 @@ data:
     # GCP auth to apply to all objects that require GCP auth but,
     # do not specify it. This is expected to be Channels and Sources.
     #
-    # When determing the defaults to use for a custom object in a specific
+    # When determining the defaults to use for a custom object in a specific
     # namespace, the precedence rules are:
     # If the custom object's spec specifies the GCP auth to use, use that.
     # If not and that namespace is in the `namespaceDefaults` key, then use the


### PR DESCRIPTION
The automated PR https://github.com/google/knative-gcp/pull/1770 was failing due to unchanged configmap checksums after fixing spelling mistakes in configmaps. This PR runs `./hack/update-codegen.sh` to fix the checksums as well as the spelling errors.

Produced via:
```shell
export FILES=( $(find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*') )
misspell -w "${FILES[@]}"
./hack/update-codegen.sh
```
/cc nachocano grantr ian-mi nlopezgi
/assign nachocano grantr ian-mi nlopezgi