### PR TITLE
Increase e2e test parallel limit to 24

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -25,7 +25,7 @@ if [ "${SKIP_TESTS:-}" == "true" ]; then
   exit 0
 fi
 
-go_test_e2e -timeout=30m -parallel=12 ./test/e2e \
+go_test_e2e -timeout=30m -parallel=24 ./test/e2e \
   -channels='messaging.cloud.google.com/v1alpha1:Channel,messaging.cloud.google.com/v1beta1:Channel' \
   || fail_test
 


### PR DESCRIPTION
This significantly speeds up e2e test runs. In my testing, full test runs complete in approximately 400 seconds with this change and I have not seen this cause an e2e test failure. Regardless, e2e test flakiness should be monitored after this change is submitted.