### PR TITLE
Enable conformance tests

### DIFF
--- a/test/e2e-conformance-tests.sh
+++ b/test/e2e-conformance-tests.sh
@@ -16,9 +16,6 @@
 # Script entry point.
 source $(dirname "$0")/e2e-secret-tests.sh
 
-# TODO: https://github.com/google/knative-gcp/issues/1932. Until then,
-# temporarily disable conformance tests.
-SKIP_TESTS="true"
 if [ "${SKIP_TESTS:-}" == "true" ]; then
   echo "**************************************"
   echo "***         TESTS SKIPPED          ***"


### PR DESCRIPTION
Fixes #1932 

Nightly eventing YAML now includes the MT broker again since merging https://github.com/knative/eventing/pull/4546, so conformance tests should work after merging https://github.com/knative/hack/pull/26

## Proposed Changes

- Enable conformance tests.