### PR TITLE
added missing source obersever role in knative-gcp in 0.18(cherry pick #1823)

### DIFF
--- a/config/201-source-observer-clusterrole.yaml
+++ b/config/201-source-observer-clusterrole.yaml
@@ -1,0 +1,1 @@
+core/roles/source-observer-clusterrole.yaml

--- a/config/core/roles/clusterrole.yaml
+++ b/config/core/roles/clusterrole.yaml
@@ -160,27 +160,3 @@ rules:
   resources:
     - leases
   verbs: *everything
-
----
-# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".
-# See https://github.com/knative/eventing/blob/master/config/200-source-observer-clusterrole.yaml.
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: knative-gcp-sources-observer
-  labels:
-    eventing.knative.dev/release: devel
-    duck.knative.dev/source: "true"
-rules:
-  - apiGroups:
-      - "events.cloud.google.com"
-    resources:
-      - "cloudstoragesources"
-      - "cloudpubsubsources"
-      - "cloudauditlogssources"
-      - "cloudschedulersources"
-      - "cloudbuildsources"
-    verbs:
-      - get
-      - list
-      - watch

--- a/config/core/roles/clusterrolebinding.yaml
+++ b/config/core/roles/clusterrolebinding.yaml
@@ -47,6 +47,22 @@ roleRef:
   name: addressable-resolver
 
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cloud-run-events-controller-source-observer
+  labels:
+   events.cloud.google.com/release: devel
+subjects:
+  - kind: ServiceAccount
+    name: controller
+    namespace: cloud-run-events
+roleRef:
+  kind: ClusterRole
+  name: cloud-run-events-source-observer
+  apiGroup: rbac.authorization.k8s.io
+
+---
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/core/roles/source-observer-clusterrole.yaml
+++ b/config/core/roles/source-observer-clusterrole.yaml
@@ -1,0 +1,52 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use this aggregated ClusterRole when you need to read "Sources".
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cloud-run-events-source-observer
+  labels:
+    events.cloud.google.com/release: devel
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        duck.knative.dev/source: "true"
+rules: [] # Rules are automatically filled in by the controller manager.
+
+---
+# The role is needed for the aggregated role cloud-run-events-source-observer in knative-gcp to provide readonly access to "Sources".
+# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".
+# See https://github.com/knative/eventing/blob/master/config/200-source-observer-clusterrole.yaml.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-gcp-sources-observer
+  labels:
+    events.cloud.google.com/release: devel
+    duck.knative.dev/source: "true"
+# Do not use this role directly. These rules will be added to the "cloud-run-events-source-observer" in knative-gcp and "source-observer" role in knative-eventing.
+rules:
+  - apiGroups:
+      - "events.cloud.google.com"
+    resources:
+      - "cloudstoragesources"
+      - "cloudpubsubsources"
+      - "cloudauditlogssources"
+      - "cloudschedulersources"
+      - "cloudbuildsources"
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Cherry pick source observer to 0.18
-
-

