### PR TITLE
Explicitly depend on knative.dev/hack

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	k8s.io/apimachinery v0.18.8
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 	knative.dev/eventing v0.18.1-0.20201029043934-af98d5579864
+	knative.dev/hack v0.0.0-20201028205534-fe80f1c8af68
 	knative.dev/pkg v0.0.0-20201029122234-6d905b3f84a6
 	knative.dev/serving v0.18.1-0.20201029100934-fbc2b6640b56
 	sigs.k8s.io/yaml v1.2.0

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -20,6 +20,8 @@ limitations under the License.
 package tools
 
 import (
+	_ "knative.dev/hack"
+
 	_ "knative.dev/pkg/configmap/hash-gen"
 	_ "knative.dev/pkg/hack"
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1137,6 +1137,7 @@ knative.dev/eventing/test/upgrade/prober/wathola/forwarder
 knative.dev/eventing/test/upgrade/prober/wathola/receiver
 knative.dev/eventing/test/upgrade/prober/wathola/sender
 # knative.dev/hack v0.0.0-20201028205534-fe80f1c8af68
+## explicit
 knative.dev/hack
 # knative.dev/networking v0.0.0-20201028132534-429a6210295c
 knative.dev/networking/pkg


### PR DESCRIPTION
Our shell scripts use knative.dev/hack, so we should explicitly depend on it. This change imports knative.dev/hack in tools.go and runs `./hack/update.deps.sh`.

## Proposed Changes
- Explicitly depend on knative.dev/hack