### PR TITLE
feat: Add topic and subscription check to trigger test

### DIFF
--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -131,6 +131,11 @@ func TestAllCasesTrigger(t *testing.T) {
 			WantPatches: []clientgotesting.PatchActionImpl{
 				patchRemoveFinalizers(testNS, triggerName),
 			},
+			OtherTestData: map[string]interface{}{},
+			PostConditions: []func(*testing.T, *TableRow){
+				NoTopicsExist(),
+				NoSubscriptionsExist(),
+			},
 		},
 		{
 			// The finalization logic should be skipped since there is no finalizer string.
@@ -165,6 +170,10 @@ func TestAllCasesTrigger(t *testing.T) {
 				"pre": []PubsubAction{
 					TopicAndSub("cre-tgr_testnamespace_test-trigger_abc123", "cre-tgr_testnamespace_test-trigger_abc123"),
 				},
+			},
+			PostConditions: []func(*testing.T, *TableRow){
+				NoTopicsExist(),
+				NoSubscriptionsExist(),
 			},
 		},
 		{


### PR DESCRIPTION
Before this change, the trigger test only used events to verify
that the topic and subscription are deleted. However, the event
emission logic and actual pubsub operations are separate. After
this change, the stardard pubsub client will be used to make sure
the topic and subscription are indeed deleted from fake server.

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
