### PR TITLE
Replace disrespectful terms - 3

### DIFF
--- a/cmd/broker/fanout/main.go
+++ b/cmd/broker/fanout/main.go
@@ -99,7 +99,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Failed to create fanout sync pool", zap.Error(err))
 	}
-	if _, err := handler.StartSyncPool(ctx, syncPool, syncSignal, env.MaxStaleDuration, handler.DefaultHealthCheckPort); err != nil {
+	if _, err := handler.StartSyncPool(ctx, syncPool, syncSignal, env.MaxStaleDuration, handler.DefaultProbeCheckPort); err != nil {
 		logger.Fatalw("Failed to start fanout sync pool", zap.Error(err))
 	}
 

--- a/cmd/broker/retry/main.go
+++ b/cmd/broker/retry/main.go
@@ -97,7 +97,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Failed to get retry sync pool", zap.Error(err))
 	}
-	if _, err := handler.StartSyncPool(ctx, syncPool, syncSignal, env.MaxStaleDuration, handler.DefaultHealthCheckPort); err != nil {
+	if _, err := handler.StartSyncPool(ctx, syncPool, syncSignal, env.MaxStaleDuration, handler.DefaultProbeCheckPort); err != nil {
 		logger.Fatal("Failed to start retry sync pool", zap.Error(err))
 	}
 

--- a/pkg/broker/handler/pool_test.go
+++ b/pkg/broker/handler/pool_test.go
@@ -69,36 +69,36 @@ func TestSyncPool(t *testing.T) {
 			t.Errorf("StartSyncPool got unexpected error: %v", err)
 		}
 		syncPool.verifySyncOnceCalled(t)
-		// Make sure the health checker is up.
+		// Make sure the probe checker is up.
 		time.Sleep(500 * time.Millisecond)
 
 		ch <- struct{}{}
 		syncPool.verifySyncOnceCalled(t)
-		assertHealthCheckResult(t, p, true)
+		assertProbeCheckResult(t, p, true)
 
-		// Intentionally causing a unhealth check.
+		// Intentionally causing a failed check.
 		time.Sleep(time.Second)
-		assertHealthCheckResult(t, p, false)
+		assertProbeCheckResult(t, p, false)
 	})
 }
 
