### PR TITLE
Automatically succeed on conformance tests (release-0.17)

### DIFF
--- a/test/e2e-conformance-tests.sh
+++ b/test/e2e-conformance-tests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Script entry point.
+source $(dirname "$0")/e2e-secret-tests.sh
+
+# Automatically succeed on conformance tests in releases <0.19.
+success

--- a/test/e2e-conformance-tests.sh
+++ b/test/e2e-conformance-tests.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # Script entry point.
-source $(dirname "$0")/e2e-secret-tests.sh
+source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/e2e-tests.sh
 
 # Automatically succeed on conformance tests in releases <0.19.
 success


### PR DESCRIPTION
Part of #1865

Prow tries to run ./test/e2e-conformance-tests.sh as a required job on release branches which don't have that script. This change adds the script and automatically succeeds.