### PR TITLE
Enable conformance tests

### DIFF
--- a/test/e2e-conformance-tests.sh
+++ b/test/e2e-conformance-tests.sh
@@ -16,9 +16,6 @@
 # Script entry point.
 source $(dirname "$0")/e2e-secret-tests.sh
 
-# TODO: Fix https://github.com/google/knative-gcp/issues/1844. Until then,
-# temporarily disable conformance tests.
-SKIP_TESTS="true"
 if [ "${SKIP_TESTS:-}" == "true" ]; then
   echo "**************************************"
   echo "***         TESTS SKIPPED          ***"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -16,14 +16,14 @@
 # Script entry point.
 source $(dirname "$0")/e2e-secret-tests.sh
 
-initialize $@
-
 if [ "${SKIP_TESTS:-}" == "true" ]; then
   echo "**************************************"
   echo "***         TESTS SKIPPED          ***"
   echo "**************************************"
   exit 0
 fi
+
+initialize $@
 
 go_test_e2e -timeout=30m -parallel=12 ./test/e2e \
   -channels='messaging.cloud.google.com/v1alpha1:Channel,messaging.cloud.google.com/v1beta1:Channel' \

--- a/test/e2e-wi-tests.sh
+++ b/test/e2e-wi-tests.sh
@@ -155,16 +155,16 @@ function gcp_auth_setup() {
   sed "s/K8S_SERVICE_ACCOUNT_NAME/${K8S_SERVICE_ACCOUNT_NAME}/g; s/PUBSUB-SERVICE-ACCOUNT/${DATA_PLANE_SERVICE_ACCOUNT_EMAIL}/g" ${CONFIG_GCP_AUTH} | ko apply -f -
 }
 
-# Create a cluster with Workload Identity enabled.
-# We could specify --version to force the cluster using a particular GKE version.
-initialize "$@" --enable-workload-identity=true
-
 if [ "${SKIP_TESTS:-}" == "true" ]; then
   echo "**************************************"
   echo "***         TESTS SKIPPED          ***"
   echo "**************************************"
   exit 0
 fi
+
+# Create a cluster with Workload Identity enabled.
+# We could specify --version to force the cluster using a particular GKE version.
+initialize "$@" --enable-workload-identity=true
 
 # Channel related e2e tests we have in Eventing is not running here.
 go_test_e2e -timeout=30m -parallel=6 ./test/e2e -workloadIdentity=true -serviceAccountName="${K8S_SERVICE_ACCOUNT_NAME}" || fail_test


### PR DESCRIPTION
Fixes #1844 

## Proposed Changes

- Enable conformance tests.
- Optionally skip all tests before initializing cluster to avoid waste.

Depends on https://github.com/knative/test-infra/pull/2522