### PR TITLE
Handle requests with very large payload

### DIFF
--- a/pkg/broker/ingress/handler.go
+++ b/pkg/broker/ingress/handler.go
@@ -47,8 +47,8 @@ const (
 	// TODO(liu-cong) configurable timeout
 	decoupleSinkTimeout = 30 * time.Second
 
-	// Limit for request payload in bytes (100Mb)
-	maxRequestBodyBytes = 100000000
+	// Limit for request payload in bytes (10Mb -- corresponds to message size limit on PubSub as of 09/2020)
+	maxRequestBodyBytes = 10000000
 
 	// EventArrivalTime is used to access the metadata stored on a
 	// CloudEvent to measure the time difference between when an event is

--- a/pkg/broker/ingress/handler.go
+++ b/pkg/broker/ingress/handler.go
@@ -154,7 +154,7 @@ func (h *Handler) ServeHTTP(response nethttp.ResponseWriter, request *nethttp.Re
 		nethttp.Error(response, err.Error(), httpStatus)
 		return
 	}
-	
+
 	event.SetExtension(EventArrivalTime, cev2.Timestamp{Time: time.Now()})
 
 	span := trace.FromContext(ctx)

--- a/pkg/broker/ingress/handler.go
+++ b/pkg/broker/ingress/handler.go
@@ -122,7 +122,6 @@ func (h *Handler) ServeHTTP(response nethttp.ResponseWriter, request *nethttp.Re
 		response.WriteHeader(nethttp.StatusOK)
 		return
 	}
-	
 	ctx := request.Context()
 	ctx = logging.WithLogger(ctx, h.logger)
 	ctx = tracing.WithLogging(ctx, trace.FromContext(ctx))

--- a/pkg/broker/ingress/handler_test.go
+++ b/pkg/broker/ingress/handler_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"math/rand"
+
 	"cloud.google.com/go/pubsub"
 	"cloud.google.com/go/pubsub/pstest"
 	cepubsub "github.com/cloudevents/sdk-go/protocol/pubsub/v2"
@@ -52,7 +54,6 @@ import (
 	logtest "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/metrics/metricskey"
 	"knative.dev/pkg/metrics/metricstest"
-	"math/rand"
 
 	_ "knative.dev/pkg/metrics/testing"
 )

--- a/pkg/broker/ingress/handler_test.go
+++ b/pkg/broker/ingress/handler_test.go
@@ -118,7 +118,7 @@ type testCase struct {
 	// additional assertions on the output event.
 	eventAssertions []eventAssertion
 	decouple        DecoupleSink
-	contentLength *int64
+	contentLength   *int64
 }
 
 type fakeOverloadedDecoupleSink struct{}
@@ -187,12 +187,12 @@ func TestHandler(t *testing.T) {
 			wantCode: nethttp.StatusRequestEntityTooLarge,
 		},
 		{
-			name:     "malicious requests or requests with unknown Content-Length and a very large payload",
-			method:   "POST",
-			path:     "/ns1/broker1",
-			event:    createTestEventWithPayloadSize("test-event", 110000000),
+			name:          "malicious requests or requests with unknown Content-Length and a very large payload",
+			method:        "POST",
+			path:          "/ns1/broker1",
+			event:         createTestEventWithPayloadSize("test-event", 110000000),
 			contentLength: ptr.Int64(-1),
-			wantCode: nethttp.StatusRequestEntityTooLarge,
+			wantCode:      nethttp.StatusRequestEntityTooLarge,
 		},
 		{
 			name:     "malformed path",


### PR DESCRIPTION
Fixes #1754. In particular:
- Prevents potential out-of-memory issues caused by requests with very large  payload;
- Addresses a functional issue that occurs even for relatively small payload sizes that exceeds PubSub limit on message size, which is 10Mb (non-extendable). Requests with payloads above that are not passing the publishing stage;
    * You may find it on [PubSub quotas page](https://cloud.google.com/pubsub/quotas): after the main table, there is a section with non-extendable quotas;
 

### On memory consumption
Memory stress test was re-run several times. Here's is how a typical memory consumption pattern looks like:
![image](https://user-images.githubusercontent.com/1721518/94524452-7b249400-01e7-11eb-9182-072d4d522f9d.png)
In both cases, there is an initial spike varying around 600-800MiB, which then gradually smoothes out. There appears to be little to no impact on memory caused by the MaxBytesReader wrapper. This can also be seen from [MaxBytesReader's implementation](https://github.com/golang/go/blob/2cd2ff6f564dce5be0c4fb7f06338ff7af3fc9a9/src/net/http/request.go#L1121), which turns out to be lightweight and does not have any notable memory overheads.