### PR TITLE
Code cleanup in trigger and broker controller

### DIFF
--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -73,19 +73,20 @@ func newController(ctx context.Context, cmw configmap.Watcher, drs *dataresidenc
 	brokerInformer := brokerinformer.Get(ctx)
 	bcInformer := brokercellinformer.Get(ctx)
 
+	var client *pubsub.Client = nil
 	// If there is an error, the projectID will be empty. The reconciler will retry
 	// to get the projectID during reconciliation.
 	projectID, err := utils.ProjectID(env.ProjectID, metadataClient.NewDefaultMetadataClient())
 	if err != nil {
 		logging.FromContext(ctx).Error("Failed to get project ID", zap.Error(err))
-	}
-	// Attempt to create a pubsub client for all worker threads to use. If this
-	// fails, pass a nil value to the Reconciler. They will attempt to
-	// create a client on reconcile.
-	client, err := pubsub.NewClient(ctx, projectID)
-	if err != nil {
-		client = nil
-		logging.FromContext(ctx).Error("Failed to create controller-wide Pub/Sub client", zap.Error(err))
+	} else {
+		// Attempt to create a pubsub client for all worker threads to use. If this
+		// fails, pass a nil value to the Reconciler. They will attempt to
+		// create a client on reconcile.
+		if client, err = pubsub.NewClient(ctx, projectID); err != nil {
+			client = nil
+			logging.FromContext(ctx).Error("Failed to create controller-wide Pub/Sub client", zap.Error(err))
+		}
 	}
 
 	if client != nil {

--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -73,7 +73,7 @@ func newController(ctx context.Context, cmw configmap.Watcher, drs *dataresidenc
 	brokerInformer := brokerinformer.Get(ctx)
 	bcInformer := brokercellinformer.Get(ctx)
 
-	var client *pubsub.Client = nil
+	var client *pubsub.Client
 	// If there is an error, the projectID will be empty. The reconciler will retry
 	// to get the projectID during reconciliation.
 	projectID, err := utils.ProjectID(env.ProjectID, metadataClient.NewDefaultMetadataClient())

--- a/pkg/reconciler/trigger/controller.go
+++ b/pkg/reconciler/trigger/controller.go
@@ -81,7 +81,7 @@ func newController(ctx context.Context, cmw configmap.Watcher, drs *dataresidenc
 
 	triggerInformer := triggerinformer.Get(ctx)
 
-	var client *pubsub.Client = nil
+	var client *pubsub.Client
 	// If there is an error, the projectID will be empty. The reconciler will retry
 	// to get the projectID during reconciliation.
 	projectID, err := utils.ProjectID(env.ProjectID, metadataClient.NewDefaultMetadataClient())

--- a/pkg/utils/metadata.go
+++ b/pkg/utils/metadata.go
@@ -25,6 +25,11 @@ const (
 	ProjectIDEnvKey = "PROJECT_ID"
 )
 
+// ProjectIDEnvConfig is a struct to parse Project id from env var
+type ProjectIDEnvConfig struct {
+	ProjectID string `envconfig:"PROJECT_ID"`
+}
+
 // ProjectID returns the project ID for a particular resource.
 func ProjectID(project string, client metadataClient.Client) (string, error) {
 	// If project is set, then return that one.

--- a/pkg/utils/metadata.go
+++ b/pkg/utils/metadata.go
@@ -25,7 +25,7 @@ const (
 	ProjectIDEnvKey = "PROJECT_ID"
 )
 
-// ProjectIDEnvConfig is a struct to parse Project id from env var
+// ProjectIDEnvConfig is a struct to parse project ID from env var
 type ProjectIDEnvConfig struct {
 	ProjectID string `envconfig:"PROJECT_ID"`
 }


### PR DESCRIPTION
Remove duplicate metadataclient query in both broker and trigger
controllers. Use single ProjectIDEnvConfig for parsing project
id from env, to avoid inconsistency in the future.

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
