### PR TITLE
Make the Probe Helper a KService and refactor

### DIFF
--- a/test/test_images/probe_helper/health.go
+++ b/test/test_images/probe_helper/health.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2020 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	nethttp "net/http"
+	"time"
+)
+
+// healthChecker carries timestamps of the latest handled events from the
+// forwarder and receiver, as well as the longest tolerated staleness time.
+// The healthChecker is expected to declare the probe helper as unhealthy if
+// the probe helper is unable to handle either sort of event.
+type healthChecker struct {
+	lastProbeEventTimestamp    eventTimestamp
+	lastReceiverEventTimestamp eventTimestamp
+	maxStaleDuration           time.Duration
+}
+
+// stalenessHandlerFunc returns the HTTP handler for probe helper health checks.
+func (c *healthChecker) stalenessHandlerFunc() nethttp.HandlerFunc {
+	return func(w nethttp.ResponseWriter, req *nethttp.Request) {
+		if req.URL.Path != "/healthz" {
+			w.WriteHeader(nethttp.StatusNotFound)
+			return
+		}
+		now := time.Now()
+		if now.Sub(c.lastProbeEventTimestamp.getTime()) > c.maxStaleDuration ||
+			now.Sub(c.lastReceiverEventTimestamp.getTime()) > c.maxStaleDuration {
+			w.WriteHeader(nethttp.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(nethttp.StatusOK)
+	}
+}

--- a/test/test_images/probe_helper/main.go
+++ b/test/test_images/probe_helper/main.go
@@ -81,11 +81,13 @@ The Probe Helper can handle multiple different types of probes.
 package main
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/zap"
 	"knative.dev/pkg/logging"
+	"knative.dev/pkg/metrics"
 	"knative.dev/pkg/signals"
 
 	"github.com/google/knative-gcp/pkg/utils"
@@ -104,33 +106,43 @@ type envConfig struct {
 	// Environment variable containing an upper bound on the duration between events emitted by the CloudSchedulerSource
 	CloudSchedulerSourcePeriod time.Duration `envconfig:"CLOUDSCHEDULERSOURCE_PERIOD" default:"90s"`
 
-	// Environment variable containing the port which listens to the probe to deliver the event
+	// Environment variable containing the port which listens to the probe to forward events
 	ProbePort int `envconfig:"PROBE_PORT" default:"8070"`
 
-	// Environment variable containing the port to receive the event from the trigger
+	// Environment variable containing the port to receive delivered events
 	ReceiverPort int `envconfig:"RECEIVER_PORT" default:"8080"`
-
-	// Environment variable containing the port to send health checks to
-	HealthCheckerPort int `envconfig:"HEALTH_CHECKER_PORT" default:"8060"`
 
 	// Environment variable containing the maximum tolerated staleness duration
 	MaxStaleDuration time.Duration `envconfig:"MAX_STALE_DURATION" default:"5m"`
 
-	// Environment variable containing the timeout duration to wait for an event to be delivered back
-	TimeoutDuration time.Duration `envconfig:"TIMEOUT_DURATION" default:"30m"`
+	// Environment variable containing the maximum timeout duration to wait for an event to be delivered
+	MaxTimeoutDuration time.Duration `envconfig:"MAX_TIMEOUT_DURATION" default:"2m"`
 }
 
 func main() {
-	ctx := signals.NewContext()
-
 	var env envConfig
 	if err := envconfig.Process("", &env); err != nil {
-		logging.FromContext(ctx).Fatal("Failed to process env var", zap.Error(err))
+		panic(fmt.Sprintf("Failed to process env var: %s", err))
 	}
+
+	// Create the logger and attach it to the context
+	loggingConfig, err := logging.NewConfigFromMap(map[string]string{})
+	if err != nil {
+		// If this fails, there is no recovering.
+		panic(err)
+	}
+	sl, _ := logging.NewLoggerFromConfig(loggingConfig, "probe-helper")
+	logger := sl.Desugar()
+	defer flush(logger)
+	ctx := logging.WithLogger(signals.NewContext(), logger.Sugar())
+
+	// Get the default project ID
 	projectID, err := utils.ProjectIDOrDefault("")
 	if err != nil {
 		logging.FromContext(ctx).Fatal("Failed to get the default project ID", zap.Error(err))
 	}
+
+	// Create and start the probe helper
 	ph := &ProbeHelper{
 		projectID:                  projectID,
 		brokerURL:                  env.BrokerURL,
@@ -139,11 +151,15 @@ func main() {
 		cloudPubSubSourceTopicID:   env.CloudPubSubSourceTopicID,
 		cloudStorageSourceBucketID: env.CloudStorageSourceBucketID,
 		cloudSchedulerSourcePeriod: env.CloudSchedulerSourcePeriod,
-		timeoutDuration:            env.TimeoutDuration,
+		maxTimeoutDuration:         env.MaxTimeoutDuration,
 		healthChecker: &healthChecker{
-			port:             env.HealthCheckerPort,
 			maxStaleDuration: env.MaxStaleDuration,
 		},
 	}
 	ph.run(ctx)
+}
+
+func flush(logger *zap.Logger) {
+	_ = logger.Sync()
+	metrics.FlushExporter()
 }

--- a/test/test_images/probe_helper/probe_helper.yaml
+++ b/test/test_images/probe_helper/probe_helper.yaml
@@ -41,8 +41,10 @@ spec:
               value: "8070"
             - name: RECEIVER_PORT
               value: "8080"
-            - name: MAX_TIMEOUT_DURATION
+            - name: DEFAULT_TIMEOUT_DURATION
               value: "2m"
+            - name: MAX_TIMEOUT_DURATION
+              value: "30m"
             - name: MAX_STALE_DURATION
               value: "5m"
           livenessProbe:

--- a/test/test_images/probe_helper/probe_helper.yaml
+++ b/test/test_images/probe_helper/probe_helper.yaml
@@ -12,22 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: serving.knative.dev/v1
+kind: Service
 metadata:
-  name: probe-helper
+  name: probe-helper-receiver
   namespace: cloud-run-events-probe
-  labels:
-    app: probe-helper
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: probe-helper
   template:
     metadata:
-      labels:
-        app: probe-helper
+      annotations:
+        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "1"
     spec:
       serviceAccountName: probe-helper
       containers:
@@ -46,18 +41,17 @@ spec:
               value: "8070"
             - name: RECEIVER_PORT
               value: "8080"
-            - name: TIMEOUT_DURATION
-              value: "30m"
-            - name: HEALTH_CHECKER_PORT
-              value: "8060"
+            - name: MAX_TIMEOUT_DURATION
+              value: "2m"
             - name: MAX_STALE_DURATION
               value: "5m"
           livenessProbe:
             failureThreshold: 3
             httpGet:
               path: /healthz
-              port: 8060
             initialDelaySeconds: 5
             periodSeconds: 125
             successThreshold: 1
             timeoutSeconds: 10
+          ports:
+            - containerPort: 8080

--- a/test/test_images/probe_helper/probe_helper_test.go
+++ b/test/test_images/probe_helper/probe_helper_test.go
@@ -273,9 +273,9 @@ func withProbeSubject(subject string) probeEventOption {
 	}
 }
 
-func withProbeTimeout(timeout string) probeEventOption {
+func withProbeTimeout(timeout time.Duration) probeEventOption {
 	return func(event *cloudevents.Event) {
-		event.SetExtension("timeout", timeout)
+		event.SetExtension("timeout", timeout.String())
 	}
 }
 
@@ -462,7 +462,7 @@ func TestProbeHelper(t *testing.T) {
 		name: "Custom timeout",
 		steps: []eventAndResult{
 			{
-				event:      probeEvent("broker-e2e-delivery-probe", withProbeTimeout("0s")),
+				event:      probeEvent("broker-e2e-delivery-probe", withProbeTimeout(0)),
 				wantResult: cloudevents.ResultNACK,
 			},
 		},
@@ -546,7 +546,8 @@ func makeProbeHelper(ctx context.Context, t *testing.T, group *errgroup.Group) m
 		probeListener:              probeListener,
 		receiverListener:           receiverListener,
 		cloudSchedulerSourcePeriod: time.Minute,
-		maxTimeoutDuration:         2 * time.Minute,
+		defaultTimeoutDuration:     2 * time.Minute,
+		maxTimeoutDuration:         30 * time.Minute,
 		healthChecker: &healthChecker{
 			maxStaleDuration: time.Second,
 		},

--- a/test/test_images/probe_helper/probe_helper_test.go
+++ b/test/test_images/probe_helper/probe_helper_test.go
@@ -546,7 +546,7 @@ func makeProbeHelper(ctx context.Context, t *testing.T, group *errgroup.Group) m
 		probeListener:              probeListener,
 		receiverListener:           receiverListener,
 		cloudSchedulerSourcePeriod: time.Minute,
-		maxTimeoutDuration:         30 * time.Minute,
+		maxTimeoutDuration:         2 * time.Minute,
 		healthChecker: &healthChecker{
 			maxStaleDuration: time.Second,
 		},

--- a/test/test_images/probe_helper/probe_helper_test.go
+++ b/test/test_images/probe_helper/probe_helper_test.go
@@ -265,14 +265,30 @@ func runTestCloudSchedulerSource(ctx context.Context, group *errgroup.Group, per
 	})
 }
 
+type probeEventOption func(*cloudevents.Event)
+
+func withProbeSubject(subject string) probeEventOption {
+	return func(event *cloudevents.Event) {
+		event.SetSubject(subject)
+	}
+}
+
+func withProbeTimeout(timeout string) probeEventOption {
+	return func(event *cloudevents.Event) {
+		event.SetExtension("timeout", timeout)
+	}
+}
+
 // Creates a new CloudEvent in the shape of probe events sent to the probe helper.
-func probeEvent(name, subject string) *cloudevents.Event {
+func probeEvent(name string, opts ...probeEventOption) *cloudevents.Event {
 	event := cloudevents.NewEvent()
 	event.SetID(name + "-1234567890")
-	event.SetSubject(subject)
 	event.SetSource("probe-helper-test")
 	event.SetType(name)
 	event.SetTime(time.Now())
+	for _, opt := range opts {
+		opt(&event)
+	}
 	return &event
 }
 
@@ -346,7 +362,7 @@ func TestProbeHelper(t *testing.T) {
 		name: "Broker E2E delivery probe",
 		steps: []eventAndResult{
 			{
-				event:      probeEvent("broker-e2e-delivery-probe", ""),
+				event:      probeEvent("broker-e2e-delivery-probe"),
 				wantResult: cloudevents.ResultACK,
 			},
 		},
@@ -354,7 +370,7 @@ func TestProbeHelper(t *testing.T) {
 		name: "Unrecognized Broker E2E delivery probe subject",
 		steps: []eventAndResult{
 			{
-				event:      probeEvent("broker-e2e-delivery-probe", "invalid-subject"),
+				event:      probeEvent("broker-e2e-delivery-probe", withProbeSubject("invalid-subject")),
 				wantResult: cloudevents.ResultNACK,
 			},
 		},
@@ -362,7 +378,7 @@ func TestProbeHelper(t *testing.T) {
 		name: "CloudPubSubSource probe",
 		steps: []eventAndResult{
 			{
-				event:      probeEvent("cloudpubsubsource-probe", ""),
+				event:      probeEvent("cloudpubsubsource-probe"),
 				wantResult: cloudevents.ResultACK,
 			},
 		},
@@ -370,7 +386,7 @@ func TestProbeHelper(t *testing.T) {
 		name: "Unrecognized CloudPubSubSource probe subject",
 		steps: []eventAndResult{
 			{
-				event:      probeEvent("cloudpubsubsource-probe", "invalid-subject"),
+				event:      probeEvent("cloudpubsubsource-probe", withProbeSubject("invalid-subject")),
 				wantResult: cloudevents.ResultNACK,
 			},
 		},
@@ -378,19 +394,19 @@ func TestProbeHelper(t *testing.T) {
 		name: "CloudStorageSource probe",
 		steps: []eventAndResult{
 			{
-				event:      probeEvent("cloudstoragesource-probe", "create"),
+				event:      probeEvent("cloudstoragesource-probe", withProbeSubject("create")),
 				wantResult: cloudevents.ResultACK,
 			},
 			{
-				event:      probeEvent("cloudstoragesource-probe", "update-metadata"),
+				event:      probeEvent("cloudstoragesource-probe", withProbeSubject("update-metadata")),
 				wantResult: cloudevents.ResultACK,
 			},
 			{
-				event:      probeEvent("cloudstoragesource-probe", "archive"),
+				event:      probeEvent("cloudstoragesource-probe", withProbeSubject("archive")),
 				wantResult: cloudevents.ResultACK,
 			},
 			{
-				event:      probeEvent("cloudstoragesource-probe", "delete"),
+				event:      probeEvent("cloudstoragesource-probe", withProbeSubject("delete")),
 				wantResult: cloudevents.ResultACK,
 			},
 		},
@@ -398,7 +414,7 @@ func TestProbeHelper(t *testing.T) {
 		name: "Unrecognized CloudStorageSource probe subject",
 		steps: []eventAndResult{
 			{
-				event:      probeEvent("cloudstoragesource-probe", "invalid-subject"),
+				event:      probeEvent("cloudstoragesource-probe", withProbeSubject("invalid-subject")),
 				wantResult: cloudevents.ResultNACK,
 			},
 		},
@@ -406,7 +422,7 @@ func TestProbeHelper(t *testing.T) {
 		name: "CloudAuditLogsSource probe",
 		steps: []eventAndResult{
 			{
-				event:      probeEvent("cloudauditlogssource-probe", ""),
+				event:      probeEvent("cloudauditlogssource-probe"),
 				wantResult: cloudevents.ResultACK,
 			},
 		},
@@ -414,7 +430,7 @@ func TestProbeHelper(t *testing.T) {
 		name: "Unrecognized CloudAuditLogsSource probe subject",
 		steps: []eventAndResult{
 			{
-				event:      probeEvent("cloudauditlogssource-probe", "invalid-subject"),
+				event:      probeEvent("cloudauditlogssource-probe", withProbeSubject("invalid-subject")),
 				wantResult: cloudevents.ResultNACK,
 			},
 		},
@@ -422,7 +438,7 @@ func TestProbeHelper(t *testing.T) {
 		name: "CloudSchedulerSource probe",
 		steps: []eventAndResult{
 			{
-				event:      probeEvent("cloudschedulersource-probe", ""),
+				event:      probeEvent("cloudschedulersource-probe"),
 				wantResult: cloudevents.ResultACK,
 			},
 		},
@@ -430,7 +446,7 @@ func TestProbeHelper(t *testing.T) {
 		name: "Unrecognized CloudSchedulerSource probe subject",
 		steps: []eventAndResult{
 			{
-				event:      probeEvent("cloudschedulersource-probe", "invalid-subject"),
+				event:      probeEvent("cloudschedulersource-probe", withProbeSubject("invalid-subject")),
 				wantResult: cloudevents.ResultNACK,
 			},
 		},
@@ -438,7 +454,15 @@ func TestProbeHelper(t *testing.T) {
 		name: "Unrecognized probe event type",
 		steps: []eventAndResult{
 			{
-				event:      probeEvent("unrecognized-probe-type", ""),
+				event:      probeEvent("unrecognized-probe-type"),
+				wantResult: cloudevents.ResultNACK,
+			},
+		},
+	}, {
+		name: "Custom timeout",
+		steps: []eventAndResult{
+			{
+				event:      probeEvent("broker-e2e-delivery-probe", withProbeTimeout("0s")),
 				wantResult: cloudevents.ResultNACK,
 			},
 		},
@@ -481,13 +505,7 @@ func makeProbeHelper(ctx context.Context, t *testing.T, group *errgroup.Group) m
 	}
 	probePort := probeListener.Addr().(*net.TCPAddr).Port
 	probeURL := fmt.Sprintf("http://localhost:%d", probePort)
-
-	healthCheckerListener, err := GetFreePortListener()
-	if err != nil {
-		t.Errorf("Failed to get free health checker port listener: %v", err)
-	}
-	healthCheckerPort := healthCheckerListener.Addr().(*net.TCPAddr).Port
-	healthCheckerURL := fmt.Sprintf("http://localhost:%d/healthz", healthCheckerPort)
+	healthCheckerURL := fmt.Sprintf("http://localhost:%d/healthz", probePort)
 
 	// Set up the resources for testing the CloudPubSubSource.
 	pubsubClient, closePubsub := testPubsubClient(ctx, t, testProjectID)
@@ -528,9 +546,8 @@ func makeProbeHelper(ctx context.Context, t *testing.T, group *errgroup.Group) m
 		probeListener:              probeListener,
 		receiverListener:           receiverListener,
 		cloudSchedulerSourcePeriod: time.Minute,
-		timeoutDuration:            30 * time.Minute,
+		maxTimeoutDuration:         30 * time.Minute,
 		healthChecker: &healthChecker{
-			listener:         healthCheckerListener,
 			maxStaleDuration: time.Second,
 		},
 	}

--- a/test/test_images/probe_helper/utils.go
+++ b/test/test_images/probe_helper/utils.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2020 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// eventTimestamp is a synchronized wrapper around a timestamp.
+type eventTimestamp struct {
+	sync.RWMutex
+	time time.Time
+}
+
+// setNow sets the desired timestamp to the current time.
+func (t *eventTimestamp) setNow() {
+	t.Lock()
+	defer t.Unlock()
+	t.time = time.Now()
+}
+
+// getTime gets the timestamp's time.
+func (t *eventTimestamp) getTime() time.Time {
+	t.RLock()
+	defer t.RUnlock()
+	return t.time
+}
+
+// receivedEventsMap is a sychronized map which holds waiting channels on each of
+// the probe requests which are currently in the process of being handled.
+type receivedEventsMap struct {
+	sync.RWMutex
+	channels map[string]chan bool
+}
+
+// createReceiverChannel creates a new channel at a given index in the receivedEventsMap.
+// It is expected to fail if the index is already populated, i.e., if the probe
+// request is duplicated.
+func (r *receivedEventsMap) createReceiverChannel(channelID string) (chan bool, error) {
+	r.Lock()
+	defer r.Unlock()
+	if _, ok := r.channels[channelID]; ok {
+		return nil, fmt.Errorf("Receiver channel already exists for key %v", channelID)
+	}
+	receiverChannel := make(chan bool, 1)
+	r.channels[channelID] = receiverChannel
+	return receiverChannel, nil
+}
+
+// deleteReceiverChannel closes the waiting channel at a given index in the receivedEventsMap
+// and deletes the map entry.
+func (r *receivedEventsMap) deleteReceiverChannel(channelID string) {
+	r.Lock()
+	if ch, ok := r.channels[channelID]; ok {
+		close(ch)
+		delete(r.channels, channelID)
+	}
+	r.Unlock()
+}


### PR DESCRIPTION
The probe helper must be made into a KService in order to be correctly addressable. Other convenience changes are packaged into this PR.

## Proposed Changes

- Make the Probe Helper a KService
- Improve Probe Helper logging
- Allow for specifying custom timeout using "timeout" CloudEvent extension, but cap to maximum timeout. (Added a unit test to show the custom timeouts work)
- Adjust livenessProbe to pass through Probe Helper KService containerPort instead of its own port
- Move health checker related code to `health.go`
- Move utilities to `utils.go`
