### PR TITLE
Skip conformance tests

### DIFF
--- a/test/e2e-conformance-tests.sh
+++ b/test/e2e-conformance-tests.sh
@@ -18,6 +18,9 @@ source $(dirname "$0")/e2e-secret-tests.sh
 
 initialize $@
 
+# TODO: Fix https://github.com/google/knative-gcp/issues/1844. Until then,
+# temporarily disable conformance tests.
+SKIP_TESTS="true"
 if [ "${SKIP_TESTS:-}" == "true" ]; then
   echo "**************************************"
   echo "***         TESTS SKIPPED          ***"

--- a/test/e2e-conformance-tests.sh
+++ b/test/e2e-conformance-tests.sh
@@ -16,8 +16,6 @@
 # Script entry point.
 source $(dirname "$0")/e2e-secret-tests.sh
 
-initialize $@
-
 # TODO: Fix https://github.com/google/knative-gcp/issues/1844. Until then,
 # temporarily disable conformance tests.
 SKIP_TESTS="true"
@@ -27,6 +25,8 @@ if [ "${SKIP_TESTS:-}" == "true" ]; then
   echo "**************************************"
   exit 0
 fi
+
+initialize $@
 
 go_test_e2e -timeout=30m -parallel=12 ./test/conformance \
   -channels='messaging.cloud.google.com/v1alpha1:Channel,messaging.cloud.google.com/v1beta1:Channel' \


### PR DESCRIPTION
The conformance tests are currently broken and blocking all PRs against knative-gcp.

## Proposed Changes
- Skip the conformance tests temporarily until the real cause of the problem is fixed.

This is related to https://github.com/google/knative-gcp/issues/1844.