### PR TITLE
 format go code + add *_gen.go to skip list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,4 +15,3 @@
 /test/** coverage-excluded=true
 /cmd/**/main.go coverage-excluded=true
 /pkg/broker/config/targets.pb.go coverage-excluded=true
-/pkg/broker/handler/pool/testing/** coverage-excluded=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 **/zz_generated.*.go linguist-generated=true
 /pkg/client/** linguist-generated=true
 /test/client/** linguist-generated=true
+**/*_gen.go linguist-generated=true
 
 # coverage-excluded is an attribute used to explicitly exclude a path from being included in code
 # coverage. If a path is marked as linguist-generated already, it will be implicitly excluded and


### PR DESCRIPTION
Fixes #1852

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-  adding *_gen.go to the list of patterns in .gitattributes

- also run:
```shell
export FILES=( $(find -path './vendor' -prune -o -path './third_party' -prune -o -name '*.pb.go' -prune -o -type f -name '*.go' -print) )
goimports -w "${FILES[@]}"
gofmt -s -w  "${FILES[@]}"
```
to verify https://github.com/google/knative-gcp/pull/1850 would pass.
