### PR TITLE
Update documentation for using MTBroker with Pub/Sub channel

### DIFF
--- a/docs/install/config-br-default-channel.yaml
+++ b/docs/install/config-br-default-channel.yaml
@@ -21,10 +21,10 @@ data:
   channelTemplateSpec: |
     apiVersion: messaging.cloud.google.com/v1beta1
     kind: Channel
-    Spec:
-#  # If running with workload identity enabled, update spec.googleServiceAccount.
-#      googleServiceAccount: service-account@project-id@.iam.gserviceaccount.com
-#  # If running with secret, here is the default secret name and key, change this if required.
+    spec:
+#        # If running with workload identity enabled, update serviceAccountName.
+#      serviceAccountName: kubernetes-service-account-name
+#        # If running with secret, here is the default secret name and key, change this if required.
 #      secret:
 #        name: google-cloud-key
 #        key: key.json

--- a/docs/install/install-broker-with-pubsub-channel.md
+++ b/docs/install/install-broker-with-pubsub-channel.md
@@ -28,7 +28,7 @@ Channel.
 
     1.  If you are in GKE and using
         [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity),
-        update `serviceAccount` with the Pub/Sub enabled service account you
+        update `serviceAccountName` with the Pub/Sub enabled service account you
         created in
         [Create a Service Account for the Data Plane](./dataplane-service-account.md).
 


### PR DESCRIPTION
The documentation for using MTBroker with Pub/Sub channel was out of date.

## Proposed Changes
- Use serviceAccountName instead of googleServiceAccount in config-br-default-channel
- Update docs accordingly