### PR TITLE
Fix KO_FLAGS parameter issue in hack/release.sh

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -45,7 +45,7 @@ function build_release() {
   for yaml in "${!COMPONENTS[@]}"; do
     local config="${COMPONENTS[${yaml}]}"
     echo "Building Cloud Run Events Components - ${config}"
-    ko resolve --strict "${KO_FLAGS}" -f "${config}"/ | "${LABEL_YAML_CMD[@]}" > "${yaml}"
+    ko resolve --strict ${KO_FLAGS} -f "${config}"/ | "${LABEL_YAML_CMD[@]}" > "${yaml}"
     all_yamls+=(${yaml})
   done
   # Assemble the release


### PR DESCRIPTION
Fixes the failure of nightly release in test grid 
https://prow.knative.dev/view/gcs/knative-prow/logs/ci-google-knative-gcp-nightly-release/1315949351930957825

Error message: 
```
Tagged release, updating release labels to events.cloud.google.com/release: "v20201013-8957a127"
Building Cloud Run Events Components - config/pre-install/v0.19.0
Error: unknown shorthand flag: ' ' in - --platform=all
```

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
