### PR TITLE
Upgrade CloudEvents SDK to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/pubsub v1.6.1
 	cloud.google.com/go/storage v1.10.0
 	github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.2.1-0.20200806165906-9ae0708e27fa
-	github.com/cloudevents/sdk-go/v2 v2.2.1-0.20200729225950-2d83dc10864e
+	github.com/cloudevents/sdk-go/v2 v2.3.1
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/protobuf v1.4.2
 	github.com/google/go-cmp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -292,8 +292,8 @@ github.com/cloudevents/sdk-go/v2 v2.0.0 h1:AUdGJwaSUnA+VvepKqgjy6XDkPcf0hf/3L7ic
 github.com/cloudevents/sdk-go/v2 v2.0.0/go.mod h1:3CTrpB4+u7Iaj6fd7E2Xvm5IxMdRoaAhqaRVnOr2rCU=
 github.com/cloudevents/sdk-go/v2 v2.2.0 h1:FlBJg7W0QywbOjuZGmRXUyFk8qkCHx2euETp+tuopSU=
 github.com/cloudevents/sdk-go/v2 v2.2.0/go.mod h1:3CTrpB4+u7Iaj6fd7E2Xvm5IxMdRoaAhqaRVnOr2rCU=
-github.com/cloudevents/sdk-go/v2 v2.2.1-0.20200729225950-2d83dc10864e h1:xaqndWHYVJulyej25QsJsDRIHgdbxkmNgfx+mJsxzsE=
-github.com/cloudevents/sdk-go/v2 v2.2.1-0.20200729225950-2d83dc10864e/go.mod h1:3CTrpB4+u7Iaj6fd7E2Xvm5IxMdRoaAhqaRVnOr2rCU=
+github.com/cloudevents/sdk-go/v2 v2.3.1 h1:QRTu0yRA4FbznjRSds0/4Hy6cVYpWV2wInlNJSHWAtw=
+github.com/cloudevents/sdk-go/v2 v2.3.1/go.mod h1:4fO2UjPMYYR1/7KPJQCwTPb0lFA8zYuitkUpAZFSY1Q=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=

--- a/vendor/github.com/cloudevents/sdk-go/v2/client/client.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/client/client.go
@@ -170,6 +170,9 @@ func (c *ceClient) Request(ctx context.Context, e event.Event) (*event.Event, pr
 // StartReceiver sets up the given fn to handle Receive.
 // See Client.StartReceiver for details. This is a blocking call.
 func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	c.receiverMu.Lock()
 	defer c.receiverMu.Unlock()
 
@@ -196,15 +199,6 @@ func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
 	defer func() {
 		c.invoker = nil
 	}()
-
-	// Start the opener, if set.
-	if c.opener != nil {
-		go func() {
-			if err := c.opener.OpenInbound(ctx); err != nil {
-				cecontext.LoggerFrom(ctx).Errorf("Error while opening the inbound connection: %s", err)
-			}
-		}()
-	}
 
 	// Start Polling.
 	wg := sync.WaitGroup{}
@@ -233,14 +227,29 @@ func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
 					continue
 				}
 
-				if err := c.invoker.Invoke(ctx, msg, respFn); err != nil {
-					cecontext.LoggerFrom(ctx).Warnf("Error while handling a message: %s", err)
-				}
+				// Do not block on the invoker.
+				wg.Add(1)
+				go func() {
+					if err := c.invoker.Invoke(ctx, msg, respFn); err != nil {
+						cecontext.LoggerFrom(ctx).Warnf("Error while handling a message: %s", err)
+					}
+					wg.Done()
+				}()
 			}
 		}()
 	}
+
+	// Start the opener, if set.
+	if c.opener != nil {
+		if err = c.opener.OpenInbound(ctx); err != nil {
+			err = fmt.Errorf("error while opening the inbound connection: %s", err)
+			cancel()
+		}
+	}
+
 	wg.Wait()
-	return nil
+
+	return err
 }
 
 // noRespFn is used to simply forward the protocol.Result for receivers that aren't responders

