### PR TITLE
Remove v1alpha1 versions from CRDs

### DIFF
--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# TODO: merge v1alpha1 schema into v1beta1 then remove v1alpha1 schema from CRD
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -30,11 +28,11 @@ spec:
     plural: channels
     singular: channel
     categories:
-    - all
-    - knative
-    - pubsub
-    - messaging
-    - channel
+      - all
+      - knative
+      - pubsub
+      - messaging
+      - channel
     shortNames:
       - pschan
   scope: Namespaced
@@ -51,206 +49,147 @@ spec:
           name: webhook
           namespace: cloud-run-events
   versions:
-  - &version
-    name: v1alpha1
-    served: false
-    storage: false
-    subresources:
-      status: {}
-    additionalPrinterColumns:
-    - name: Ready
-      type: string
-      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
-    - name: Reason
-      type: string
-      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
-    - name: Address
-      type: string
-      jsonPath: .status.address.url
-    - name: Age
-      type: date
-      jsonPath: .metadata.creationTimestamp
-    schema:
-      openAPIV3Schema: &openAPIV3Schema
-        type: object
-        properties: &properties
-          spec: &spec
-            type: object
-            properties:
-              serviceAccountName: &serviceAccountName
-                type: string
-                description: >
-                  k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
-                  The value of the k8s service account must be a valid DNS subdomain name.
-                  (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
-              secret: &secret
-                type: object
-                description: >
-                  Credential to use to manage Cloud Pub/Sub. The value of the secret entry must be a service
-                  account key in the JSON format (see
-                  https://cloud.google.com/iam/docs/creating-managing-service-account-keys). Defaults to
-                  secret.name of 'google-cloud-key' and secret.key of 'key.json'.
-                properties:
-                  name:
-                    type: string
-                  key:
-                    type: string
-                  optional:
-                    type: boolean
-              project: &project
-                type: string
-                description: >
-                  ID of the Google Cloud Project to own the Pub/Sub credentials. E.g.
-                  'my-project-1234' rather than its display name, 'My Project' or its number
-                  '1234567890'. If omitted uses the Project ID from the GKE cluster metadata service.
-              subscribable:
-                type: object
-                properties:
-                  subscribers: &subscribers
-                    type: array
-                    items: &items
-                      type: object
-                      required:
-                        - uid
-                      properties: &subscribersProperties
-                        uid: &uid
-                          type: string
-                          minLength: 1
-                        generation: &generation
-                          type: integer
-                        subscriberURI: &subscriberURI
-                          type: string
-                        replyURI: &replyURI
-                          type: string
-                        deadLetterSink:
-                          type: string
-                        delivery: &delivery
-                          type: object
-                          properties:
-                            deadLetterSink:
-                              type: object
-                              properties:
-                                ref:
-                                  type: object
-                                  properties:
-                                    kind:
-                                      type: string
-                                    namespace:
-                                      type: string
-                                    name:
-                                      type: string
-                                    apiVersion:
-                                      type: string
-                                uri:
-                                  type: string
-                            retry:
-                              type: integer
-                            backoffPolicy:
-                              type: string
-                            backoffDelay:
-                              type: string
-          status: &status
-            type: object
-            properties: &statusProperties
-              observedGeneration: &observedGeneration
-                type: integer
-                format: int64
-              conditions: &conditions
-                type: array
-                items:
+    - &version
+      name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: { }
+      additionalPrinterColumns:
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+        - name: Address
+          type: string
+          jsonPath: .status.address.url
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                serviceAccountName:
+                  type: string
+                  description: >
+                    k8s service account used to bind to a google service account to poll the Cloud Pub/Sub Subscription.
+                    The value of the k8s service account must be a valid DNS subdomain name.
+                    (see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
+                secret:
+                  type: object
+                  description: >
+                    Credential to use to manage Cloud Pub/Sub. The value of the secret entry must be a service
+                    account key in the JSON format (see
+                    https://cloud.google.com/iam/docs/creating-managing-service-account-keys). Defaults to
+                    secret.name of 'google-cloud-key' and secret.key of 'key.json'.
+                  properties:
+                    name:
+                      type: string
+                    key:
+                      type: string
+                    optional:
+                      type: boolean
+                project:
+                  type: string
+                  description: >
+                    ID of the Google Cloud Project to own the Pub/Sub credentials. E.g.
+                    'my-project-1234' rather than its display name, 'My Project' or its number
+                    '1234567890'. If omitted uses the Project ID from the GKE cluster metadata service.
+                subscribers:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - uid
+                    properties:
+                      uid:
+                        type: string
+                        minLength: 1
+                      generation:
+                        type: integer
+                      subscriberUri:
+                        type: string
+                      replyUri:
+                        type: string
+                      delivery:
+                        type: object
+                        properties:
+                          deadLetterSink:
+                            type: object
+                            properties:
+                              ref:
+                                type: object
+                                properties:
+                                  kind:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                  name:
+                                    type: string
+                                  apiVersion:
+                                    type: string
+                              uri:
+                                type: string
+                          retry:
+                            type: integer
+                          backoffPolicy:
+                            type: string
+                          backoffDelay:
+                            type: string
+            status:
+              type: object
+              properties:
+                # No subscribable in v1beta1
+                observedGeneration:
+                  type: integer
+                  format: int64
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      lastTransitionTime:
+                        # We use a string in the stored object but a wrapper object at runtime.
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      severity:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - type
+                      - status
+                address:
                   type: object
                   properties:
-                    lastTransitionTime:
-                      # We use a string in the stored object but a wrapper object at runtime.
+                    url:
                       type: string
-                    message:
-                      type: string
-                    reason:
-                      type: string
-                    severity:
-                      type: string
-                    status:
-                      type: string
-                    type:
-                      type: string
-                  required:
-                    - type
-                    - status
-              serviceAccountName:
-                type: string
-              address: &address
-                type: object
-                properties:
-                  url:
-                    type: string
-              subscribableStatus:
-                type: object
-                properties:
-                  subscribers: &statusSubscribers
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        uid:
-                          type: string
-                        observedGeneration:
-                          type: integer
-                          format: int64
-                        ready:
-                          type: string
-                        message:
-                          type: string
-              projectId: &projectId
-                type: string
-              subscriptionId: &subscriptionId
-                type: string
-  - <<: *version
-    name: v1beta1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        <<: *openAPIV3Schema
-        properties:
-          spec:
-            <<: *spec
-            properties:
-              # No subscribable in v1beta1
-              serviceAccountName:
-                <<: *serviceAccountName
-              secret:
-                <<: *secret
-              project:
-                <<: *project
-              subscribers:
-                <<: *subscribers
-                items:
-                  <<: *items
-                  properties:
-                    # No deadLetterSink in subscribers properties in v1beta1
-                    uid:
-                      <<: *uid
-                    generation:
-                      <<: *generation
-                    subscriberUri:
-                      <<: *subscriberURI
-                    replyUri:
-                      <<: *replyURI
-                    delivery:
-                      <<: *delivery
-          status:
-            <<: *status
-            properties:
-              # No subscribable in v1beta1
-              observedGeneration:
-                <<: *observedGeneration
-              conditions:
-                <<: *conditions
-              address:
-                <<: *address
-              subscribers:
-                <<: *statusSubscribers
-              projectId:
-                <<: *projectId
-              subscriptionId:
-                <<: *subscriptionId
+                subscribers:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      uid:
+                        type: string
+                      observedGeneration:
+                        type: integer
+                        format: int64
+                      ready:
+                        type: string
+                      message:
+                        type: string
+                projectId:
+                  type: string
+                subscriptionId:
+                  type: string

--- a/config/core/resources/cloudauditlogssource.yaml
+++ b/config/core/resources/cloudauditlogssource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -194,12 +194,11 @@ spec:
                 description: >
                   ID of the Stackdriver sink used to publish audit log messages.
   - <<: *version
-    # TODO: remove v1alpha1 schema from CRD
-    name: v1alpha1
-    served: false
+    name: v1beta1
+    served: true
     storage: false
-    # v1alpha1 and v1beta have status.properties.serviceAccountName in the schema
-    schema: &v1alpha1Schema
+    # v1beta has status.properties.serviceAccountName in the schema
+    schema:
       openAPIV3Schema:
         <<: *openAPIV3Schema
         properties:
@@ -210,9 +209,3 @@ spec:
               <<: *statusProperties
               serviceAccountName:
                 type: string
-  - <<: *version
-    name: v1beta1
-    served: true
-    storage: false
-    # the schema of v1beta1 is exactly the same as v1alpha1 schema
-    schema: *v1alpha1Schema

--- a/config/core/resources/cloudbuildsource.yaml
+++ b/config/core/resources/cloudbuildsource.yaml
@@ -71,9 +71,9 @@ spec:
           jsonPath: .metadata.creationTimestamp
       # We remove status.ServiceAccountName from the schema in v1.
       schema: &v1Schema
-        openAPIV3Schema: &openAPIV3Schema
+        openAPIV3Schema:
           type: object
-          properties: &properties
+          properties:
             spec:
               type: object
               required:
@@ -141,9 +141,9 @@ spec:
                   description: >
                     Google Cloud Project ID of the project into which the topic should be created. If omitted uses
                     the Project ID from the GKE cluster metadata service.
-            status: &status
+            status:
               type: object
-              properties: &statusProperties
+              properties:
                 observedGeneration:
                   type: integer
                   format: int64
@@ -190,20 +190,3 @@ spec:
       served: true
       storage: false
       schema: *v1Schema
-    - <<: *version
-      # TODO: remove v1alpha1 schema from CRD
-      name: v1alpha1
-      served: false
-      storage: false
-      # v1alpha1 have status.properties.serviceAccountName in the schema
-      schema:
-        openAPIV3Schema:
-          <<: *openAPIV3Schema
-          properties:
-            <<: *properties
-            status:
-              <<: *status
-              properties:
-                <<: *statusProperties
-                serviceAccountName:
-                  type: string

--- a/config/core/resources/cloudpubsubsource.yaml
+++ b/config/core/resources/cloudpubsubsource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -209,12 +209,11 @@ spec:
               subscriptionId:
                 type: string
   - <<: *version
-    # TODO: remove v1alpha1 schema from CRD
-    name: v1alpha1
-    served: false
+    name: v1beta1
+    served: true
     storage: false
-    # v1alpha1 and v1beta have status.properties.serviceAccountName in the schema
-    schema: &v1alpha1Schema
+    # v1beta has status.properties.serviceAccountName in the schema
+    schema:
       openAPIV3Schema:
         <<: *openAPIV3Schema
         properties:
@@ -225,9 +224,3 @@ spec:
               <<: *statusProperties
               serviceAccountName:
                 type: string
-  - <<: *version
-    name: v1beta1
-    served: true
-    storage: false
-    # the schema of v1beta1 is exactly the same as v1alpha1 schema
-    schema: *v1alpha1Schema

--- a/config/core/resources/cloudschedulersource.yaml
+++ b/config/core/resources/cloudschedulersource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -199,12 +199,11 @@ spec:
               jobName:
                 type: string
   - << : *version
-    # TODO: remove v1alpha1 schema from CRD
-    name: v1alpha1
-    served: false
+    name: v1beta1
+    served: true
     storage: false
-    # v1alpha1 and v1beta have status.properties.serviceAccountName in the schema
-    schema: &v1alpha1Schema
+    # v1beta has status.properties.serviceAccountName in the schema
+    schema:
       openAPIV3Schema:
         << : *openAPIV3Schema
         properties:
@@ -215,9 +214,3 @@ spec:
               << : *statusProperties
               serviceAccountName:
                 type: string
-  - <<: *version
-    name: v1beta1
-    served: true
-    storage: false
-    # the schema of v1beta1 is exactly the same as v1alpha1 schema
-    schema: *v1alpha1Schema

--- a/config/core/resources/cloudstoragesource.yaml
+++ b/config/core/resources/cloudstoragesource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -205,12 +205,11 @@ spec:
               notificationId:
                 type: string
   - << : *version
-    # TODO: remove v1alpha1 schema from CRD
-    name: v1alpha1
-    served: false
+    name: v1beta1
+    served: true
     storage: false
-    # v1alpha1 and v1beta have spec.properties.payloadFormat and status.properties.serviceAccountName in the schema
-    schema: &v1alpha1Schema
+    # v1beta has spec.properties.payloadFormat and status.properties.serviceAccountName in the schema
+    schema:
       openAPIV3Schema:
         <<: *openAPIV3Schema
         properties:
@@ -229,9 +228,3 @@ spec:
               <<: *statusProperties
               serviceAccountName:
                 type: string
-  - <<: *version
-    name: v1beta1
-    served: true
-    storage: false
-    # the schema of v1beta1 is exactly the same as v1alpha1 schema
-    schema: *v1alpha1Schema

--- a/config/core/resources/pullsubscription.yaml
+++ b/config/core/resources/pullsubscription.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -186,12 +186,11 @@ spec:
               transformerUri:
                 type: string
   - << : *version
-    # TODO: remove v1alpha1 schema from CRD
-    name: v1alpha1
-    served: false
+    name: v1beta1
+    served: true
     storage: false
-    # v1alpha1 and v1beta have spec.properties.mode and status.properties.serviceAccountName in the schema
-    schema: &v1alpha1Schema
+    # v1beta has spec.properties.mode and status.properties.serviceAccountName in the schema
+    schema:
       openAPIV3Schema:
         << : *openAPIV3Schema
         properties:
@@ -210,9 +209,3 @@ spec:
               << : *statusProperties
               serviceAccountName:
                 type: string
-  - << : *version
-    name: v1beta1
-    served: true
-    storage: false
-    # the schema of v1beta1 is exactly the same as v1alpha1 schema
-    schema: *v1alpha1Schema

--- a/config/core/resources/topic.yaml
+++ b/config/core/resources/topic.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -136,12 +136,11 @@ spec:
                   url:
                     type: string
   - << : *version
-    # TODO: remove v1alpha1 schema from CRD
-    name: v1alpha1
-    served: false
+    name: v1beta1
+    served: true
     storage: false
-    # v1alpha1 and v1beta1 have serviceAccountName in status.properties in the schema
-    schema: &v1alpha1Schema
+    # v1beta1 has serviceAccountName in status.properties in the schema
+    schema:
       openAPIV3Schema:
         << : *openAPIV3Schema
         properties:
@@ -152,9 +151,3 @@ spec:
               <<: *statusProperties
               serviceAccountName:
                 type: string
-  - << : *version
-    name: v1beta1
-    served: true
-    storage: false
-    # the schema of v1beta1 is exactly the same as v1alpha1 schema
-    schema: *v1alpha1Schema


### PR DESCRIPTION
Part of https://github.com/google/knative-gcp/issues/1544, follow-up to https://github.com/google/knative-gcp/pull/1858

_Reviewers: `channel.yaml` needs some effort to review since v1beta1's schema was merged from v1alpha1 with additions._

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🗑️ Remove v1alpha1 version from CRDs
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Removed v1alpha1 CRD api versions for following resources: 

- CloudPubSubSource
- CloudStorageSource
- CloudSchedulerSource
- CloudAuditLogsSource
- CloudBuildSource
- Topic
- PullSubscription
- Channel
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
