### PR TITLE
Use containerPort for Probe Helper health check

### DIFF
--- a/test/test_images/probe_helper/health.go
+++ b/test/test_images/probe_helper/health.go
@@ -45,7 +45,8 @@ func (c *healthChecker) stalenessHandlerFunc(ctx context.Context) nethttp.Handle
 			logging.FromContext(ctx).Warnw("Health check failed, probe delay exceeds staleness threshold", zap.Duration("delay", delay), zap.Duration("staleness", c.maxStaleDuration))
 			w.WriteHeader(nethttp.StatusServiceUnavailable)
 			return
-		} else if delay := now.Sub(c.lastReceiverEventTimestamp.getTime()); delay > c.maxStaleDuration {
+		}
+		if delay := now.Sub(c.lastReceiverEventTimestamp.getTime()); delay > c.maxStaleDuration {
 			logging.FromContext(ctx).Warnw("Health check failed, receiver delay exceeds staleness threshold", zap.Duration("delay", delay), zap.Duration("staleness", c.maxStaleDuration))
 			w.WriteHeader(nethttp.StatusServiceUnavailable)
 			return

--- a/test/test_images/probe_helper/health.go
+++ b/test/test_images/probe_helper/health.go
@@ -14,8 +14,12 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	nethttp "net/http"
 	"time"
+
+	"go.uber.org/zap"
+	"knative.dev/pkg/logging"
 )
 
 // healthChecker carries timestamps of the latest handled events from the
@@ -29,18 +33,24 @@ type healthChecker struct {
 }
 
 // stalenessHandlerFunc returns the HTTP handler for probe helper health checks.
-func (c *healthChecker) stalenessHandlerFunc() nethttp.HandlerFunc {
+func (c *healthChecker) stalenessHandlerFunc(ctx context.Context) nethttp.HandlerFunc {
 	return func(w nethttp.ResponseWriter, req *nethttp.Request) {
 		if req.URL.Path != "/healthz" {
+			logging.FromContext(ctx).Warnw("Invalid health check request path", zap.String("path", req.URL.Path))
 			w.WriteHeader(nethttp.StatusNotFound)
 			return
 		}
 		now := time.Now()
-		if now.Sub(c.lastProbeEventTimestamp.getTime()) > c.maxStaleDuration ||
-			now.Sub(c.lastReceiverEventTimestamp.getTime()) > c.maxStaleDuration {
+		if delay := now.Sub(c.lastProbeEventTimestamp.getTime()); delay > c.maxStaleDuration {
+			logging.FromContext(ctx).Warnw("Health check failed, probe delay exceeds staleness threshold", zap.Duration("delay", delay), zap.Duration("staleness", c.maxStaleDuration))
+			w.WriteHeader(nethttp.StatusServiceUnavailable)
+			return
+		} else if delay := now.Sub(c.lastReceiverEventTimestamp.getTime()); delay > c.maxStaleDuration {
+			logging.FromContext(ctx).Warnw("Health check failed, receiver delay exceeds staleness threshold", zap.Duration("delay", delay), zap.Duration("staleness", c.maxStaleDuration))
 			w.WriteHeader(nethttp.StatusServiceUnavailable)
 			return
 		}
+		logging.FromContext(ctx).Info("Health check succeeded")
 		w.WriteHeader(nethttp.StatusOK)
 	}
 }

--- a/test/test_images/probe_helper/main.go
+++ b/test/test_images/probe_helper/main.go
@@ -86,6 +86,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/zap"
+
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
 

--- a/test/test_images/probe_helper/probe_helper.go
+++ b/test/test_images/probe_helper/probe_helper.go
@@ -549,7 +549,6 @@ func (ph *ProbeHelper) run(ctx context.Context) {
 	if ph.probeClient == nil {
 		spOpts := []cehttp.Option{
 			cloudevents.WithTarget(ph.brokerURL),
-			cloudevents.WithGetHandlerFunc(ph.healthChecker.stalenessHandlerFunc()),
 		}
 		if ph.probeListener != nil {
 			spOpts = append(spOpts, cloudevents.WithListener(ph.probeListener))
@@ -568,7 +567,9 @@ func (ph *ProbeHelper) run(ctx context.Context) {
 
 	// create receiver client
 	if ph.receiverClient == nil {
-		rpOpts := []cehttp.Option{}
+		rpOpts := []cehttp.Option{
+			cloudevents.WithGetHandlerFunc(ph.healthChecker.stalenessHandlerFunc(ctx)),
+		}
 		if ph.probeListener != nil {
 			rpOpts = append(rpOpts, cloudevents.WithListener(ph.receiverListener))
 		} else {

--- a/test/test_images/probe_helper/probe_helper_test.go
+++ b/test/test_images/probe_helper/probe_helper_test.go
@@ -505,7 +505,7 @@ func makeProbeHelper(ctx context.Context, t *testing.T, group *errgroup.Group) m
 	}
 	probePort := probeListener.Addr().(*net.TCPAddr).Port
 	probeURL := fmt.Sprintf("http://localhost:%d", probePort)
-	healthCheckerURL := fmt.Sprintf("http://localhost:%d/healthz", probePort)
+	healthCheckerURL := fmt.Sprintf("http://localhost:%d/healthz", receiverPort)
 
 	// Set up the resources for testing the CloudPubSubSource.
 	pubsubClient, closePubsub := testPubsubClient(ctx, t, testProjectID)


### PR DESCRIPTION
The livenessProbe must pass through the probe helper containerPort 8080. It was accidentally passing through 8070, causing all health checks to fail.

## Proposed Changes
- Pass health check through probe helper containerPort 8080.
- Improve health checker logging.