### PR TITLE
Use single function to resolve project ID

### DIFF
--- a/cmd/broker/fanout/main.go
+++ b/cmd/broker/fanout/main.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/google/knative-gcp/pkg/broker/config/volume"
 	"github.com/google/knative-gcp/pkg/broker/handler"
-	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 	"github.com/google/knative-gcp/pkg/metrics"
 	"github.com/google/knative-gcp/pkg/utils"
 	"github.com/google/knative-gcp/pkg/utils/appcredentials"
@@ -42,7 +41,6 @@ const (
 
 type envConfig struct {
 	PodName                string `envconfig:"POD_NAME" required:"true"`
-	ProjectID              string `envconfig:"PROJECT_ID"`
 	TargetsConfigPath      string `envconfig:"TARGETS_CONFIG_PATH" default:"/var/run/cloud-run-events/broker/targets"`
 	HandlerConcurrency     int    `envconfig:"HANDLER_CONCURRENCY"`
 	MaxConcurrencyPerEvent int    `envconfig:"MAX_CONCURRENCY_PER_EVENT"`
@@ -78,7 +76,7 @@ func main() {
 
 	logger.Info("Starting the broker fanout")
 
-	projectID, err := utils.ProjectID(env.ProjectID, metadataClient.NewDefaultMetadataClient())
+	projectID, err := utils.ProjectIDOrDefault(ctx, "")
 	if err != nil {
 		logger.Fatalf("failed to get default ProjectID: %v", err)
 	}

--- a/cmd/broker/fanout/main.go
+++ b/cmd/broker/fanout/main.go
@@ -76,7 +76,7 @@ func main() {
 
 	logger.Info("Starting the broker fanout")
 
-	projectID, err := utils.ProjectIDOrDefault(ctx, "")
+	projectID, err := utils.ProjectIDOrDefault("")
 	if err != nil {
 		logger.Fatalf("failed to get default ProjectID: %v", err)
 	}

--- a/cmd/broker/ingress/main.go
+++ b/cmd/broker/ingress/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 	"github.com/google/knative-gcp/pkg/metrics"
 	"github.com/google/knative-gcp/pkg/utils"
 	"github.com/google/knative-gcp/pkg/utils/appcredentials"
@@ -29,9 +28,8 @@ import (
 )
 
 type envConfig struct {
-	PodName   string `envconfig:"POD_NAME" required:"true"`
-	Port      int    `envconfig:"PORT" default:"8080"`
-	ProjectID string `envconfig:"PROJECT_ID"`
+	PodName string `envconfig:"POD_NAME" required:"true"`
+	Port    int    `envconfig:"PORT" default:"8080"`
 
 	// Default 300Mi.
 	PublishBufferedByteLimit int `envconfig:"PUBLISH_BUFFERED_BYTES_LIMIT" default:"314572800"`
@@ -55,7 +53,7 @@ func main() {
 	defer res.Cleanup()
 	logger := res.Logger
 
-	projectID, err := utils.ProjectID(env.ProjectID, metadataClient.NewDefaultMetadataClient())
+	projectID, err := utils.ProjectIDOrDefault(ctx, "")
 	if err != nil {
 		logger.Desugar().Fatal("Failed to create project id", zap.Error(err))
 	}

--- a/cmd/broker/ingress/main.go
+++ b/cmd/broker/ingress/main.go
@@ -53,7 +53,7 @@ func main() {
 	defer res.Cleanup()
 	logger := res.Logger
 
-	projectID, err := utils.ProjectIDOrDefault(ctx, "")
+	projectID, err := utils.ProjectIDOrDefault("")
 	if err != nil {
 		logger.Desugar().Fatal("Failed to create project id", zap.Error(err))
 	}

--- a/cmd/broker/retry/main.go
+++ b/cmd/broker/retry/main.go
@@ -77,7 +77,7 @@ func main() {
 	targetsUpdateCh := make(chan struct{})
 	logger.Info("Starting the broker retry")
 
-	projectID, err := utils.ProjectIDOrDefault(ctx, "")
+	projectID, err := utils.ProjectIDOrDefault("")
 	if err != nil {
 		logger.Fatalf("failed to get default ProjectID: %v", err)
 	}

--- a/cmd/broker/retry/main.go
+++ b/cmd/broker/retry/main.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/google/knative-gcp/pkg/broker/config/volume"
 	"github.com/google/knative-gcp/pkg/broker/handler"
-	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 	"github.com/google/knative-gcp/pkg/metrics"
 	"github.com/google/knative-gcp/pkg/utils"
 	"github.com/google/knative-gcp/pkg/utils/appcredentials"
@@ -42,7 +41,6 @@ const (
 
 type envConfig struct {
 	PodName            string `envconfig:"POD_NAME" required:"true"`
-	ProjectID          string `envconfig:"PROJECT_ID"`
 	TargetsConfigPath  string `envconfig:"TARGETS_CONFIG_PATH" default:"/var/run/cloud-run-events/broker/targets"`
 	HandlerConcurrency int    `envconfig:"HANDLER_CONCURRENCY"`
 
@@ -79,7 +77,7 @@ func main() {
 	targetsUpdateCh := make(chan struct{})
 	logger.Info("Starting the broker retry")
 
-	projectID, err := utils.ProjectID(env.ProjectID, metadataClient.NewDefaultMetadataClient())
+	projectID, err := utils.ProjectIDOrDefault(ctx, "")
 	if err != nil {
 		logger.Fatalf("failed to get default ProjectID: %v", err)
 	}

--- a/cmd/pubsub/publisher/main.go
+++ b/cmd/pubsub/publisher/main.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"log"
 
-	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 	. "github.com/google/knative-gcp/pkg/pubsub/publisher"
 	tracingconfig "github.com/google/knative-gcp/pkg/tracing"
 	"github.com/google/knative-gcp/pkg/utils"
@@ -36,9 +35,6 @@ import (
 type envConfig struct {
 	// Environment variable containing the port for the publisher.
 	Port int `envconfig:"PORT" default:"8080"`
-
-	// Environment variable containing project id.
-	Project string `envconfig:"PROJECT_ID"`
 
 	// Topic is the environment variable containing the PubSub Topic being
 	// subscribed to's name. In the form that is unique within the project.
@@ -69,7 +65,7 @@ func main() {
 		logger.Fatal("Failed to process env var", zap.Error(err))
 	}
 
-	projectID, err := utils.ProjectID(env.Project, metadataClient.NewDefaultMetadataClient())
+	projectID, err := utils.ProjectIDOrDefault(ctx, "")
 	if err != nil {
 		logger.Fatal("Failed to retrieve project id", zap.Error(err))
 	}

--- a/cmd/pubsub/publisher/main.go
+++ b/cmd/pubsub/publisher/main.go
@@ -65,7 +65,7 @@ func main() {
 		logger.Fatal("Failed to process env var", zap.Error(err))
 	}
 
-	projectID, err := utils.ProjectIDOrDefault(ctx, "")
+	projectID, err := utils.ProjectIDOrDefault("")
 	if err != nil {
 		logger.Fatal("Failed to retrieve project id", zap.Error(err))
 	}

--- a/cmd/pubsub/receive_adapter/main.go
+++ b/cmd/pubsub/receive_adapter/main.go
@@ -148,7 +148,7 @@ func main() {
 		logger.Error("Failed to setup tracing", zap.Error(err), zap.Any("tracingConfig", tracingConfig))
 	}
 
-	projectID, err := utils.ProjectIDOrDefault(ctx, "")
+	projectID, err := utils.ProjectIDOrDefault("")
 	if err != nil {
 		logger.Fatal("Failed to retrieve project id", zap.Error(err))
 	}

--- a/cmd/pubsub/receive_adapter/main.go
+++ b/cmd/pubsub/receive_adapter/main.go
@@ -27,7 +27,6 @@ import (
 	"knative.dev/pkg/metrics"
 	"knative.dev/pkg/signals"
 
-	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 	. "github.com/google/knative-gcp/pkg/pubsub/adapter"
 	"github.com/google/knative-gcp/pkg/pubsub/adapter/converters"
 	tracingconfig "github.com/google/knative-gcp/pkg/tracing"
@@ -47,9 +46,6 @@ const (
 // TODO we should refactor this and reduce the number of environment variables.
 //  most of them are due to metrics, which has to change anyways.
 type envConfig struct {
-	// Environment variable containing project id.
-	Project string `envconfig:"PROJECT_ID"`
-
 	// Environment variable containing the sink URI.
 	Sink string `envconfig:"SINK_URI" required:"true"`
 
@@ -152,7 +148,7 @@ func main() {
 		logger.Error("Failed to setup tracing", zap.Error(err), zap.Any("tracingConfig", tracingConfig))
 	}
 
-	projectID, err := utils.ProjectID(env.Project, metadataClient.NewDefaultMetadataClient())
+	projectID, err := utils.ProjectIDOrDefault(ctx, "")
 	if err != nil {
 		logger.Fatal("Failed to retrieve project id", zap.Error(err))
 	}

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -112,7 +112,7 @@ func (r *Reconciler) reconcileDecouplingTopicAndSubscription(ctx context.Context
 	logger := logging.FromContext(ctx)
 	logger.Debug("Reconciling decoupling topic", zap.Any("broker", b))
 	// get ProjectID from metadata if projectID isn't set
-	projectID, err := utils.ProjectIDOrDefault(ctx, r.projectID)
+	projectID, err := utils.ProjectIDOrDefault(r.projectID)
 	if err != nil {
 		logger.Error("Failed to find project id", zap.Error(err))
 		b.Status.MarkTopicUnknown("ProjectIdNotFound", "Failed to find project id: %v", err)
@@ -188,7 +188,7 @@ func (r *Reconciler) deleteDecouplingTopicAndSubscription(ctx context.Context, b
 	logger.Debug("Deleting decoupling topic")
 
 	// get ProjectID from metadata if projectID isn't set
-	projectID, err := utils.ProjectIDOrDefault(ctx, r.projectID)
+	projectID, err := utils.ProjectIDOrDefault(r.projectID)
 	if err != nil {
 		logger.Error("Failed to find project id", zap.Error(err))
 		b.Status.MarkTopicUnknown("FinalizeTopicProjectIdNotFound", "Failed to find project id: %v", err)

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -34,7 +34,6 @@ import (
 	brokerv1beta1 "github.com/google/knative-gcp/pkg/apis/broker/v1beta1"
 	brokerreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/broker/v1beta1/broker"
 	inteventslisters "github.com/google/knative-gcp/pkg/client/listers/intevents/v1alpha1"
-	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 	"github.com/google/knative-gcp/pkg/reconciler"
 	"github.com/google/knative-gcp/pkg/reconciler/broker/resources"
 	reconcilerutilspubsub "github.com/google/knative-gcp/pkg/reconciler/utils/pubsub"
@@ -113,7 +112,7 @@ func (r *Reconciler) reconcileDecouplingTopicAndSubscription(ctx context.Context
 	logger := logging.FromContext(ctx)
 	logger.Debug("Reconciling decoupling topic", zap.Any("broker", b))
 	// get ProjectID from metadata if projectID isn't set
-	projectID, err := utils.ProjectID(r.projectID, metadataClient.NewDefaultMetadataClient())
+	projectID, err := utils.ProjectIDOrDefault(ctx, r.projectID)
 	if err != nil {
 		logger.Error("Failed to find project id", zap.Error(err))
 		b.Status.MarkTopicUnknown("ProjectIdNotFound", "Failed to find project id: %v", err)
@@ -189,7 +188,7 @@ func (r *Reconciler) deleteDecouplingTopicAndSubscription(ctx context.Context, b
 	logger.Debug("Deleting decoupling topic")
 
 	// get ProjectID from metadata if projectID isn't set
-	projectID, err := utils.ProjectID(r.projectID, metadataClient.NewDefaultMetadataClient())
+	projectID, err := utils.ProjectIDOrDefault(ctx, r.projectID)
 	if err != nil {
 		logger.Error("Failed to find project id", zap.Error(err))
 		b.Status.MarkTopicUnknown("FinalizeTopicProjectIdNotFound", "Failed to find project id: %v", err)

--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -64,7 +64,7 @@ func newController(ctx context.Context, cmw configmap.Watcher, drs *dataresidenc
 	var client *pubsub.Client
 	// If there is an error, the projectID will be empty. The reconciler will retry
 	// to get the projectID during reconciliation.
-	projectID, err := utils.ProjectIDOrDefault(ctx, "")
+	projectID, err := utils.ProjectIDOrDefault("")
 	if err != nil {
 		logging.FromContext(ctx).Error("Failed to get project ID", zap.Error(err))
 	} else {

--- a/pkg/reconciler/events/scheduler/scheduler.go
+++ b/pkg/reconciler/events/scheduler/scheduler.go
@@ -30,7 +30,6 @@ import (
 	v1 "github.com/google/knative-gcp/pkg/apis/events/v1"
 	cloudschedulersourcereconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/events/v1/cloudschedulersource"
 	listers "github.com/google/knative-gcp/pkg/client/listers/events/v1"
-	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 	gscheduler "github.com/google/knative-gcp/pkg/gclient/scheduler"
 	"github.com/google/knative-gcp/pkg/reconciler/events/scheduler/resources"
 	"github.com/google/knative-gcp/pkg/reconciler/identity"
@@ -95,7 +94,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, scheduler *v1.CloudSched
 
 func (r *Reconciler) reconcileJob(ctx context.Context, scheduler *v1.CloudSchedulerSource, topic, jobName string) error {
 	if scheduler.Status.ProjectID == "" {
-		projectID, err := utils.ProjectID(scheduler.Spec.Project, metadataClient.NewDefaultMetadataClient())
+		projectID, err := utils.ProjectIDOrDefault(ctx, scheduler.Spec.Project)
 		if err != nil {
 			logging.FromContext(ctx).Desugar().Error("Failed to find project id", zap.Error(err))
 			return err

--- a/pkg/reconciler/events/scheduler/scheduler.go
+++ b/pkg/reconciler/events/scheduler/scheduler.go
@@ -94,7 +94,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, scheduler *v1.CloudSched
 
 func (r *Reconciler) reconcileJob(ctx context.Context, scheduler *v1.CloudSchedulerSource, topic, jobName string) error {
 	if scheduler.Status.ProjectID == "" {
-		projectID, err := utils.ProjectIDOrDefault(ctx, scheduler.Spec.Project)
+		projectID, err := utils.ProjectIDOrDefault(scheduler.Spec.Project)
 		if err != nil {
 			logging.FromContext(ctx).Desugar().Error("Failed to find project id", zap.Error(err))
 			return err

--- a/pkg/reconciler/events/storage/storage.go
+++ b/pkg/reconciler/events/storage/storage.go
@@ -110,7 +110,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, storage *v1.CloudStorage
 
 func (r *Reconciler) reconcileNotification(ctx context.Context, storage *v1.CloudStorageSource) (string, error) {
 	if storage.Status.ProjectID == "" {
-		projectID, err := utils.ProjectIDOrDefault(ctx, storage.Spec.Project)
+		projectID, err := utils.ProjectIDOrDefault(storage.Spec.Project)
 		if err != nil {
 			logging.FromContext(ctx).Desugar().Error("Failed to find project id", zap.Error(err))
 			return "", err

--- a/pkg/reconciler/events/storage/storage.go
+++ b/pkg/reconciler/events/storage/storage.go
@@ -32,7 +32,6 @@ import (
 	v1 "github.com/google/knative-gcp/pkg/apis/events/v1"
 	cloudstoragesourcereconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/events/v1/cloudstoragesource"
 	listers "github.com/google/knative-gcp/pkg/client/listers/events/v1"
-	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 	gstorage "github.com/google/knative-gcp/pkg/gclient/storage"
 	"github.com/google/knative-gcp/pkg/reconciler/events/storage/resources"
 	"github.com/google/knative-gcp/pkg/reconciler/identity"
@@ -111,7 +110,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, storage *v1.CloudStorage
 
 func (r *Reconciler) reconcileNotification(ctx context.Context, storage *v1.CloudStorageSource) (string, error) {
 	if storage.Status.ProjectID == "" {
-		projectID, err := utils.ProjectID(storage.Spec.Project, metadataClient.NewDefaultMetadataClient())
+		projectID, err := utils.ProjectIDOrDefault(ctx, storage.Spec.Project)
 		if err != nil {
 			logging.FromContext(ctx).Desugar().Error("Failed to find project id", zap.Error(err))
 			return "", err

--- a/pkg/reconciler/identity/reconciler.go
+++ b/pkg/reconciler/identity/reconciler.go
@@ -168,7 +168,7 @@ func (i *Identity) createServiceAccount(ctx context.Context, identityNames resou
 // TODO he iam policy binding should be mocked so that we can unit test it. issue https://github.com/google/knative-gcp/issues/657
 // addIamPolicyBinding will add iam policy binding, which is related to a provided k8s ServiceAccount, to a GCP ServiceAccount.
 func (i *Identity) addIamPolicyBinding(ctx context.Context, projectID string, identityNames resources.IdentityNames) error {
-	projectID, err := utils.ProjectIDOrDefault(ctx, projectID)
+	projectID, err := utils.ProjectIDOrDefault(projectID)
 	if err != nil {
 		return fmt.Errorf("failed to get project id: %w", err)
 	}
@@ -181,7 +181,7 @@ func (i *Identity) addIamPolicyBinding(ctx context.Context, projectID string, id
 
 // removeIamPolicyBinding will remove iam policy binding, which is related to a provided k8s ServiceAccount, from a GCP ServiceAccount.
 func (i *Identity) removeIamPolicyBinding(ctx context.Context, projectID string, identityNames resources.IdentityNames) error {
-	projectID, err := utils.ProjectIDOrDefault(ctx, projectID)
+	projectID, err := utils.ProjectIDOrDefault(projectID)
 	if err != nil {
 		return fmt.Errorf("failed to get project id: %w", err)
 	}

--- a/pkg/reconciler/identity/reconciler.go
+++ b/pkg/reconciler/identity/reconciler.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
 	duck "github.com/google/knative-gcp/pkg/duck/v1"
-	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 	"github.com/google/knative-gcp/pkg/reconciler/identity/iam"
 	"github.com/google/knative-gcp/pkg/reconciler/identity/resources"
 	"github.com/google/knative-gcp/pkg/utils"
@@ -169,7 +168,7 @@ func (i *Identity) createServiceAccount(ctx context.Context, identityNames resou
 // TODO he iam policy binding should be mocked so that we can unit test it. issue https://github.com/google/knative-gcp/issues/657
 // addIamPolicyBinding will add iam policy binding, which is related to a provided k8s ServiceAccount, to a GCP ServiceAccount.
 func (i *Identity) addIamPolicyBinding(ctx context.Context, projectID string, identityNames resources.IdentityNames) error {
-	projectID, err := utils.ProjectID(projectID, metadataClient.NewDefaultMetadataClient())
+	projectID, err := utils.ProjectIDOrDefault(ctx, projectID)
 	if err != nil {
 		return fmt.Errorf("failed to get project id: %w", err)
 	}
@@ -182,7 +181,7 @@ func (i *Identity) addIamPolicyBinding(ctx context.Context, projectID string, id
 
 // removeIamPolicyBinding will remove iam policy binding, which is related to a provided k8s ServiceAccount, from a GCP ServiceAccount.
 func (i *Identity) removeIamPolicyBinding(ctx context.Context, projectID string, identityNames resources.IdentityNames) error {
-	projectID, err := utils.ProjectID(projectID, metadataClient.NewDefaultMetadataClient())
+	projectID, err := utils.ProjectIDOrDefault(ctx, projectID)
 	if err != nil {
 		return fmt.Errorf("failed to get project id: %w", err)
 	}

--- a/pkg/reconciler/intevents/pullsubscription/reconciler.go
+++ b/pkg/reconciler/intevents/pullsubscription/reconciler.go
@@ -154,7 +154,7 @@ func (r *Base) ReconcileKind(ctx context.Context, ps *v1.PullSubscription) recon
 
 func (r *Base) reconcileSubscription(ctx context.Context, ps *v1.PullSubscription) (string, error) {
 	if ps.Status.ProjectID == "" {
-		projectID, err := utils.ProjectIDOrDefault(ctx, ps.Spec.Project)
+		projectID, err := utils.ProjectIDOrDefault(ps.Spec.Project)
 		if err != nil {
 			logging.FromContext(ctx).Desugar().Error("Failed to find project id", zap.Error(err))
 			return "", err

--- a/pkg/reconciler/intevents/pullsubscription/reconciler.go
+++ b/pkg/reconciler/intevents/pullsubscription/reconciler.go
@@ -31,7 +31,6 @@ import (
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 
-	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 	"github.com/google/knative-gcp/pkg/utils"
 
 	"knative.dev/pkg/apis"
@@ -155,7 +154,7 @@ func (r *Base) ReconcileKind(ctx context.Context, ps *v1.PullSubscription) recon
 
 func (r *Base) reconcileSubscription(ctx context.Context, ps *v1.PullSubscription) (string, error) {
 	if ps.Status.ProjectID == "" {
-		projectID, err := utils.ProjectID(ps.Spec.Project, metadataClient.NewDefaultMetadataClient())
+		projectID, err := utils.ProjectIDOrDefault(ctx, ps.Spec.Project)
 		if err != nil {
 			logging.FromContext(ctx).Desugar().Error("Failed to find project id", zap.Error(err))
 			return "", err

--- a/pkg/reconciler/intevents/topic/topic.go
+++ b/pkg/reconciler/intevents/topic/topic.go
@@ -129,7 +129,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, topic *v1.Topic) reconci
 
 func (r *Reconciler) reconcileTopic(ctx context.Context, topic *v1.Topic) error {
 	if topic.Status.ProjectID == "" {
-		projectID, err := utils.ProjectIDOrDefault(ctx, topic.Spec.Project)
+		projectID, err := utils.ProjectIDOrDefault(topic.Spec.Project)
 		if err != nil {
 			logging.FromContext(ctx).Desugar().Error("Failed to find project id", zap.Error(err))
 			return err

--- a/pkg/reconciler/intevents/topic/topic.go
+++ b/pkg/reconciler/intevents/topic/topic.go
@@ -30,7 +30,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 
-	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 	"github.com/google/knative-gcp/pkg/tracing"
 	"github.com/google/knative-gcp/pkg/utils"
 
@@ -130,7 +129,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, topic *v1.Topic) reconci
 
 func (r *Reconciler) reconcileTopic(ctx context.Context, topic *v1.Topic) error {
 	if topic.Status.ProjectID == "" {
-		projectID, err := utils.ProjectID(topic.Spec.Project, metadataClient.NewDefaultMetadataClient())
+		projectID, err := utils.ProjectIDOrDefault(ctx, topic.Spec.Project)
 		if err != nil {
 			logging.FromContext(ctx).Desugar().Error("Failed to find project id", zap.Error(err))
 			return err

--- a/pkg/reconciler/trigger/controller.go
+++ b/pkg/reconciler/trigger/controller.go
@@ -72,7 +72,7 @@ func newController(ctx context.Context, cmw configmap.Watcher, drs *dataresidenc
 	var client *pubsub.Client
 	// If there is an error, the projectID will be empty. The reconciler will retry
 	// to get the projectID during reconciliation.
-	projectID, err := utils.ProjectIDOrDefault(ctx, "")
+	projectID, err := utils.ProjectIDOrDefault("")
 	if err != nil {
 		logging.FromContext(ctx).Error("Failed to get project ID", zap.Error(err))
 	} else {

--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -39,7 +39,6 @@ import (
 	"github.com/google/knative-gcp/pkg/apis/configs/dataresidency"
 	triggerreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/broker/v1beta1/trigger"
 	brokerlisters "github.com/google/knative-gcp/pkg/client/listers/broker/v1beta1"
-	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 	"github.com/google/knative-gcp/pkg/reconciler"
 	"github.com/google/knative-gcp/pkg/reconciler/broker/resources"
 	reconcilerutilspubsub "github.com/google/knative-gcp/pkg/reconciler/utils/pubsub"
@@ -214,7 +213,7 @@ func (r *Reconciler) reconcileRetryTopicAndSubscription(ctx context.Context, tri
 	logger.Debug("Reconciling retry topic")
 	// get ProjectID from metadata
 	//TODO get from context
-	projectID, err := utils.ProjectID(r.projectID, metadataClient.NewDefaultMetadataClient())
+	projectID, err := utils.ProjectIDOrDefault(ctx, r.projectID)
 	if err != nil {
 		logger.Error("Failed to find project id", zap.Error(err))
 		trig.Status.MarkTopicUnknown("ProjectIdNotFound", "Failed to find project id: %v", err)
@@ -328,7 +327,7 @@ func (r *Reconciler) deleteRetryTopicAndSubscription(ctx context.Context, trig *
 
 	// get ProjectID from metadata
 	//TODO get from context
-	projectID, err := utils.ProjectID(r.projectID, metadataClient.NewDefaultMetadataClient())
+	projectID, err := utils.ProjectIDOrDefault(ctx, r.projectID)
 	if err != nil {
 		logger.Error("Failed to find project id", zap.Error(err))
 		trig.Status.MarkTopicUnknown("FinalizeTopicProjectIdNotFound", "Failed to find project id: %v", err)

--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -213,7 +213,7 @@ func (r *Reconciler) reconcileRetryTopicAndSubscription(ctx context.Context, tri
 	logger.Debug("Reconciling retry topic")
 	// get ProjectID from metadata
 	//TODO get from context
-	projectID, err := utils.ProjectIDOrDefault(ctx, r.projectID)
+	projectID, err := utils.ProjectIDOrDefault(r.projectID)
 	if err != nil {
 		logger.Error("Failed to find project id", zap.Error(err))
 		trig.Status.MarkTopicUnknown("ProjectIdNotFound", "Failed to find project id: %v", err)
@@ -327,7 +327,7 @@ func (r *Reconciler) deleteRetryTopicAndSubscription(ctx context.Context, trig *
 
 	// get ProjectID from metadata
 	//TODO get from context
-	projectID, err := utils.ProjectIDOrDefault(ctx, r.projectID)
+	projectID, err := utils.ProjectIDOrDefault(r.projectID)
 	if err != nil {
 		logger.Error("Failed to find project id", zap.Error(err))
 		trig.Status.MarkTopicUnknown("FinalizeTopicProjectIdNotFound", "Failed to find project id: %v", err)

--- a/pkg/utils/metadata.go
+++ b/pkg/utils/metadata.go
@@ -17,7 +17,6 @@ limitations under the License.
 package utils
 
 import (
-	"context"
 	"os"
 
 	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
@@ -49,7 +48,7 @@ type ProjectIDEnvConfig struct {
 // 1) if the input project ID is valid, simply use it.
 // 2) if there is a PROJECT_ID environmental variable, use it.
 // 3) use metadataClient to resolve project id.
-func ProjectIDOrDefault(ctx context.Context, projectID string) (string, error) {
+func ProjectIDOrDefault(projectID string) (string, error) {
 	if projectID != "" {
 		return projectID, nil
 	}

--- a/pkg/utils/metadata.go
+++ b/pkg/utils/metadata.go
@@ -17,13 +17,22 @@ limitations under the License.
 package utils
 
 import (
+	"context"
+
 	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
+	"github.com/google/knative-gcp/pkg/logging"
+	"github.com/kelseyhightower/envconfig"
+	"go.uber.org/zap"
 )
 
 const (
 	clusterNameAttr = "cluster-name"
 	ProjectIDEnvKey = "PROJECT_ID"
 )
+
+// defaultMetadataClientCreator is a create function to get a default metadata client. This can be
+// swapped during testing.
+var defaultMetadataClientCreator func() metadataClient.Client = metadataClient.NewDefaultMetadataClient
 
 // ProjectIDEnvConfig is a struct to parse project ID from env var
 type ProjectIDEnvConfig struct {
@@ -42,6 +51,22 @@ func ProjectID(project string, client metadataClient.Client) (string, error) {
 		return "", err
 	}
 	return projectID, nil
+}
+
+// ProjectIDOrDefault returns the project ID by performing the following order:
+// 1) if the input project ID is valid, simply use it.
+// 2) if there is a PROJECT_ID environmental variable, use it.
+// 3) use metadataClient to resolve project id.
+func ProjectIDOrDefault(ctx context.Context, projectID string) (string, error) {
+	if projectID != "" {
+		return projectID, nil
+	}
+	// Parse project id from env var, if not found we simply continue
+	var env ProjectIDEnvConfig
+	if err := envconfig.Process("", &env); err != nil {
+		logging.FromContext(ctx).Fatal("Failed to process env var", zap.Error(err))
+	}
+	return ProjectID(env.ProjectID, defaultMetadataClientCreator())
 }
 
 // ClusterName returns the cluster name for a particular resource.

--- a/pkg/utils/metadata.go
+++ b/pkg/utils/metadata.go
@@ -45,20 +45,6 @@ type ProjectIDEnvConfig struct {
 	ProjectID string `envconfig:"PROJECT_ID"`
 }
 
-// ProjectID returns the project ID for a particular resource.
-func ProjectID(project string, client metadataClient.Client) (string, error) {
-	// If project is set, then return that one.
-	if project != "" {
-		return project, nil
-	}
-	// Otherwise, ask GKE metadata server.
-	projectID, err := client.ProjectID()
-	if err != nil {
-		return "", err
-	}
-	return projectID, nil
-}
-
 // ProjectIDOrDefault returns the project ID by performing the following order:
 // 1) if the input project ID is valid, simply use it.
 // 2) if there is a PROJECT_ID environmental variable, use it.
@@ -67,7 +53,15 @@ func ProjectIDOrDefault(ctx context.Context, projectID string) (string, error) {
 	if projectID != "" {
 		return projectID, nil
 	}
-	return ProjectID(projectIDFromEnv, defaultMetadataClientCreator())
+	if projectIDFromEnv != "" {
+		return projectIDFromEnv, nil
+	}
+	// Otherwise, ask GKE metadata server.
+	projectGKE, err := defaultMetadataClientCreator().ProjectID()
+	if err != nil {
+		return "", err
+	}
+	return projectGKE, nil
 }
 
 // ClusterName returns the cluster name for a particular resource.

--- a/pkg/utils/metadata.go
+++ b/pkg/utils/metadata.go
@@ -64,7 +64,7 @@ func ProjectIDOrDefault(ctx context.Context, projectID string) (string, error) {
 	// Parse project id from env var, if not found we simply continue
 	var env ProjectIDEnvConfig
 	if err := envconfig.Process("", &env); err != nil {
-		logging.FromContext(ctx).Fatal("Failed to process env var", zap.Error(err))
+		logging.FromContext(ctx).Error("Failed to process env var", zap.Error(err))
 	}
 	return ProjectID(env.ProjectID, defaultMetadataClientCreator())
 }

--- a/pkg/utils/metadata_test.go
+++ b/pkg/utils/metadata_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package utils
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
+	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 	testingMetadataClient "github.com/google/knative-gcp/pkg/gclient/metadata/testing"
 )
 
@@ -57,6 +60,66 @@ func TestProjectID(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			client := testingMetadataClient.NewTestClient(tc.data)
 			got, err := ProjectID(tc.input, client)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Unexpected differences (-want +got): %v", diff)
+			}
+			if tc.error != (err != nil) {
+				t.Fatalf("Unexpected validation failure. Got %v", err)
+			}
+		})
+	}
+}
+
+func TestProjectIDOrDefault(t *testing.T) {
+	testCases := map[string]struct {
+		want  string
+		data  testingMetadataClient.TestClientData
+		input string
+		env   string
+		error bool
+	}{
+		"project id exists": {
+			want:  "testing-project",
+			data:  testingMetadataClient.TestClientData{},
+			input: "testing-project",
+			error: false,
+		},
+		"Successfully get project id from env": {
+			want:  "testing-project",
+			data:  testingMetadataClient.TestClientData{},
+			env:   "testing-project",
+			input: "",
+			error: false,
+		},
+		"Successfully get project id from client": {
+			want:  testingMetadataClient.FakeProjectID,
+			data:  testingMetadataClient.TestClientData{},
+			input: "",
+			error: false,
+		},
+		"project id doesn't exist, get project id failed": {
+			want: "",
+			data: testingMetadataClient.TestClientData{
+				ProjectIDErr: fmt.Errorf("error getting project id"),
+			},
+			input: "",
+			error: true,
+		},
+	}
+
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			// Save and restore changed variables
+			origEnv := os.Getenv(ProjectIDEnvKey)
+			defer func() { os.Setenv(ProjectIDEnvKey, origEnv) }()
+			orig := defaultMetadataClientCreator
+			defer func() { defaultMetadataClientCreator = orig }()
+
+			os.Setenv(ProjectIDEnvKey, tc.env)
+			defaultMetadataClientCreator = func() metadataClient.Client {
+				return testingMetadataClient.NewTestClient(tc.data)
+			}
+			got, err := ProjectIDOrDefault(context.Background(), tc.input)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("Unexpected differences (-want +got): %v", diff)
 			}

--- a/pkg/utils/metadata_test.go
+++ b/pkg/utils/metadata_test.go
@@ -27,48 +27,6 @@ import (
 	testingMetadataClient "github.com/google/knative-gcp/pkg/gclient/metadata/testing"
 )
 
-func TestProjectID(t *testing.T) {
-	testCases := map[string]struct {
-		want  string
-		data  testingMetadataClient.TestClientData
-		input string
-		error bool
-	}{
-		"project id exists": {
-			want:  "testing-project",
-			data:  testingMetadataClient.TestClientData{},
-			input: "testing-project",
-			error: false,
-		},
-		"project id doesn't exist, successfully get project id ": {
-			want:  testingMetadataClient.FakeProjectID,
-			data:  testingMetadataClient.TestClientData{},
-			input: "",
-			error: false,
-		},
-		"project id doesn't exist, get project idfailed": {
-			want: "",
-			data: testingMetadataClient.TestClientData{
-				ProjectIDErr: fmt.Errorf("error getting project id"),
-			},
-			input: "",
-			error: true,
-		},
-	}
-	for n, tc := range testCases {
-		t.Run(n, func(t *testing.T) {
-			client := testingMetadataClient.NewTestClient(tc.data)
-			got, err := ProjectID(tc.input, client)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("Unexpected differences (-want +got): %v", diff)
-			}
-			if tc.error != (err != nil) {
-				t.Fatalf("Unexpected validation failure. Got %v", err)
-			}
-		})
-	}
-}
-
 func TestProjectIDOrDefault(t *testing.T) {
 	testCases := map[string]struct {
 		want  string

--- a/pkg/utils/metadata_test.go
+++ b/pkg/utils/metadata_test.go
@@ -19,7 +19,6 @@ package utils
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -110,12 +109,12 @@ func TestProjectIDOrDefault(t *testing.T) {
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
 			// Save and restore changed variables
-			origEnv := os.Getenv(ProjectIDEnvKey)
-			defer func() { os.Setenv(ProjectIDEnvKey, origEnv) }()
+			origEnv := projectIDFromEnv
+			defer func() { projectIDFromEnv = origEnv }()
 			orig := defaultMetadataClientCreator
 			defer func() { defaultMetadataClientCreator = orig }()
 
-			os.Setenv(ProjectIDEnvKey, tc.env)
+			projectIDFromEnv = tc.env
 			defaultMetadataClientCreator = func() metadataClient.Client {
 				return testingMetadataClient.NewTestClient(tc.data)
 			}

--- a/pkg/utils/metadata_test.go
+++ b/pkg/utils/metadata_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package utils
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -76,7 +75,7 @@ func TestProjectIDOrDefault(t *testing.T) {
 			defaultMetadataClientCreator = func() metadataClient.Client {
 				return testingMetadataClient.NewTestClient(tc.data)
 			}
-			got, err := ProjectIDOrDefault(context.Background(), tc.input)
+			got, err := ProjectIDOrDefault(tc.input)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("Unexpected differences (-want +got): %v", diff)
 			}

--- a/test/test_images/probe_helper/main.go
+++ b/test/test_images/probe_helper/main.go
@@ -88,14 +88,10 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
 
-	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 	"github.com/google/knative-gcp/pkg/utils"
 )
 
 type envConfig struct {
-	// Environment variable containing the project ID
-	ProjectID string `envconfig:"PROJECT_ID"`
-
 	// Environment variable containing the sink URL (broker URL) that the event will be forwarded to by the probeHelper for the e2e delivery probe
 	BrokerURL string `envconfig:"K_SINK" default:"http://default-brokercell-ingress.cloud-run-events.svc.cluster.local/cloud-run-events-probe/default"`
 
@@ -131,7 +127,7 @@ func main() {
 	if err := envconfig.Process("", &env); err != nil {
 		logging.FromContext(ctx).Fatal("Failed to process env var", zap.Error(err))
 	}
-	projectID, err := utils.ProjectID(env.ProjectID, metadataClient.NewDefaultMetadataClient())
+	projectID, err := utils.ProjectIDOrDefault(ctx, "")
 	if err != nil {
 		logging.FromContext(ctx).Fatal("Failed to get the default project ID", zap.Error(err))
 	}

--- a/test/test_images/probe_helper/main.go
+++ b/test/test_images/probe_helper/main.go
@@ -127,7 +127,7 @@ func main() {
 	if err := envconfig.Process("", &env); err != nil {
 		logging.FromContext(ctx).Fatal("Failed to process env var", zap.Error(err))
 	}
-	projectID, err := utils.ProjectIDOrDefault(ctx, "")
+	projectID, err := utils.ProjectIDOrDefault("")
 	if err != nil {
 		logging.FromContext(ctx).Fatal("Failed to get the default project ID", zap.Error(err))
 	}


### PR DESCRIPTION
Before this change different reconcilers resolve project ID in different
ways, eg broker controller respect env var "PROJECT_ID" but in reconciler
it does not consider it. This kind of inconsistency will result in hard
to debug problem regarding project id resolve as not all the paths to
resolve project ID will be run regularly. In this change a new helper
function `ProjectIDOrDefault` is defined to resolve project id from
both env var and metadata client. This fix will be applied to all sources
too.

Fixes #1781 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add helper function `ProjectIDOrDefault`
- Replace all occurrence of `ProjectID` with `ProjectIDOrDefault` call.
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

- 🎁 Infer project ID from environmental variable in all sources and brokers

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- Infer project ID from environmental variable in all sources and brokers
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