--- a/vendor/github.com/cloudevents/sdk-go/v2/client/client_default.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/client/client_default.go
@@ -12,7 +12,7 @@ import (
 // client, all outbound events will have a time and id set if not already
 // present.
 func NewDefault() (Client, error) {
-	p, err := http.New()
+	p, err := http.NewObserved()
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/cloudevents/sdk-go/v2/client/http_receiver.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/client/http_receiver.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"context"
+	cecontext "github.com/cloudevents/sdk-go/v2/context"
+	"go.uber.org/zap"
 	"net/http"
 	"sync"
 
@@ -36,9 +38,9 @@ func (r *EventReceiver) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	msg, respFn, err := r.p.Respond(ctx)
 	if err != nil {
-		//lint:ignore SA9003 TODO: Branch left empty
+		cecontext.LoggerFrom(context.TODO()).Debugw("failed to call Respond", zap.Error(err))
 	} else if err := r.invoker.Invoke(ctx, msg, respFn); err != nil {
-		// TODO
+		cecontext.LoggerFrom(context.TODO()).Debugw("failed to call Invoke", zap.Error(err))
 	}
 	// Block until ServeHTTP has returned
 	wg.Wait()

--- a/vendor/github.com/cloudevents/sdk-go/v2/client/invoker.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/client/invoker.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
 	cecontext "github.com/cloudevents/sdk-go/v2/context"
@@ -58,7 +59,16 @@ func (r *receiveInvoker) Invoke(ctx context.Context, m binding.Message, respFn p
 
 		// Let's invoke the receiver fn
 		var resp *event.Event
-		resp, result = r.fn.invoke(ctx, e)
+		resp, result = func() (resp *event.Event, result protocol.Result) {
+			defer func() {
+				if r := recover(); r != nil {
+					result = fmt.Errorf("call to Invoker.Invoke(...) has panicked: %v", r)
+					cecontext.LoggerFrom(ctx).Error(result)
+				}
+			}()
+			resp, result = r.fn.invoke(ctx, e)
+			return
+		}()
 
 		if respFn == nil {
 			break
@@ -71,7 +81,7 @@ func (r *receiveInvoker) Invoke(ctx context.Context, m binding.Message, respFn p
 			}
 			// Validate the event conforms to the CloudEvents Spec.
 			if vErr := resp.Validate(); vErr != nil {
-				cecontext.LoggerFrom(ctx).Errorf("cloudevent validation failed on response event: %w", vErr)
+				cecontext.LoggerFrom(ctx).Errorf("cloudevent validation failed on response event: %v", vErr)
 			}
 		}
 

--- a/vendor/github.com/cloudevents/sdk-go/v2/client/receiver.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/client/receiver.go
@@ -113,16 +113,16 @@ func (r *receiverFn) validateInParamSignature(fnType reflect.Type) error {
 	switch fnType.NumIn() {
 	case 2:
 		// has to be (context.Context, event.Event)
-		if !fnType.In(1).ConvertibleTo(eventType) {
-			return fmt.Errorf("%s; cannot convert parameter 2 from %s to event.Event", inParamUsage, fnType.In(1))
+		if !eventType.ConvertibleTo(fnType.In(1)) {
+			return fmt.Errorf("%s; cannot convert parameter 2 to %s from event.Event", inParamUsage, fnType.In(1))
 		} else {
 			r.hasEventIn = true
 		}
 		fallthrough
 	case 1:
-		if !fnType.In(0).ConvertibleTo(contextType) {
-			if !fnType.In(0).ConvertibleTo(eventType) {
-				return fmt.Errorf("%s; cannot convert parameter 1 from %s to context.Context or event.Event", inParamUsage, fnType.In(0))
+		if !contextType.ConvertibleTo(fnType.In(0)) {
+			if !eventType.ConvertibleTo(fnType.In(0)) {
+				return fmt.Errorf("%s; cannot convert parameter 1 to %s from context.Context or event.Event", inParamUsage, fnType.In(0))
 			} else if r.hasEventIn {
 				return fmt.Errorf("%s; duplicate parameter of type event.Event", inParamUsage)
 			} else {

--- a/vendor/github.com/cloudevents/sdk-go/v2/go.mod
+++ b/vendor/github.com/cloudevents/sdk-go/v2/go.mod
@@ -22,7 +22,7 @@ require (
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
-	gopkg.in/yaml.v2 v2.2.8 // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
 )
 
 go 1.13

--- a/vendor/github.com/cloudevents/sdk-go/v2/go.sum
+++ b/vendor/github.com/cloudevents/sdk-go/v2/go.sum
@@ -110,6 +110,6 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/gochan/protocol.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/gochan/protocol.go
@@ -26,8 +26,8 @@ func New() *SendReceiver {
 	}
 }
 
-func (sr *SendReceiver) Send(ctx context.Context, in binding.Message) (err error) {
-	return sr.sender.Send(ctx, in)
+func (sr *SendReceiver) Send(ctx context.Context, in binding.Message, transformers ...binding.Transformer) (err error) {
+	return sr.sender.Send(ctx, in, transformers...)
 }
 
 func (sr *SendReceiver) Receive(ctx context.Context) (binding.Message, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -111,7 +111,7 @@ github.com/cespare/xxhash/v2
 github.com/cloudevents/sdk-go/protocol/pubsub/v2
 github.com/cloudevents/sdk-go/protocol/pubsub/v2/context
 github.com/cloudevents/sdk-go/protocol/pubsub/v2/internal
-# github.com/cloudevents/sdk-go/v2 v2.2.1-0.20200729225950-2d83dc10864e
+# github.com/cloudevents/sdk-go/v2 v2.3.1
 ## explicit
 github.com/cloudevents/sdk-go/v2
 github.com/cloudevents/sdk-go/v2/binding


### PR DESCRIPTION
Fixes #1612

Produced by running `go get github.com/cloudevents/sdk-go/v2 && ./hack/update-deps.sh`

## Proposed Changes

- Upgrades CloudEvents SDK to latest release (2.3.1)
- Mainly fixes an issue where CloudEvents client could only handle up to GOMAXPROCS concurrent requests