-func assertHealthCheckResult(t *testing.T, port int, ok bool) {
+func assertProbeCheckResult(t *testing.T, port int, ok bool) {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/healthz", port), nil)
 	if err != nil {
-		t.Fatalf("Failed to create health check request: %v", err)
+		t.Fatalf("Failed to create probe check request: %v", err)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		t.Logf("Failed to execute health check: %v", err)
+		t.Logf("Failed to execute probe check: %v", err)
 		if ok {
-			t.Errorf("health check result ok got=%v, want=%v", !ok, ok)
+			t.Errorf("probe check result ok got=%v, want=%v", !ok, ok)
 		}
 		return
 	}
 	if ok != (resp.StatusCode == http.StatusOK) {
-		t.Logf("Got health check status code: %v", resp.StatusCode)
-		t.Errorf("health check result ok got=%v, want=%v", !ok, ok)
+		t.Logf("Got probe check status code: %v", resp.StatusCode)
+		t.Errorf("probe check result ok got=%v, want=%v", !ok, ok)
 	}
 }
 

--- a/pkg/broker/handler/pool_test.go
+++ b/pkg/broker/handler/pool_test.go
@@ -86,18 +86,18 @@ func assertProbeCheckResult(t *testing.T, port int, ok bool) {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/healthz", port), nil)
 	if err != nil {
-		t.Fatalf("Failed to create probe check request: %v", err)
+		t.Fatal("Failed to create probe check request:", err)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		t.Logf("Failed to execute probe check: %v", err)
+		t.Log("Failed to execute probe check:", err)
 		if ok {
 			t.Errorf("probe check result ok got=%v, want=%v", !ok, ok)
 		}
 		return
 	}
 	if ok != (resp.StatusCode == http.StatusOK) {
-		t.Logf("Got probe check status code: %v", resp.StatusCode)
+		t.Log("Got probe check status code:", resp.StatusCode)
 		t.Errorf("probe check result ok got=%v, want=%v", !ok, ok)
 	}
 }

--- a/pkg/broker/ingress/handler_test.go
+++ b/pkg/broker/ingress/handler_test.go
@@ -138,7 +138,7 @@ func (m *fakeOverloadedDecoupleSink) Send(_ context.Context, _ types.NamespacedN
 func TestHandler(t *testing.T) {
 	tests := []testCase{
 		{
-			name:     "health check",
+			name:     "probe check",
 			path:     "/healthz",
 			method:   nethttp.MethodGet,
 			wantCode: nethttp.StatusOK,

--- a/pkg/reconciler/brokercell/resources/deployments.go
+++ b/pkg/reconciler/brokercell/resources/deployments.go
@@ -82,7 +82,7 @@ func MakeFanoutDeployment(args FanoutArgs) *appsv1.Deployment {
 	container.Ports = append(container.Ports,
 		corev1.ContainerPort{
 			Name:          "http-health",
-			ContainerPort: handler.DefaultHealthCheckPort,
+			ContainerPort: handler.DefaultProbeCheckPort,
 		},
 	)
 	container.Env = append(container.Env, corev1.EnvVar{
@@ -93,7 +93,7 @@ func MakeFanoutDeployment(args FanoutArgs) *appsv1.Deployment {
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Path:   "/healthz",
-				Port:   intstr.FromInt(handler.DefaultHealthCheckPort),
+				Port:   intstr.FromInt(handler.DefaultProbeCheckPort),
 				Scheme: corev1.URISchemeHTTP,
 			},
 		},
@@ -113,14 +113,14 @@ func MakeRetryDeployment(args RetryArgs) *appsv1.Deployment {
 	container.Ports = append(container.Ports,
 		corev1.ContainerPort{
 			Name:          "http-health",
-			ContainerPort: handler.DefaultHealthCheckPort,
+			ContainerPort: handler.DefaultProbeCheckPort,
 		},
 	)
 	container.LivenessProbe = &corev1.Probe{
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Path:   "/healthz",
-				Port:   intstr.FromInt(handler.DefaultHealthCheckPort),
+				Port:   intstr.FromInt(handler.DefaultProbeCheckPort),
 				Scheme: corev1.URISchemeHTTP,
 			},
 		},

--- a/test/test_images/probe_helper/main.go
+++ b/test/test_images/probe_helper/main.go
@@ -154,7 +154,7 @@ func main() {
 		cloudSchedulerSourcePeriod: env.CloudSchedulerSourcePeriod,
 		defaultTimeoutDuration:     env.DefaultTimeoutDuration,
 		maxTimeoutDuration:         env.MaxTimeoutDuration,
-		healthChecker: &healthChecker{
+		probeChecker: &probeChecker{
 			maxStaleDuration: env.MaxStaleDuration,
 		},
 	}

--- a/test/test_images/probe_helper/probe_helper_test.go
+++ b/test/test_images/probe_helper/probe_helper_test.go
@@ -566,18 +566,18 @@ func makeProbeHelper(ctx context.Context, t *testing.T, group *errgroup.Group) m
 func assertProbeCheckResult(t *testing.T, url string, ok bool) {
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		t.Fatalf("Failed to create probe check request: %v", err)
+		t.Fatal("Failed to create probe check request:", err)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		t.Logf("Failed to execute probe check: %v", err)
+		t.Log("Failed to execute probe check:", err)
 		if ok {
 			t.Errorf("probe check result ok got=%v, want=%v", !ok, ok)
 		}
 		return
 	}
 	if ok != (resp.StatusCode == http.StatusOK) {
-		t.Logf("Got probe check status code: %v", resp.StatusCode)
+		t.Log("Got probe check status code:", resp.StatusCode)
 		t.Errorf("probe check result ok got=%v, want=%v", !ok, ok)
 	}
 }

--- a/test/test_images/probe_helper/probe_helper_test.go
+++ b/test/test_images/probe_helper/probe_helper_test.go
@@ -485,10 +485,10 @@ func TestProbeHelper(t *testing.T) {
 }
 
 type makeProbeHelperReturn struct {
-	probeHelper    *ProbeHelper
-	probeURL       string
-	healthCheckURL string
-	cleanup        func()
+	probeHelper   *ProbeHelper
+	probeURL      string
+	probeCheckURL string
+	cleanup       func()
 }
 
 func makeProbeHelper(ctx context.Context, t *testing.T, group *errgroup.Group) makeProbeHelperReturn {
@@ -505,7 +505,7 @@ func makeProbeHelper(ctx context.Context, t *testing.T, group *errgroup.Group) m
 	}
 	probePort := probeListener.Addr().(*net.TCPAddr).Port
 	probeURL := fmt.Sprintf("http://localhost:%d", probePort)
-	healthCheckerURL := fmt.Sprintf("http://localhost:%d/healthz", receiverPort)
+	probeCheckURL := fmt.Sprintf("http://localhost:%d/healthz", receiverPort)
 
 	// Set up the resources for testing the CloudPubSubSource.
 	pubsubClient, closePubsub := testPubsubClient(ctx, t, testProjectID)
@@ -548,14 +548,14 @@ func makeProbeHelper(ctx context.Context, t *testing.T, group *errgroup.Group) m
 		cloudSchedulerSourcePeriod: time.Minute,
 		defaultTimeoutDuration:     2 * time.Minute,
 		maxTimeoutDuration:         30 * time.Minute,
-		healthChecker: &healthChecker{
+		probeChecker: &probeChecker{
 			maxStaleDuration: time.Second,
 		},
 	}
 	return makeProbeHelperReturn{
-		probeHelper:    ph,
-		probeURL:       probeURL,
-		healthCheckURL: healthCheckerURL,
+		probeHelper:   ph,
+		probeURL:      probeURL,
+		probeCheckURL: probeCheckURL,
 		cleanup: func() {
 			closeStorage()
 			closePubsub()
@@ -563,22 +563,22 @@ func makeProbeHelper(ctx context.Context, t *testing.T, group *errgroup.Group) m
 	}
 }
 
-func assertHealthCheckResult(t *testing.T, url string, ok bool) {
+func assertProbeCheckResult(t *testing.T, url string, ok bool) {
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		t.Fatalf("Failed to create health check request: %v", err)
+		t.Fatalf("Failed to create probe check request: %v", err)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		t.Logf("Failed to execute health check: %v", err)
+		t.Logf("Failed to execute probe check: %v", err)
 		if ok {
-			t.Errorf("health check result ok got=%v, want=%v", !ok, ok)
+			t.Errorf("probe check result ok got=%v, want=%v", !ok, ok)
 		}
 		return
 	}
 	if ok != (resp.StatusCode == http.StatusOK) {
-		t.Logf("Got health check status code: %v", resp.StatusCode)
-		t.Errorf("health check result ok got=%v, want=%v", !ok, ok)
+		t.Logf("Got probe check status code: %v", resp.StatusCode)
+		t.Errorf("probe check result ok got=%v, want=%v", !ok, ok)
 	}
 }
 
@@ -600,14 +600,14 @@ func TestProbeHelperHealth(t *testing.T) {
 	phr := makeProbeHelper(ctx, t, group)
 	go phr.probeHelper.run(ctx)
 
-	// Make sure the health checker is up.
+	// Make sure the probe checker is up.
 	time.Sleep(500 * time.Millisecond)
-	assertHealthCheckResult(t, phr.healthCheckURL, true)
+	assertProbeCheckResult(t, phr.probeCheckURL, true)
 
 	// Guarantee that it has been long enough that the stale duration has been reached. This will cause
-	// the health checker's result to be unhealthy.
-	time.Sleep(2 * phr.probeHelper.healthChecker.maxStaleDuration)
-	assertHealthCheckResult(t, phr.healthCheckURL, false)
+	// the probe checker's result to be unhealthy.
+	time.Sleep(2 * phr.probeHelper.probeChecker.maxStaleDuration)
+	assertProbeCheckResult(t, phr.probeCheckURL, false)
 
 	// Cancel gracefully to avoid logger panic if parent goroutine terminates.
 	phr.cleanup()


### PR DESCRIPTION
Fixes #
related #1862
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-  It is suggested to not "health check", and provided preferred terms: check, confidence check, initial check, readiness check. However, no preferred terms are close to the meaning of the "health check" here. As the "health check" is connecting to the readiness probe and liveness probe in the Pod, change the name to be probe check.
- 
_

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
