### PR TITLE
Report event_count metric in Broker Ingress for invalid events

### DIFF
--- a/pkg/broker/ingress/handler.go
+++ b/pkg/broker/ingress/handler.go
@@ -161,6 +161,7 @@ func (h *Handler) ServeHTTP(response nethttp.ResponseWriter, request *nethttp.Re
 			httpStatus = nethttp.StatusRequestEntityTooLarge
 		}
 		nethttp.Error(response, err.Error(), httpStatus)
+		h.reportMetrics(ctx, "_invalid_cloud_event_", httpStatus)
 		return
 	}
 
@@ -186,7 +187,7 @@ func (h *Handler) ServeHTTP(response nethttp.ResponseWriter, request *nethttp.Re
 	statusCode := nethttp.StatusAccepted
 	ctx, cancel := context.WithTimeout(ctx, decoupleSinkTimeout)
 	defer cancel()
-	defer func() { h.reportMetrics(ctx, event, statusCode) }()
+	defer func() { h.reportMetrics(ctx, event.Type(), statusCode) }()
 	if res := h.decouple.Send(ctx, broker, *event); !cev2.IsACK(res) {
 		logging.FromContext(ctx).Error("Error publishing to PubSub", zap.Error(res))
 		statusCode = nethttp.StatusInternalServerError
@@ -230,9 +231,9 @@ func (h *Handler) toEvent(ctx context.Context, request *nethttp.Request) (*cev2.
 	return event, nil
 }
 
-func (h *Handler) reportMetrics(ctx context.Context, event *cev2.Event, statusCode int) {
+func (h *Handler) reportMetrics(ctx context.Context, eventType string, statusCode int) {
 	args := metrics.IngressReportArgs{
-		EventType:    event.Type(),
+		EventType:    eventType,
 		ResponseCode: statusCode,
 	}
 	if err := h.reporter.ReportEventCount(ctx, args); err != nil {

--- a/pkg/broker/ingress/handler_test.go
+++ b/pkg/broker/ingress/handler_test.go
@@ -184,13 +184,21 @@ func TestHandler(t *testing.T) {
 			wantCode: nethttp.StatusRequestEntityTooLarge,
 		},
 		{
-			name:          "malicious requests or requests with unknown Content-Length and a very large payload",
-			method:        "POST",
-			path:          "/ns1/broker1",
-			event:         createTestEventWithPayloadSize("test-event", 11000000), // 11Mb
-			contentLength: ptr.Int64(-1),
-			wantCode:      nethttp.StatusRequestEntityTooLarge,
-			timeout:       10 * time.Second,
+			name:           "malicious requests or requests with unknown Content-Length and a very large payload",
+			method:         "POST",
+			path:           "/ns1/broker1",
+			event:          createTestEventWithPayloadSize("test-event", 11000000), // 11Mb
+			contentLength:  ptr.Int64(-1),
+			wantCode:       nethttp.StatusRequestEntityTooLarge,
+			timeout:        10 * time.Second,
+			wantEventCount: 1,
+			wantMetricTags: map[string]string{
+				metricskey.LabelEventType:         "_invalid_cloud_event_",
+				metricskey.LabelResponseCode:      "413",
+				metricskey.LabelResponseCodeClass: "4xx",
+				metricskey.PodName:                pod,
+				metricskey.ContainerName:          container,
+			},
 		},
 		{
 			name:     "malformed path",
@@ -199,10 +207,18 @@ func TestHandler(t *testing.T) {
 			wantCode: nethttp.StatusNotFound,
 		},
 		{
-			name:     "request is not an event",
-			path:     "/ns1/broker1",
-			wantCode: nethttp.StatusBadRequest,
-			header:   nethttp.Header{},
+			name:           "request is not an event",
+			path:           "/ns1/broker1",
+			wantCode:       nethttp.StatusBadRequest,
+			header:         nethttp.Header{},
+			wantEventCount: 1,
+			wantMetricTags: map[string]string{
+				metricskey.LabelEventType:         "_invalid_cloud_event_",
+				metricskey.LabelResponseCode:      "400",
+				metricskey.LabelResponseCodeClass: "4xx",
+				metricskey.PodName:                pod,
+				metricskey.ContainerName:          container,
+			},
 		},
 		{
 			name:           "wrong path - broker doesn't exist in given namespace",

--- a/pkg/metrics/tags.go
+++ b/pkg/metrics/tags.go
@@ -58,6 +58,7 @@ var (
 	allowedEventTypes = map[string]struct{}{
 		"e2e-dummy-event-type":              {},
 		"e2e-testing-resp-event-type-dummy": {},
+		"_invalid_cloud_event_":             {},
 	}
 )
 

--- a/pkg/metrics/tags_test.go
+++ b/pkg/metrics/tags_test.go
@@ -39,6 +39,9 @@ func TestEventTypeMetricValue(t *testing.T) {
 		{"some.custom.event", "custom"},
 		{"", "custom"},
 
+		// Used to mark invalid cloud events
+		{"_invalid_cloud_event_", "_invalid_cloud_event_"},
+
 		// Used in E2E tests
 		{"e2e-dummy-event-type", "e2e-dummy-event-type"},
 		{"e2e-testing-resp-event-type-dummy", "e2e-testing-resp-event-type-dummy"},


### PR DESCRIPTION
Fixes #1706 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Report event_count metric in Broker Ingress for invalid events

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Invalid Broker Ingress events now produce the event_count metric with event type _invalid_cloud_event_.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
