### PR TITLE
Fix typo in flag name, workloadIndentity -> workloadIdentity.

### DIFF
--- a/test/e2e-wi-tests.sh
+++ b/test/e2e-wi-tests.sh
@@ -167,6 +167,6 @@ if [ "${SKIP_TESTS:-}" == "true" ]; then
 fi
 
 # Channel related e2e tests we have in Eventing is not running here.
-go_test_e2e -timeout=30m -parallel=6 ./test/e2e -workloadIndentity=true -serviceAccountName="${K8S_SERVICE_ACCOUNT_NAME}" || fail_test
+go_test_e2e -timeout=30m -parallel=6 ./test/e2e -workloadIdentity=true -serviceAccountName="${K8S_SERVICE_ACCOUNT_NAME}" || fail_test
 
 success

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -167,14 +167,14 @@ and replace the `default-auth-config:` part with:
 `$PUBSUB_SERVICE_ACCOUNT@$PROJECT_ID.iam.gserviceaccount.com` is the Pub/Sub
 enabled Google Cloud Service Account.
 
-Then, add `-workloadIndentity=true` and `-serviceAccountName=test-default-ksa`
+Then, add `-workloadIdentity=true` and `-serviceAccountName=test-default-ksa`
 to the `go test` command.
 
 For example,
 
 ```shell
 E2E_PROJECT_ID=<project name> go test --tags=e2e ./test/e2e/... \
-  -workloadIndentity=true \
+  -workloadIdentity=true \
   -serviceAccountName=test-default-ksa \
   -run TestPullSubscription
 ```

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -34,7 +34,7 @@ type EnvironmentFlags struct {
 // InitializeFlags registers flags used by e2e tests, calling flag.Parse() here would fail in
 // go1.13+, see https://github.com/knative/test-infra/issues/1329 for details
 func InitializeFlags() {
-	flag.BoolVar(&Flags.WorkloadIdentity, "workloadIndentity", false, "Indicating whether the workload identity is enabled or not.")
+	flag.BoolVar(&Flags.WorkloadIdentity, "workloadIdentity", false, "Indicating whether the workload identity is enabled or not.")
 	flag.StringVar(&Flags.ServiceAccountName, "serviceAccountName", "", "Kubernetes ServiceAccount bound to a Google Cloud Service, which is used for data plane.")
 
 	// WorkloadIdentity will be enabled only if the input is true.


### PR DESCRIPTION
## Proposed Changes

- Fix typo in flag name, `workloadIndentity` -> `workloadIdentity`.


**Release Note**

```release-note
NONE
```