### PR TITLE
Unpin github.com/jmespath/go-jmespath

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,8 +46,6 @@ replace (
 
 // The following packages were pinned as part of the go module transition and should eventually be
 // unpinned.
-replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
-
 replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.7
 
 replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742

--- a/go.sum
+++ b/go.sum
@@ -807,8 +807,12 @@ github.com/jinzhu/now v1.0.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/
 github.com/jinzhu/now v1.1.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jirfag/go-printf-func-name v0.0.0-20191110105641-45db9963cdd3/go.mod h1:HEWGJkRDzjJY2sqdDwxccsGicWEf9BQOZsq2tV+xzM0=
 github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af/go.mod h1:HEWGJkRDzjJY2sqdDwxccsGicWEf9BQOZsq2tV+xzM0=
+github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
+github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=

--- a/vendor/github.com/jmespath/go-jmespath/.travis.yml
+++ b/vendor/github.com/jmespath/go-jmespath/.travis.yml
@@ -3,7 +3,15 @@ language: go
 sudo: false
 
 go:
-  - 1.4
+  - 1.5.x
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
+  - 1.12.x
+  - 1.13.x
 
 install: go get -v -t ./...
 script: make test

--- a/vendor/github.com/jmespath/go-jmespath/README.md
+++ b/vendor/github.com/jmespath/go-jmespath/README.md
@@ -4,4 +4,84 @@
 
 
 
-See http://jmespath.org for more info.
+go-jmespath is a GO implementation of JMESPath,
+which is a query language for JSON.  It will take a JSON
+document and transform it into another JSON document
+through a JMESPath expression.
+
+Using go-jmespath is really easy.  There's a single function
+you use, `jmespath.search`:
+
+
+```go
+> import "github.com/jmespath/go-jmespath"
+>
+> var jsondata = []byte(`{"foo": {"bar": {"baz": [0, 1, 2, 3, 4]}}}`) // your data
+> var data interface{}
+> err := json.Unmarshal(jsondata, &data)
+> result, err := jmespath.Search("foo.bar.baz[2]", data)
+result = 2
+```
+
+In the example we gave the ``search`` function input data of
+`{"foo": {"bar": {"baz": [0, 1, 2, 3, 4]}}}` as well as the JMESPath
+expression `foo.bar.baz[2]`, and the `search` function evaluated
+the expression against the input data to produce the result ``2``.
+
+The JMESPath language can do a lot more than select an element
+from a list.  Here are a few more examples:
+
+```go
+> var jsondata = []byte(`{"foo": {"bar": {"baz": [0, 1, 2, 3, 4]}}}`) // your data
+> var data interface{}
+> err := json.Unmarshal(jsondata, &data)
+> result, err := jmespath.search("foo.bar", data)
+result = { "baz": [ 0, 1, 2, 3, 4 ] }
+
+
+> var jsondata  = []byte(`{"foo": [{"first": "a", "last": "b"},
+                           {"first": "c", "last": "d"}]}`) // your data
+> var data interface{}
+> err := json.Unmarshal(jsondata, &data)
+> result, err := jmespath.search({"foo[*].first", data)
+result [ 'a', 'c' ]
+
+
+> var jsondata = []byte(`{"foo": [{"age": 20}, {"age": 25},
+                           {"age": 30}, {"age": 35},
+                           {"age": 40}]}`) // your data
+> var data interface{}
+> err := json.Unmarshal(jsondata, &data)
+> result, err := jmespath.search("foo[?age > `30`]")
+result = [ { age: 35 }, { age: 40 } ]
+```
+
+You can also pre-compile your query. This is usefull if 
+you are going to run multiple searches with it:
+
+```go
+	> var jsondata = []byte(`{"foo": "bar"}`)
+	> var data interface{}
+    > err := json.Unmarshal(jsondata, &data)
+	> precompiled, err := Compile("foo")
+	> if err != nil{
+    >   // ... handle the error
+    > }
+    > result, err := precompiled.Search(data)
+	result = "bar"
+```
+
+## More Resources
+
+The example above only show a small amount of what
+a JMESPath expression can do.  If you want to take a
+tour of the language, the *best* place to go is the
+[JMESPath Tutorial](http://jmespath.org/tutorial.html).
+
+One of the best things about JMESPath is that it is
+implemented in many different programming languages including
+python, ruby, php, lua, etc.  To see a complete list of libraries,
+check out the [JMESPath libraries page](http://jmespath.org/libraries.html).
+
+And finally, the full JMESPath specification can be found
+on the [JMESPath site](http://jmespath.org/specification.html).

--- a/vendor/github.com/jmespath/go-jmespath/api.go
+++ b/vendor/github.com/jmespath/go-jmespath/api.go
@@ -2,7 +2,7 @@ package jmespath
 
 import "strconv"
 
-// JMESPath is the epresentation of a compiled JMES path query. A JMESPath is
+// JMESPath is the representation of a compiled JMES path query. A JMESPath is
 // safe for concurrent use by multiple goroutines.
 type JMESPath struct {
 	ast  ASTNode

--- a/vendor/github.com/jmespath/go-jmespath/go.mod
+++ b/vendor/github.com/jmespath/go-jmespath/go.mod
@@ -1,0 +1,5 @@
+module github.com/jmespath/go-jmespath
+
+go 1.14
+
+require github.com/stretchr/testify v1.5.1

--- a/vendor/github.com/jmespath/go-jmespath/go.sum
+++ b/vendor/github.com/jmespath/go-jmespath/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/vendor/github.com/jmespath/go-jmespath/parser.go
+++ b/vendor/github.com/jmespath/go-jmespath/parser.go
@@ -137,7 +137,7 @@ func (p *Parser) Parse(expression string) (ASTNode, error) {
 	}
 	if p.current() != tEOF {
 		return ASTNode{}, p.syntaxError(fmt.Sprintf(
-			"Unexpected token at the end of the expresssion: %s", p.current()))
+			"Unexpected token at the end of the expression: %s", p.current()))
 	}
 	return parsed, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -238,7 +238,7 @@ github.com/hashicorp/golang-lru/simplelru
 github.com/imdario/mergo
 # github.com/influxdata/tdigest v0.0.1
 github.com/influxdata/tdigest
-# github.com/jmespath/go-jmespath v0.3.0 => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+# github.com/jmespath/go-jmespath v0.3.0
 github.com/jmespath/go-jmespath
 # github.com/joho/godotenv v1.3.0
 github.com/joho/godotenv
@@ -1319,7 +1319,6 @@ sigs.k8s.io/yaml
 # k8s.io/client-go => k8s.io/client-go v0.18.8
 # k8s.io/code-generator => k8s.io/code-generator v0.18.8
 # k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20190918143330-0270cf2f1c1d
-# github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 # github.com/json-iterator/go => github.com/json-iterator/go v1.1.7
 # github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742
 # github.com/pkg/errors => github.com/pkg/errors v0.8.1


### PR DESCRIPTION
Upgrades go-jmespath to v0.3.0.
