### PR TITLE
Adjusting the large payload unit test to prevent occasional timeouts

### DIFF
--- a/pkg/broker/ingress/handler_test.go
+++ b/pkg/broker/ingress/handler_test.go
@@ -179,14 +179,14 @@ func TestHandler(t *testing.T) {
 			name:     "an event with a very large payload",
 			method:   "POST",
 			path:     "/ns1/broker1",
-			event:    createTestEventWithPayloadSize("test-event", 110000000),
+			event:    createTestEventWithPayloadSize("test-event", 10000001), // 10Mb + extra byte
 			wantCode: nethttp.StatusRequestEntityTooLarge,
 		},
 		{
 			name:          "malicious requests or requests with unknown Content-Length and a very large payload",
 			method:        "POST",
 			path:          "/ns1/broker1",
-			event:         createTestEventWithPayloadSize("test-event", 110000000),
+			event:         createTestEventWithPayloadSize("test-event", 10000001), // 10Mb + extra byte
 			contentLength: ptr.Int64(-1),
 			wantCode:      nethttp.StatusRequestEntityTooLarge,
 		},

--- a/pkg/broker/ingress/handler_test.go
+++ b/pkg/broker/ingress/handler_test.go
@@ -119,7 +119,7 @@ type testCase struct {
 	eventAssertions []eventAssertion
 	decouple        DecoupleSink
 	contentLength   *int64
-	timeout time.Duration
+	timeout         time.Duration
 }
 
 type fakeOverloadedDecoupleSink struct{}
@@ -182,7 +182,7 @@ func TestHandler(t *testing.T) {
 			path:     "/ns1/broker1",
 			event:    createTestEventWithPayloadSize("test-event", 11000000), // 11Mb
 			wantCode: nethttp.StatusRequestEntityTooLarge,
-			timeout: 5*time.Second,
+			timeout:  5 * time.Second,
 		},
 		{
 			name:          "malicious requests or requests with unknown Content-Length and a very large payload",
@@ -191,7 +191,7 @@ func TestHandler(t *testing.T) {
 			event:         createTestEventWithPayloadSize("test-event", 11000000), // 11Mb
 			contentLength: ptr.Int64(-1),
 			wantCode:      nethttp.StatusRequestEntityTooLarge,
-			timeout: 10*time.Second,
+			timeout:       10 * time.Second,
 		},
 		{
 			name:     "malformed path",
@@ -298,7 +298,7 @@ func TestHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			reportertest.ResetIngressMetrics()
 			ctx := logging.WithLogger(context.Background(), logtest.TestLogger(t))
-			timeout := 3*time.Second
+			timeout := 3 * time.Second
 			if tc.timeout > 0 {
 				timeout = tc.timeout
 			}

--- a/pkg/broker/ingress/handler_test.go
+++ b/pkg/broker/ingress/handler_test.go
@@ -179,14 +179,14 @@ func TestHandler(t *testing.T) {
 			name:     "an event with a very large payload",
 			method:   "POST",
 			path:     "/ns1/broker1",
-			event:    createTestEventWithPayloadSize("test-event", 10000001), // 10Mb + extra byte
+			event:    createTestEventWithPayloadSize("test-event", 11000000), // 11Mb
 			wantCode: nethttp.StatusRequestEntityTooLarge,
 		},
 		{
 			name:          "malicious requests or requests with unknown Content-Length and a very large payload",
 			method:        "POST",
 			path:          "/ns1/broker1",
-			event:         createTestEventWithPayloadSize("test-event", 10000001), // 10Mb + extra byte
+			event:         createTestEventWithPayloadSize("test-event", 11000000), // 11Mb
 			contentLength: ptr.Int64(-1),
 			wantCode:      nethttp.StatusRequestEntityTooLarge,
 		},

--- a/pkg/broker/ingress/handler_test.go
+++ b/pkg/broker/ingress/handler_test.go
@@ -182,7 +182,6 @@ func TestHandler(t *testing.T) {
 			path:     "/ns1/broker1",
 			event:    createTestEventWithPayloadSize("test-event", 11000000), // 11Mb
 			wantCode: nethttp.StatusRequestEntityTooLarge,
-			timeout:  5 * time.Second,
 		},
 		{
 			name:          "malicious requests or requests with unknown Content-Length and a very large payload",
@@ -298,7 +297,7 @@ func TestHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			reportertest.ResetIngressMetrics()
 			ctx := logging.WithLogger(context.Background(), logtest.TestLogger(t))
-			timeout := 3 * time.Second
+			timeout := 5 * time.Second
 			if tc.timeout > 0 {
 				timeout = tc.timeout
 			}


### PR DESCRIPTION
Reducing payload size from 100Mb to 10mb and increasing timeout to 10 seconds for the unit test _"malicious requests or requests with unknown Content-Length and a very large payload"_ to prevent occasional timeouts. This does not reproduce on local environments, but occasionally happens on the remote test server.