### PR TITLE
Remove redundant and flaky tests from conformance package

### DIFF
--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -92,16 +92,6 @@ func TestBrokerChannelFlow(t *testing.T) {
 	)
 }
 
-// TestBrokerWithPubSubChannel tests we can knock a Knative Service from a broker with PubSub Channel.
-func TestBrokerWithPubSubChannel(t *testing.T) {
-	if authConfig.WorkloadIdentity {
-		t.Skip("Skip broker related test when workloadIdentity is enabled, issue: https://github.com/google/knative-gcp/issues/746")
-	}
-	cancel := logstream.Start(t)
-	defer cancel()
-	BrokerWithPubSubChannelTestImpl(t, authConfig)
-}
-
 // TestCloudPubSubSourceBrokerWithPubSubChannel tests we can knock a Knative Service from a broker with PubSub Channel from a CloudPubSubSource.
 func TestCloudPubSubSourceBrokerWithPubSubChannel(t *testing.T) {
 	if authConfig.WorkloadIdentity {
@@ -110,34 +100,4 @@ func TestCloudPubSubSourceBrokerWithPubSubChannel(t *testing.T) {
 	cancel := logstream.Start(t)
 	defer cancel()
 	PubSubSourceBrokerWithPubSubChannelTestImpl(t, authConfig)
-}
-
-// TestCloudStorageSourceBrokerWithPubSubChannel tests we can knock a Knative Service from a broker with PubSub Channel from a CloudStorageSource.
-func TestCloudStorageSourceBrokerWithPubSubChannel(t *testing.T) {
-	if authConfig.WorkloadIdentity {
-		t.Skip("Skip broker related test when workloadIdentity is enabled, issue: https://github.com/google/knative-gcp/issues/746")
-	}
-	cancel := logstream.Start(t)
-	defer cancel()
-	StorageSourceBrokerWithPubSubChannelTestImpl(t, authConfig)
-}
-
-// TestCloudAuditLogsSourceBrokerWithPubSubChannel tests we can knock a Knative Service from a broker with PubSub Channel from a CloudAuditLogsSource.
-func TestCloudAuditLogsSourceBrokerWithPubSubChannel(t *testing.T) {
-	if authConfig.WorkloadIdentity {
-		t.Skip("Skip broker related test when workloadIdentity is enabled, issue: https://github.com/google/knative-gcp/issues/746")
-	}
-	cancel := logstream.Start(t)
-	defer cancel()
-	AuditLogsSourceBrokerWithPubSubChannelTestImpl(t, authConfig)
-}
-
-// TestCloudSchedulerSourceBrokerWithPubSubChannel tests we can knock a Knative Service from a broker with PubSub Channel from a CloudSchedulerSource.
-func TestCloudSchedulerSourceBrokerWithPubSubChannel(t *testing.T) {
-	if authConfig.WorkloadIdentity {
-		t.Skip("Skip broker related test when workloadIdentity is enabled, issue: https://github.com/google/knative-gcp/issues/746")
-	}
-	cancel := logstream.Start(t)
-	defer cancel()
-	SchedulerSourceBrokerWithPubSubChannelTestImpl(t, authConfig)
 }

--- a/test/conformance/test_broker_pubsub.go
+++ b/test/conformance/test_broker_pubsub.go
@@ -34,29 +34,6 @@ import (
 	kngcphelpers "github.com/google/knative-gcp/test/lib/helpers"
 )
 
-/*
-PubSubWithBrokerTestImpl tests the following scenario:
-
-                              5                   4
-                    ------------------   --------------------
-                    |                 | |                    |
-          1         v	      2       | v         3          |
-(Sender or Source) ---> Broker(PubSub) ---> trigger -------> Knative Service(Receiver)
-                    |
-                    |    6                   7
-                    |-------> respTrigger -------> Service(Target)
-
-Note: the number denotes the sequence of the event that flows in this test case.
-*/
-
-func BrokerWithPubSubChannelTestImpl(t *testing.T, authConfig lib.AuthConfig) {
-	ctx := context.Background()
-	client := lib.Setup(ctx, t, true, authConfig.WorkloadIdentity)
-	defer lib.TearDown(ctx, client)
-	brokerURL, brokerName := createBrokerWithPubSubChannel(client)
-	kngcphelpers.BrokerEventTransformationTestHelper(client, brokerURL, brokerName, false)
-}
-
 func PubSubSourceBrokerWithPubSubChannelTestImpl(t *testing.T, authConfig lib.AuthConfig) {
 	ctx := context.Background()
 	client := lib.Setup(ctx, t, true, authConfig.WorkloadIdentity)
@@ -65,35 +42,6 @@ func PubSubSourceBrokerWithPubSubChannelTestImpl(t *testing.T, authConfig lib.Au
 	brokerURL, brokerName := createBrokerWithPubSubChannel(client)
 	kngcphelpers.BrokerEventTransformationTestWithPubSubSourceHelper(client, authConfig, brokerURL, brokerName)
 	// TODO(nlopezgi): assert StackDriver metrics after https://github.com/google/knative-gcp/issues/317 is resolved
-}
-
-func StorageSourceBrokerWithPubSubChannelTestImpl(t *testing.T, authConfig lib.AuthConfig) {
-	ctx := context.Background()
-	client := lib.Setup(ctx, t, true, authConfig.WorkloadIdentity)
-	defer lib.TearDown(ctx, client)
-
-	brokerURL, brokerName := createBrokerWithPubSubChannel(client)
-	kngcphelpers.BrokerEventTransformationTestWithStorageSourceHelper(client, authConfig, brokerURL, brokerName)
-}
-
-func AuditLogsSourceBrokerWithPubSubChannelTestImpl(t *testing.T, authConfig lib.AuthConfig) {
-	ctx := context.Background()
-	client := lib.Setup(ctx, t, true, authConfig.WorkloadIdentity)
-	defer lib.TearDown(ctx, client)
-
-	brokerURL, brokerName := createBrokerWithPubSubChannel(client)
-	kngcphelpers.BrokerEventTransformationTestWithAuditLogsSourceHelper(client, authConfig, brokerURL, brokerName)
-
-}
-
-func SchedulerSourceBrokerWithPubSubChannelTestImpl(t *testing.T, authConfig lib.AuthConfig) {
-	ctx := context.Background()
-	client := lib.Setup(ctx, t, true, authConfig.WorkloadIdentity)
-	defer lib.TearDown(ctx, client)
-
-	brokerURL, brokerName := createBrokerWithPubSubChannel(client)
-	kngcphelpers.BrokerEventTransformationTestWithSchedulerSourceHelper(client, authConfig, brokerURL, brokerName)
-
 }
 
 func createBrokerWithPubSubChannel(client *lib.Client) (url.URL, string) {


### PR DESCRIPTION
Fixes #1882 

## Proposed Changes
- Removes conformance `TestBrokerWithPubSubChannel` since it is an effective duplicate of `TestBrokerChannelFlow`, which more closely mirrors the matching Knative Eventing test.
- Removes conformance Source + Broker tests for all sources other than CloudPubSubSource.
- Cleans up unnecessary test helper functions.