### PR TITLE
Use K_GCP_AUTH_TYPE to differentiate authentication mode

### DIFF
--- a/pkg/apis/intevents/v1alpha1/brokercell_lifecycle.go
+++ b/pkg/apis/intevents/v1alpha1/brokercell_lifecycle.go
@@ -87,6 +87,10 @@ func (bs *BrokerCellStatus) MarkIngressFailed(reason, format string, args ...int
 	brokerCellCondSet.Manage(bs).MarkFalse(BrokerCellConditionIngress, reason, format, args...)
 }
 
+func (bs *BrokerCellStatus) MarkIngressUnknown(reason, format string, args ...interface{}) {
+	brokerCellCondSet.Manage(bs).MarkUnknown(BrokerCellConditionIngress, reason, format, args...)
+}
+
 // PropagateFanoutAvailability uses the availability of the provided Deployment
 // to determine if BrokerCellConditionFanout should be marked as true or
 // false.

--- a/pkg/apis/intevents/v1alpha1/brokercell_lifecycle_test.go
+++ b/pkg/apis/intevents/v1alpha1/brokercell_lifecycle_test.go
@@ -402,11 +402,14 @@ func TestMarkBrokerCellStatus(t *testing.T) {
 			if test.wantType != "" {
 				gotConditionStatus := test.s.Status
 				for _, cd := range gotConditionStatus.Conditions {
-					if cd.Type == test.wantType &&
-						cd.Status != test.wantCondition {
+					if cd.Type == test.wantType {
+						if cd.Status == test.wantCondition {
+							return
+						}
 						t.Errorf("unexpected condition status for %v: want %v, got %v", test.wantType, test.wantCondition, cd.Status)
 					}
 				}
+				t.Errorf("didn't see the expected condition: %v", test.wantType)
 			}
 		})
 	}

--- a/pkg/apis/intevents/v1alpha1/brokercell_lifecycle_test.go
+++ b/pkg/apis/intevents/v1alpha1/brokercell_lifecycle_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -337,7 +336,7 @@ func TestMarkBrokerCellStatus(t *testing.T) {
 		wantType      apis.ConditionType
 		wantCondition corev1.ConditionStatus
 	}{{
-		name: fmt.Sprintf("mark %s unknown", string(BrokerCellConditionIngress)),
+		name: "mark IngressReady unknown",
 		s: func() *BrokerCellStatus {
 			s := &BrokerCell{}
 			s.Status.InitializeConditions()
@@ -347,7 +346,7 @@ func TestMarkBrokerCellStatus(t *testing.T) {
 		wantType:      BrokerCellConditionIngress,
 		wantCondition: corev1.ConditionUnknown,
 	}, {}, {
-		name: fmt.Sprintf("mark %s false", string(BrokerCellConditionIngress)),
+		name: "mark IngressReady false",
 		s: func() *BrokerCellStatus {
 			s := &BrokerCell{}
 			s.Status.InitializeConditions()
@@ -357,7 +356,7 @@ func TestMarkBrokerCellStatus(t *testing.T) {
 		wantType:      BrokerCellConditionIngress,
 		wantCondition: corev1.ConditionFalse,
 	}, {
-		name: fmt.Sprintf("mark %s unknown", string(BrokerCellConditionFanout)),
+		name: "mark FanoutReady unknown",
 		s: func() *BrokerCellStatus {
 			s := &BrokerCell{}
 			s.Status.InitializeConditions()
@@ -367,7 +366,7 @@ func TestMarkBrokerCellStatus(t *testing.T) {
 		wantType:      BrokerCellConditionFanout,
 		wantCondition: corev1.ConditionUnknown,
 	}, {
-		name: fmt.Sprintf("mark %s false", string(BrokerCellConditionFanout)),
+		name: "mark FanoutReady false",
 		s: func() *BrokerCellStatus {
 			s := &BrokerCell{}
 			s.Status.InitializeConditions()
@@ -377,7 +376,7 @@ func TestMarkBrokerCellStatus(t *testing.T) {
 		wantType:      BrokerCellConditionFanout,
 		wantCondition: corev1.ConditionFalse,
 	}, {
-		name: fmt.Sprintf("mark %s unknown", string(BrokerCellConditionRetry)),
+		name: "mark RetryReady unknown",
 		s: func() *BrokerCellStatus {
 			s := &BrokerCell{}
 			s.Status.InitializeConditions()
@@ -387,7 +386,7 @@ func TestMarkBrokerCellStatus(t *testing.T) {
 		wantType:      BrokerCellConditionRetry,
 		wantCondition: corev1.ConditionUnknown,
 	}, {
-		name: fmt.Sprintf("mark %s false", string(BrokerCellConditionRetry)),
+		name: "mark RetryReady false",
 		s: func() *BrokerCellStatus {
 			s := &BrokerCell{}
 			s.Status.InitializeConditions()

--- a/pkg/apis/intevents/v1alpha1/brokercell_lifecycle_test.go
+++ b/pkg/apis/intevents/v1alpha1/brokercell_lifecycle_test.go
@@ -409,7 +409,7 @@ func TestMarkBrokerCellStatus(t *testing.T) {
 						t.Errorf("unexpected condition status for %v: want %v, got %v", test.wantType, test.wantCondition, cd.Status)
 					}
 				}
-				t.Errorf("didn't see the expected condition: %v", test.wantType)
+				t.Error("didn't see the expected condition: ", test.wantType)
 			}
 		})
 	}

--- a/pkg/apis/intevents/v1alpha1/brokercell_lifecycle_test.go
+++ b/pkg/apis/intevents/v1alpha1/brokercell_lifecycle_test.go
@@ -328,3 +328,86 @@ func TestBrokerCellConditionStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestMarkBrokerCellStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		s             *BrokerCellStatus
+		wantType      apis.ConditionType
+		wantCondition corev1.ConditionStatus
+	}{{
+		name: "mark ingressReady unknown",
+		s: func() *BrokerCellStatus {
+			s := &BrokerCell{}
+			s.Status.InitializeConditions()
+			s.Status.MarkIngressUnknown("test", "the status of ingressReady is unknown")
+			return &s.Status
+		}(),
+		wantType:      BrokerCellConditionIngress,
+		wantCondition: corev1.ConditionUnknown,
+	}, {}, {
+		name: "mark ingressReady false",
+		s: func() *BrokerCellStatus {
+			s := &BrokerCell{}
+			s.Status.InitializeConditions()
+			s.Status.MarkIngressFailed("test", "the status of ingressReady is false")
+			return &s.Status
+		}(),
+		wantType:      BrokerCellConditionIngress,
+		wantCondition: corev1.ConditionFalse,
+	}, {
+		name: "mark fanoutReady unknown",
+		s: func() *BrokerCellStatus {
+			s := &BrokerCell{}
+			s.Status.InitializeConditions()
+			s.Status.MarkFanoutUnknown("test", "the status of fanoutReady is unknown")
+			return &s.Status
+		}(),
+		wantType:      BrokerCellConditionFanout,
+		wantCondition: corev1.ConditionUnknown,
+	}, {
+		name: "mark fanoutReady false",
+		s: func() *BrokerCellStatus {
+			s := &BrokerCell{}
+			s.Status.InitializeConditions()
+			s.Status.MarkFanoutFailed("test", "the status of fanoutReady is false")
+			return &s.Status
+		}(),
+		wantType:      BrokerCellConditionFanout,
+		wantCondition: corev1.ConditionFalse,
+	}, {
+		name: "mark retryReady unknown",
+		s: func() *BrokerCellStatus {
+			s := &BrokerCell{}
+			s.Status.InitializeConditions()
+			s.Status.MarkRetryUnknown("test", "the status of retryReady is unknown")
+			return &s.Status
+		}(),
+		wantType:      BrokerCellConditionRetry,
+		wantCondition: corev1.ConditionUnknown,
+	}, {
+		name: "mark retryReady false",
+		s: func() *BrokerCellStatus {
+			s := &BrokerCell{}
+			s.Status.InitializeConditions()
+			s.Status.MarkRetryFailed("test", "the status of retryReady is false")
+			return &s.Status
+		}(),
+		wantType:      BrokerCellConditionRetry,
+		wantCondition: corev1.ConditionFalse,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.wantType != "" {
+				gotConditionStatus := test.s.Status
+				for _, cd := range gotConditionStatus.Conditions {
+					if cd.Type == test.wantType &&
+						cd.Status != test.wantCondition {
+						t.Errorf("unexpected condition status for %v: want %v, got %v", test.wantType, test.wantCondition, cd.Status)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/apis/intevents/v1alpha1/brokercell_lifecycle_test.go
+++ b/pkg/apis/intevents/v1alpha1/brokercell_lifecycle_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -336,7 +337,7 @@ func TestMarkBrokerCellStatus(t *testing.T) {
 		wantType      apis.ConditionType
 		wantCondition corev1.ConditionStatus
 	}{{
-		name: "mark ingressReady unknown",
+		name: fmt.Sprintf("mark %s unknown", string(BrokerCellConditionIngress)),
 		s: func() *BrokerCellStatus {
 			s := &BrokerCell{}
 			s.Status.InitializeConditions()
@@ -346,7 +347,7 @@ func TestMarkBrokerCellStatus(t *testing.T) {
 		wantType:      BrokerCellConditionIngress,
 		wantCondition: corev1.ConditionUnknown,
 	}, {}, {
-		name: "mark ingressReady false",
+		name: fmt.Sprintf("mark %s false", string(BrokerCellConditionIngress)),
 		s: func() *BrokerCellStatus {
 			s := &BrokerCell{}
 			s.Status.InitializeConditions()
@@ -356,7 +357,7 @@ func TestMarkBrokerCellStatus(t *testing.T) {
 		wantType:      BrokerCellConditionIngress,
 		wantCondition: corev1.ConditionFalse,
 	}, {
-		name: "mark fanoutReady unknown",
+		name: fmt.Sprintf("mark %s unknown", string(BrokerCellConditionFanout)),
 		s: func() *BrokerCellStatus {
 			s := &BrokerCell{}
 			s.Status.InitializeConditions()
@@ -366,7 +367,7 @@ func TestMarkBrokerCellStatus(t *testing.T) {
 		wantType:      BrokerCellConditionFanout,
 		wantCondition: corev1.ConditionUnknown,
 	}, {
-		name: "mark fanoutReady false",
+		name: fmt.Sprintf("mark %s false", string(BrokerCellConditionFanout)),
 		s: func() *BrokerCellStatus {
 			s := &BrokerCell{}
 			s.Status.InitializeConditions()
@@ -376,7 +377,7 @@ func TestMarkBrokerCellStatus(t *testing.T) {
 		wantType:      BrokerCellConditionFanout,
 		wantCondition: corev1.ConditionFalse,
 	}, {
-		name: "mark retryReady unknown",
+		name: fmt.Sprintf("mark %s unknown", string(BrokerCellConditionRetry)),
 		s: func() *BrokerCellStatus {
 			s := &BrokerCell{}
 			s.Status.InitializeConditions()
@@ -386,7 +387,7 @@ func TestMarkBrokerCellStatus(t *testing.T) {
 		wantType:      BrokerCellConditionRetry,
 		wantCondition: corev1.ConditionUnknown,
 	}, {
-		name: "mark retryReady false",
+		name: fmt.Sprintf("mark %s false", string(BrokerCellConditionRetry)),
 		s: func() *BrokerCellStatus {
 			s := &BrokerCell{}
 			s.Status.InitializeConditions()

--- a/pkg/reconciler/brokercell/brokercell.go
+++ b/pkg/reconciler/brokercell/brokercell.go
@@ -245,7 +245,7 @@ func (r *Reconciler) delete(ctx context.Context, bc *intv1alpha1.BrokerCell) pkg
 	return pkgreconciler.NewEvent(corev1.EventTypeNormal, "BrokerCellGarbageCollected", "BrokerCell garbage collected: \"%s/%s\"", bc.Namespace, bc.Name)
 }
 
-func (r *Reconciler) makeIngressArgs(bc *intv1alpha1.BrokerCell, authType authcheck.AuthTypes) resources.IngressArgs {
+func (r *Reconciler) makeIngressArgs(bc *intv1alpha1.BrokerCell, authType authcheck.AuthType) resources.IngressArgs {
 	return resources.IngressArgs{
 		Args: resources.Args{
 			ComponentName:      resources.IngressName,
@@ -287,7 +287,7 @@ func (r *Reconciler) makeIngressHPAArgs(bc *intv1alpha1.BrokerCell) resources.Au
 	}
 }
 
-func (r *Reconciler) makeFanoutArgs(bc *intv1alpha1.BrokerCell, authType authcheck.AuthTypes) resources.FanoutArgs {
+func (r *Reconciler) makeFanoutArgs(bc *intv1alpha1.BrokerCell, authType authcheck.AuthType) resources.FanoutArgs {
 	return resources.FanoutArgs{
 		Args: resources.Args{
 			ComponentName:      resources.FanoutName,
@@ -317,7 +317,7 @@ func (r *Reconciler) makeFanoutHPAArgs(bc *intv1alpha1.BrokerCell) resources.Aut
 	}
 }
 
-func (r *Reconciler) makeRetryArgs(bc *intv1alpha1.BrokerCell, authType authcheck.AuthTypes) resources.RetryArgs {
+func (r *Reconciler) makeRetryArgs(bc *intv1alpha1.BrokerCell, authType authcheck.AuthType) resources.RetryArgs {
 	return resources.RetryArgs{
 		Args: resources.Args{
 			ComponentName:      resources.RetryName,

--- a/pkg/reconciler/brokercell/brokercell.go
+++ b/pkg/reconciler/brokercell/brokercell.go
@@ -140,7 +140,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, bc *intv1alpha1.BrokerCe
 		return err
 	}
 
-	authType, err := authtype.GetAuthType(ctx, r.serviceAccountLister, r.secretLister, authtype.AuthTypeArgs{
+	authType, err := authtype.GetAuthTypeForBrokerCell(ctx, r.serviceAccountLister, r.secretLister, authtype.AuthTypeArgs{
 		Namespace:          bc.Namespace,
 		ServiceAccountName: authtype.BrokerServiceAccountName,
 		Secret:             authtype.BrokerSecret,
@@ -245,7 +245,7 @@ func (r *Reconciler) delete(ctx context.Context, bc *intv1alpha1.BrokerCell) pkg
 	return pkgreconciler.NewEvent(corev1.EventTypeNormal, "BrokerCellGarbageCollected", "BrokerCell garbage collected: \"%s/%s\"", bc.Namespace, bc.Name)
 }
 
-func (r *Reconciler) makeIngressArgs(bc *intv1alpha1.BrokerCell, authType string) resources.IngressArgs {
+func (r *Reconciler) makeIngressArgs(bc *intv1alpha1.BrokerCell, authType authtype.AuthTypes) resources.IngressArgs {
 	return resources.IngressArgs{
 		Args: resources.Args{
 			ComponentName:      resources.IngressName,
@@ -287,7 +287,7 @@ func (r *Reconciler) makeIngressHPAArgs(bc *intv1alpha1.BrokerCell) resources.Au
 	}
 }
 
-func (r *Reconciler) makeFanoutArgs(bc *intv1alpha1.BrokerCell, authType string) resources.FanoutArgs {
+func (r *Reconciler) makeFanoutArgs(bc *intv1alpha1.BrokerCell, authType authtype.AuthTypes) resources.FanoutArgs {
 	return resources.FanoutArgs{
 		Args: resources.Args{
 			ComponentName:      resources.FanoutName,
@@ -317,7 +317,7 @@ func (r *Reconciler) makeFanoutHPAArgs(bc *intv1alpha1.BrokerCell) resources.Aut
 	}
 }
 
-func (r *Reconciler) makeRetryArgs(bc *intv1alpha1.BrokerCell, authType string) resources.RetryArgs {
+func (r *Reconciler) makeRetryArgs(bc *intv1alpha1.BrokerCell, authType authtype.AuthTypes) resources.RetryArgs {
 	return resources.RetryArgs{
 		Args: resources.Args{
 			ComponentName:      resources.RetryName,

--- a/pkg/reconciler/brokercell/brokercell.go
+++ b/pkg/reconciler/brokercell/brokercell.go
@@ -43,7 +43,7 @@ import (
 	"github.com/google/knative-gcp/pkg/reconciler"
 	"github.com/google/knative-gcp/pkg/reconciler/brokercell/resources"
 	reconcilerutils "github.com/google/knative-gcp/pkg/reconciler/utils"
-	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
+	"github.com/google/knative-gcp/pkg/utils/authcheck"
 )
 
 type envConfig struct {
@@ -140,15 +140,15 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, bc *intv1alpha1.BrokerCe
 		return err
 	}
 
-	authType, err := authtype.GetAuthTypeForBrokerCell(ctx, r.serviceAccountLister, r.secretLister, authtype.AuthTypeArgs{
+	authType, err := authcheck.GetAuthTypeForBrokerCell(ctx, r.serviceAccountLister, r.secretLister, authcheck.AuthTypeArgs{
 		Namespace:          bc.Namespace,
-		ServiceAccountName: authtype.BrokerServiceAccountName,
-		Secret:             authtype.BrokerSecret,
+		ServiceAccountName: authcheck.BrokerServiceAccountName,
+		Secret:             authcheck.BrokerSecret,
 	})
 	if err != nil {
-		bc.Status.MarkIngressUnknown(authtype.AuthenticationCheckUnknownReason, err.Error())
-		bc.Status.MarkFanoutUnknown(authtype.AuthenticationCheckUnknownReason, err.Error())
-		bc.Status.MarkRetryUnknown(authtype.AuthenticationCheckUnknownReason, err.Error())
+		bc.Status.MarkIngressUnknown(authcheck.AuthenticationCheckUnknownReason, err.Error())
+		bc.Status.MarkFanoutUnknown(authcheck.AuthenticationCheckUnknownReason, err.Error())
+		bc.Status.MarkRetryUnknown(authcheck.AuthenticationCheckUnknownReason, err.Error())
 		logging.FromContext(ctx).Error("Error getting authType", zap.Any("namespace", bc.Namespace), zap.Any("name", bc.Name), zap.Error(err))
 		return err
 	}
@@ -245,7 +245,7 @@ func (r *Reconciler) delete(ctx context.Context, bc *intv1alpha1.BrokerCell) pkg
 	return pkgreconciler.NewEvent(corev1.EventTypeNormal, "BrokerCellGarbageCollected", "BrokerCell garbage collected: \"%s/%s\"", bc.Namespace, bc.Name)
 }
 
-func (r *Reconciler) makeIngressArgs(bc *intv1alpha1.BrokerCell, authType authtype.AuthTypes) resources.IngressArgs {
+func (r *Reconciler) makeIngressArgs(bc *intv1alpha1.BrokerCell, authType authcheck.AuthTypes) resources.IngressArgs {
 	return resources.IngressArgs{
 		Args: resources.Args{
 			ComponentName:      resources.IngressName,
@@ -287,7 +287,7 @@ func (r *Reconciler) makeIngressHPAArgs(bc *intv1alpha1.BrokerCell) resources.Au
 	}
 }
 
-func (r *Reconciler) makeFanoutArgs(bc *intv1alpha1.BrokerCell, authType authtype.AuthTypes) resources.FanoutArgs {
+func (r *Reconciler) makeFanoutArgs(bc *intv1alpha1.BrokerCell, authType authcheck.AuthTypes) resources.FanoutArgs {
 	return resources.FanoutArgs{
 		Args: resources.Args{
 			ComponentName:      resources.FanoutName,
@@ -317,7 +317,7 @@ func (r *Reconciler) makeFanoutHPAArgs(bc *intv1alpha1.BrokerCell) resources.Aut
 	}
 }
 
-func (r *Reconciler) makeRetryArgs(bc *intv1alpha1.BrokerCell, authType authtype.AuthTypes) resources.RetryArgs {
+func (r *Reconciler) makeRetryArgs(bc *intv1alpha1.BrokerCell, authType authcheck.AuthTypes) resources.RetryArgs {
 	return resources.RetryArgs{
 		Args: resources.Args{
 			ComponentName:      resources.RetryName,

--- a/pkg/reconciler/brokercell/brokercell_test.go
+++ b/pkg/reconciler/brokercell/brokercell_test.go
@@ -961,14 +961,16 @@ func TestAllCases(t *testing.T) {
 		setReconcilerEnv()
 		base := reconciler.NewBase(ctx, controllerAgentName, cmw)
 		ls := listers{
-			brokerLister:     testingListers.GetBrokerLister(),
-			hpaLister:        testingListers.GetHPALister(),
-			triggerLister:    testingListers.GetTriggerLister(),
-			configMapLister:  testingListers.GetConfigMapLister(),
-			serviceLister:    testingListers.GetK8sServiceLister(),
-			endpointsLister:  testingListers.GetEndpointsLister(),
-			deploymentLister: testingListers.GetDeploymentLister(),
-			podLister:        testingListers.GetPodLister(),
+			brokerLister:         testingListers.GetBrokerLister(),
+			hpaLister:            testingListers.GetHPALister(),
+			triggerLister:        testingListers.GetTriggerLister(),
+			configMapLister:      testingListers.GetConfigMapLister(),
+			secretLister:         testingListers.GetSecretLister(),
+			serviceAccountLister: testingListers.GetServiceAccountLister(),
+			serviceLister:        testingListers.GetK8sServiceLister(),
+			endpointsLister:      testingListers.GetEndpointsLister(),
+			deploymentLister:     testingListers.GetDeploymentLister(),
+			podLister:            testingListers.GetPodLister(),
 		}
 
 		r, err := NewReconciler(base, ls)

--- a/pkg/reconciler/brokercell/brokercell_test.go
+++ b/pkg/reconciler/brokercell/brokercell_test.go
@@ -96,7 +96,7 @@ var (
 	configmapUpdateFailedEvent    = Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for update configmaps")
 	configmapCreatedEvent         = Eventf(corev1.EventTypeNormal, "ConfigMapCreated", "Created configmap testnamespace/test-brokercell-brokercell-broker-targets")
 	configmapUpdatedEvent         = Eventf(corev1.EventTypeNormal, "ConfigMapUpdated", "Updated configmap testnamespace/test-brokercell-brokercell-broker-targets")
-	authTypeEvent                 = Eventf(corev1.EventTypeWarning, "InternalError", "authentication is not configured, Secret doesn't present, ServiceAccountName doesn't have required annotation")
+	authTypeEvent                 = Eventf(corev1.EventTypeWarning, "InternalError", "authentication is not configured, when checking Kubernetes Service Account broker, got error: can't find Kubernetes Service Account broker, when checking Kubernetes Secret google-broker-key, got error: can't find Kubernetes Secret google-broker-key")
 )
 
 func init() {
@@ -176,9 +176,9 @@ func TestAllCases(t *testing.T) {
 				Object: NewBrokerCell(brokerCellName, authtype.ControlPlaneNamespace,
 					WithInitBrokerCellConditions,
 					WithTargetsCofigReady(),
-					WithBrokerCellIngressUnknown(authtype.AuthenticationCheckUnknownReason, `authentication is not configured, Secret doesn't present, ServiceAccountName doesn't have required annotation`),
-					WithBrokerCellFanoutUnknown(authtype.AuthenticationCheckUnknownReason, `authentication is not configured, Secret doesn't present, ServiceAccountName doesn't have required annotation`),
-					WithBrokerCellRetryUnknown(authtype.AuthenticationCheckUnknownReason, `authentication is not configured, Secret doesn't present, ServiceAccountName doesn't have required annotation`),
+					WithBrokerCellIngressUnknown(authtype.AuthenticationCheckUnknownReason, `authentication is not configured, when checking Kubernetes Service Account broker, got error: can't find Kubernetes Service Account broker, when checking Kubernetes Secret google-broker-key, got error: can't find Kubernetes Secret google-broker-key`),
+					WithBrokerCellFanoutUnknown(authtype.AuthenticationCheckUnknownReason, `authentication is not configured, when checking Kubernetes Service Account broker, got error: can't find Kubernetes Service Account broker, when checking Kubernetes Secret google-broker-key, got error: can't find Kubernetes Secret google-broker-key`),
+					WithBrokerCellRetryUnknown(authtype.AuthenticationCheckUnknownReason, `authentication is not configured, when checking Kubernetes Service Account broker, got error: can't find Kubernetes Service Account broker, when checking Kubernetes Secret google-broker-key, got error: can't find Kubernetes Secret google-broker-key`),
 					WithBrokerCellSetDefaults,
 				),
 			}},

--- a/pkg/reconciler/brokercell/brokercell_test.go
+++ b/pkg/reconciler/brokercell/brokercell_test.go
@@ -43,7 +43,7 @@ import (
 	"github.com/google/knative-gcp/pkg/reconciler/brokercell/resources"
 	"github.com/google/knative-gcp/pkg/reconciler/brokercell/testingdata"
 	. "github.com/google/knative-gcp/pkg/reconciler/testing"
-	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
+	"github.com/google/knative-gcp/pkg/utils/authcheck"
 )
 
 const (
@@ -55,7 +55,7 @@ const (
 
 var (
 	testKey     = fmt.Sprintf("%s/%s", testNS, brokerCellName)
-	testKeyAuth = fmt.Sprintf("%s/%s", authtype.ControlPlaneNamespace, brokerCellName)
+	testKeyAuth = fmt.Sprintf("%s/%s", authcheck.ControlPlaneNamespace, brokerCellName)
 
 	creatorAnnotation       = map[string]string{"internal.events.cloud.google.com/creator": "googlecloud"}
 	restartedTimeAnnotation = map[string]string{
@@ -169,16 +169,16 @@ func TestAllCases(t *testing.T) {
 			Name: "authType error",
 			Key:  testKeyAuth,
 			Objects: []runtime.Object{
-				NewBrokerCell(brokerCellName, authtype.ControlPlaneNamespace, WithBrokerCellSetDefaults),
-				testingdata.EmptyConfig(t, NewBrokerCell(brokerCellName, authtype.ControlPlaneNamespace, WithBrokerCellSetDefaults)),
+				NewBrokerCell(brokerCellName, authcheck.ControlPlaneNamespace, WithBrokerCellSetDefaults),
+				testingdata.EmptyConfig(t, NewBrokerCell(brokerCellName, authcheck.ControlPlaneNamespace, WithBrokerCellSetDefaults)),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: NewBrokerCell(brokerCellName, authtype.ControlPlaneNamespace,
+				Object: NewBrokerCell(brokerCellName, authcheck.ControlPlaneNamespace,
 					WithInitBrokerCellConditions,
 					WithTargetsCofigReady(),
-					WithBrokerCellIngressUnknown(authtype.AuthenticationCheckUnknownReason, `authentication is not configured, when checking Kubernetes Service Account broker, got error: can't find Kubernetes Service Account broker, when checking Kubernetes Secret google-broker-key, got error: can't find Kubernetes Secret google-broker-key`),
-					WithBrokerCellFanoutUnknown(authtype.AuthenticationCheckUnknownReason, `authentication is not configured, when checking Kubernetes Service Account broker, got error: can't find Kubernetes Service Account broker, when checking Kubernetes Secret google-broker-key, got error: can't find Kubernetes Secret google-broker-key`),
-					WithBrokerCellRetryUnknown(authtype.AuthenticationCheckUnknownReason, `authentication is not configured, when checking Kubernetes Service Account broker, got error: can't find Kubernetes Service Account broker, when checking Kubernetes Secret google-broker-key, got error: can't find Kubernetes Secret google-broker-key`),
+					WithBrokerCellIngressUnknown(authcheck.AuthenticationCheckUnknownReason, `authentication is not configured, when checking Kubernetes Service Account broker, got error: can't find Kubernetes Service Account broker, when checking Kubernetes Secret google-broker-key, got error: can't find Kubernetes Secret google-broker-key`),
+					WithBrokerCellFanoutUnknown(authcheck.AuthenticationCheckUnknownReason, `authentication is not configured, when checking Kubernetes Service Account broker, got error: can't find Kubernetes Service Account broker, when checking Kubernetes Secret google-broker-key, got error: can't find Kubernetes Secret google-broker-key`),
+					WithBrokerCellRetryUnknown(authcheck.AuthenticationCheckUnknownReason, `authentication is not configured, when checking Kubernetes Service Account broker, got error: can't find Kubernetes Service Account broker, when checking Kubernetes Secret google-broker-key, got error: can't find Kubernetes Secret google-broker-key`),
 					WithBrokerCellSetDefaults,
 				),
 			}},

--- a/pkg/reconciler/brokercell/controller.go
+++ b/pkg/reconciler/brokercell/controller.go
@@ -35,15 +35,20 @@ import (
 	"github.com/google/knative-gcp/pkg/reconciler"
 	brokerresources "github.com/google/knative-gcp/pkg/reconciler/broker/resources"
 	"github.com/google/knative-gcp/pkg/reconciler/brokercell/resources"
+	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
 	customresourceutil "github.com/google/knative-gcp/pkg/utils/customresource"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
+
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
 	configmapinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap"
 	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
 	podinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/pod"
+	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
+	serviceaccountinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
@@ -70,17 +75,21 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
+	brokercellinformer := brokercellinformer.Get(ctx)
+
 	logger := logging.FromContext(ctx)
 
 	ls := listers{
-		brokerLister:     brokerinformer.Get(ctx).Lister(),
-		hpaLister:        hpainformer.Get(ctx).Lister(),
-		triggerLister:    triggerinformer.Get(ctx).Lister(),
-		configMapLister:  configmapinformer.Get(ctx).Lister(),
-		serviceLister:    serviceinformer.Get(ctx).Lister(),
-		endpointsLister:  endpointsinformer.Get(ctx).Lister(),
-		deploymentLister: deploymentinformer.Get(ctx).Lister(),
-		podLister:        podinformer.Get(ctx).Lister(),
+		brokerLister:         brokerinformer.Get(ctx).Lister(),
+		hpaLister:            hpainformer.Get(ctx).Lister(),
+		triggerLister:        triggerinformer.Get(ctx).Lister(),
+		configMapLister:      configmapinformer.Get(ctx).Lister(),
+		secretLister:         secretinformer.Get(ctx).Lister(),
+		serviceAccountLister: serviceaccountinformer.Get(ctx).Lister(),
+		serviceLister:        serviceinformer.Get(ctx).Lister(),
+		endpointsLister:      endpointsinformer.Get(ctx).Lister(),
+		deploymentLister:     deploymentinformer.Get(ctx).Lister(),
+		podLister:            podinformer.Get(ctx).Lister(),
 	}
 
 	base := reconciler.NewBase(ctx, controllerAgentName, cmw)
@@ -100,7 +109,8 @@ func NewController(
 
 	logger.Info("Setting up event handlers.")
 
-	brokercellinformer.Get(ctx).Informer().AddEventHandlerWithResyncPeriod(controller.HandleAll(impl.Enqueue), reconciler.DefaultResyncPeriod)
+	brokercellinformer.Informer().AddEventHandlerWithResyncPeriod(controller.HandleAll(impl.Enqueue), reconciler.DefaultResyncPeriod)
+	brokercellLister := brokercellinformer.Lister()
 
 	// Watch brokers and triggers to invoke configmap update immediately.
 	brokerinformer.Get(ctx).Informer().AddEventHandler(controller.HandleAll(
@@ -132,6 +142,19 @@ func NewController(
 	// 4. Watch the broker targets configmap.
 	configmapinformer.Get(ctx).Informer().AddEventHandler(handleResourceUpdate(impl))
 
+	// Watch componets which are not created by brokercell, but affect broker data plane.
+	// 1. Watch broker data plane's secret,
+	// if the filtered secret resource changes, enqueue brokercells from the same namespace.
+	secretinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterWithNameAndNamespace(authtype.ControlPlaneNamespace, authtype.BrokerSecret.Name),
+		Handler:    authtype.EnqueueBrokerCell(impl, brokercellLister),
+	})
+	// 2. Watch broker data plane's k8s service account,
+	// if the filtered k8s service account resource changes, enqueue brokercells from the same namespace.
+	serviceaccountinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterWithNameAndNamespace(authtype.ControlPlaneNamespace, authtype.BrokerServiceAccountName),
+		Handler:    authtype.EnqueueBrokerCell(impl, brokercellLister),
+	})
 	return impl
 }
 

--- a/pkg/reconciler/brokercell/controller.go
+++ b/pkg/reconciler/brokercell/controller.go
@@ -35,7 +35,7 @@ import (
 	"github.com/google/knative-gcp/pkg/reconciler"
 	brokerresources "github.com/google/knative-gcp/pkg/reconciler/broker/resources"
 	"github.com/google/knative-gcp/pkg/reconciler/brokercell/resources"
-	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
+	"github.com/google/knative-gcp/pkg/utils/authcheck"
 	customresourceutil "github.com/google/knative-gcp/pkg/utils/customresource"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -146,14 +146,14 @@ func NewController(
 	// 1. Watch broker data plane's secret,
 	// if the filtered secret resource changes, enqueue brokercells from the same namespace.
 	secretinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: filterWithNamespace(authtype.ControlPlaneNamespace),
-		Handler:    authtype.EnqueueBrokerCell(impl, brokerCellLister),
+		FilterFunc: filterWithNamespace(authcheck.ControlPlaneNamespace),
+		Handler:    authcheck.EnqueueBrokerCell(impl, brokerCellLister),
 	})
 	// 2. Watch broker data plane's k8s service account,
 	// if the filtered k8s service account resource changes, enqueue brokercells from the same namespace.
 	serviceaccountinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: filterWithNamespace(authtype.ControlPlaneNamespace),
-		Handler:    authtype.EnqueueBrokerCell(impl, brokerCellLister),
+		FilterFunc: filterWithNamespace(authcheck.ControlPlaneNamespace),
+		Handler:    authcheck.EnqueueBrokerCell(impl, brokerCellLister),
 	})
 	return impl
 }

--- a/pkg/reconciler/brokercell/controller.go
+++ b/pkg/reconciler/brokercell/controller.go
@@ -75,7 +75,7 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
-	brokerCellinformer := brokercellinformer.Get(ctx)
+	brokerCellInformer := brokercellinformer.Get(ctx)
 
 	logger := logging.FromContext(ctx)
 
@@ -109,8 +109,8 @@ func NewController(
 
 	logger.Info("Setting up event handlers.")
 
-	brokerCellinformer.Informer().AddEventHandlerWithResyncPeriod(controller.HandleAll(impl.Enqueue), reconciler.DefaultResyncPeriod)
-	brokerCellLister := brokerCellinformer.Lister()
+	brokerCellInformer.Informer().AddEventHandlerWithResyncPeriod(controller.HandleAll(impl.Enqueue), reconciler.DefaultResyncPeriod)
+	brokerCellLister := brokerCellInformer.Lister()
 
 	// Watch brokers and triggers to invoke configmap update immediately.
 	brokerinformer.Get(ctx).Informer().AddEventHandler(controller.HandleAll(

--- a/pkg/reconciler/brokercell/controller_test.go
+++ b/pkg/reconciler/brokercell/controller_test.go
@@ -30,17 +30,20 @@ import (
 	"knative.dev/pkg/system"
 	tracingconfig "knative.dev/pkg/tracing/config"
 
-	// Fake injection informers
-	_ "github.com/google/knative-gcp/pkg/client/injection/informers/broker/v1beta1/broker/fake"
-	_ "github.com/google/knative-gcp/pkg/client/injection/informers/broker/v1beta1/trigger/fake"
-	_ "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1alpha1/brokercell/fake"
-	_ "github.com/google/knative-gcp/pkg/client/injection/kube/informers/autoscaling/v2beta2/horizontalpodautoscaler/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/conditions/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
+
+	// Fake injection informers
+	_ "github.com/google/knative-gcp/pkg/client/injection/informers/broker/v1beta1/broker/fake"
+	_ "github.com/google/knative-gcp/pkg/client/injection/informers/broker/v1beta1/trigger/fake"
+	_ "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1alpha1/brokercell/fake"
+	_ "github.com/google/knative-gcp/pkg/client/injection/kube/informers/autoscaling/v2beta2/horizontalpodautoscaler/fake"
 )
 
 func TestNew(t *testing.T) {

--- a/pkg/reconciler/brokercell/resources/args.go
+++ b/pkg/reconciler/brokercell/resources/args.go
@@ -60,6 +60,7 @@ type Args struct {
 	MemoryRequest      string
 	MemoryLimit        string
 	RolloutRestartTime string
+	AuthType           string
 }
 
 // IngressArgs are the arguments to create a Broker's ingress Deployment.

--- a/pkg/reconciler/brokercell/resources/args.go
+++ b/pkg/reconciler/brokercell/resources/args.go
@@ -22,6 +22,7 @@ import (
 	"knative.dev/pkg/kmeta"
 
 	intv1alpha1 "github.com/google/knative-gcp/pkg/apis/intevents/v1alpha1"
+	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
 )
 
 const (
@@ -60,7 +61,7 @@ type Args struct {
 	MemoryRequest      string
 	MemoryLimit        string
 	RolloutRestartTime string
-	AuthType           string
+	AuthType           authtype.AuthTypes
 }
 
 // IngressArgs are the arguments to create a Broker's ingress Deployment.

--- a/pkg/reconciler/brokercell/resources/args.go
+++ b/pkg/reconciler/brokercell/resources/args.go
@@ -61,7 +61,7 @@ type Args struct {
 	MemoryRequest      string
 	MemoryLimit        string
 	RolloutRestartTime string
-	AuthType           authcheck.AuthTypes
+	AuthType           authcheck.AuthType
 }
 
 // IngressArgs are the arguments to create a Broker's ingress Deployment.

--- a/pkg/reconciler/brokercell/resources/args.go
+++ b/pkg/reconciler/brokercell/resources/args.go
@@ -22,7 +22,7 @@ import (
 	"knative.dev/pkg/kmeta"
 
 	intv1alpha1 "github.com/google/knative-gcp/pkg/apis/intevents/v1alpha1"
-	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
+	"github.com/google/knative-gcp/pkg/utils/authcheck"
 )
 
 const (
@@ -61,7 +61,7 @@ type Args struct {
 	MemoryRequest      string
 	MemoryLimit        string
 	RolloutRestartTime string
-	AuthType           authtype.AuthTypes
+	AuthType           authcheck.AuthTypes
 }
 
 // IngressArgs are the arguments to create a Broker's ingress Deployment.

--- a/pkg/reconciler/brokercell/resources/deployments.go
+++ b/pkg/reconciler/brokercell/resources/deployments.go
@@ -218,7 +218,7 @@ func containerTemplate(args Args) corev1.Container {
 				Value: "knative.dev/internal/eventing",
 			}, {
 				Name:  "K_GCP_AUTH_TYPE",
-				Value: args.AuthType,
+				Value: string(args.AuthType),
 			},
 		},
 		Ports: []corev1.ContainerPort{

--- a/pkg/reconciler/brokercell/resources/deployments.go
+++ b/pkg/reconciler/brokercell/resources/deployments.go
@@ -216,6 +216,9 @@ func containerTemplate(args Args) corev1.Container {
 				// Used for StackDriver only.
 				Name:  "METRICS_DOMAIN",
 				Value: "knative.dev/internal/eventing",
+			}, {
+				Name:  "K_GCP_AUTH_TYPE",
+				Value: args.AuthType,
 			},
 		},
 		Ports: []corev1.ContainerPort{

--- a/pkg/reconciler/brokercell/testingdata/fanout_deployment.yaml
+++ b/pkg/reconciler/brokercell/testingdata/fanout_deployment.yaml
@@ -73,6 +73,8 @@ spec:
           value: config-observability
         - name: METRICS_DOMAIN
           value: knative.dev/internal/eventing
+        - name: K_GCP_AUTH_TYPE
+          value: "secret"
         - name: MAX_CONCURRENCY_PER_EVENT
           value: "100"
         volumeMounts:

--- a/pkg/reconciler/brokercell/testingdata/fanout_deployment_with_restart_annotation.yaml
+++ b/pkg/reconciler/brokercell/testingdata/fanout_deployment_with_restart_annotation.yaml
@@ -75,6 +75,8 @@ spec:
               value: config-observability
             - name: METRICS_DOMAIN
               value: knative.dev/internal/eventing
+            - name: K_GCP_AUTH_TYPE
+              value: "secret"
             - name: MAX_CONCURRENCY_PER_EVENT
               value: "100"
           volumeMounts:

--- a/pkg/reconciler/brokercell/testingdata/fanout_deployment_with_status.yaml
+++ b/pkg/reconciler/brokercell/testingdata/fanout_deployment_with_status.yaml
@@ -74,6 +74,8 @@ spec:
           value: config-observability
         - name: METRICS_DOMAIN
           value: knative.dev/internal/eventing
+        - name: K_GCP_AUTH_TYPE
+          value: "secret"
         - name: MAX_CONCURRENCY_PER_EVENT
           value: "100"
         volumeMounts:

--- a/pkg/reconciler/brokercell/testingdata/ingress_deployment.yaml
+++ b/pkg/reconciler/brokercell/testingdata/ingress_deployment.yaml
@@ -82,6 +82,8 @@ spec:
           value: config-observability
         - name: METRICS_DOMAIN
           value: knative.dev/internal/eventing
+        - name: K_GCP_AUTH_TYPE
+          value: "secret"
         - name: PORT
           value: "8080"
         # TODO(1804): remove this env variable when the feature is enabled by default.

--- a/pkg/reconciler/brokercell/testingdata/ingress_deployment_with_filtering_annotation.yaml
+++ b/pkg/reconciler/brokercell/testingdata/ingress_deployment_with_filtering_annotation.yaml
@@ -85,6 +85,8 @@ spec:
           value: config-observability
         - name: METRICS_DOMAIN
           value: knative.dev/internal/eventing
+        - name: K_GCP_AUTH_TYPE
+          value: "secret"
         - name: PORT
           value: "8080"
         # TODO(1804): remove this env variable when the feature is enabled by default.

--- a/pkg/reconciler/brokercell/testingdata/ingress_deployment_with_restart_annotation.yaml
+++ b/pkg/reconciler/brokercell/testingdata/ingress_deployment_with_restart_annotation.yaml
@@ -84,6 +84,8 @@ spec:
               value: config-observability
             - name: METRICS_DOMAIN
               value: knative.dev/internal/eventing
+            - name: K_GCP_AUTH_TYPE
+              value: "secret"
             - name: PORT
               value: "8080"
             # TODO(1804): remove this env variable when the feature is enabled by default.

--- a/pkg/reconciler/brokercell/testingdata/ingress_deployment_with_status.yaml
+++ b/pkg/reconciler/brokercell/testingdata/ingress_deployment_with_status.yaml
@@ -83,6 +83,8 @@ spec:
           value: config-observability
         - name: METRICS_DOMAIN
           value: knative.dev/internal/eventing
+        - name: K_GCP_AUTH_TYPE
+          value: "secret"
         - name: PORT
           value: "8080"
         # TODO(1804): remove this env variable when the feature is enabled by default.

--- a/pkg/reconciler/brokercell/testingdata/retry_deployment.yaml
+++ b/pkg/reconciler/brokercell/testingdata/retry_deployment.yaml
@@ -73,6 +73,8 @@ spec:
           value: config-observability
         - name: METRICS_DOMAIN
           value: knative.dev/internal/eventing
+        - name: K_GCP_AUTH_TYPE
+          value: "secret"
         volumeMounts:
         - name: broker-config
           mountPath: /var/run/cloud-run-events/broker

--- a/pkg/reconciler/brokercell/testingdata/retry_deployment_with_restart_annotation.yaml
+++ b/pkg/reconciler/brokercell/testingdata/retry_deployment_with_restart_annotation.yaml
@@ -75,6 +75,8 @@ spec:
               value: config-observability
             - name: METRICS_DOMAIN
               value: knative.dev/internal/eventing
+            - name: K_GCP_AUTH_TYPE
+              value: "secret"
           volumeMounts:
             - name: broker-config
               mountPath: /var/run/cloud-run-events/broker

--- a/pkg/reconciler/brokercell/testingdata/retry_deployment_with_status.yaml
+++ b/pkg/reconciler/brokercell/testingdata/retry_deployment_with_status.yaml
@@ -74,6 +74,8 @@ spec:
           value: config-observability
         - name: METRICS_DOMAIN
           value: knative.dev/internal/eventing
+        - name: K_GCP_AUTH_TYPE
+          value: "secret"
         volumeMounts:
         - name: broker-config
           mountPath: /var/run/cloud-run-events/broker

--- a/pkg/reconciler/events/build/controller.go
+++ b/pkg/reconciler/events/build/controller.go
@@ -89,5 +89,10 @@ func newController(
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
+	serviceAccountInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterControllerGK(v1.Kind("CloudBuildSource")),
+		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
+	})
+
 	return impl
 }

--- a/pkg/reconciler/intevents/pullsubscription/keda/controller.go
+++ b/pkg/reconciler/intevents/pullsubscription/keda/controller.go
@@ -131,7 +131,7 @@ func newController(
 	})
 
 	// Watch k8s service account, if a k8s service account resource changes, enqueue qualified pullsubscriptions from the same namespace.
-	serviceAccountInformer.Informer().AddEventHandler(authtype.EnqueuePullSubscriptions(impl, pullSubscriptionLister))
+	serviceAccountInformer.Informer().AddEventHandler(authtype.EnqueuePullSubscription(impl, pullSubscriptionLister))
 
 	r.UriResolver = resolver.NewURIResolver(ctx, impl.EnqueueKey)
 	r.ReconcileDataPlaneFn = r.ReconcileScaledObject

--- a/pkg/reconciler/intevents/pullsubscription/keda/controller.go
+++ b/pkg/reconciler/intevents/pullsubscription/keda/controller.go
@@ -26,9 +26,10 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/kelseyhightower/envconfig"
+
 	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
 	"github.com/google/knative-gcp/pkg/apis/duck"
-	v1 "github.com/google/knative-gcp/pkg/apis/intevents/v1"
 	"github.com/google/knative-gcp/pkg/client/injection/ducks/duck/v1/resource"
 	pullsubscriptioninformers "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1/pullsubscription"
 	pullsubscriptionreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/intevents/v1/pullsubscription"
@@ -37,7 +38,7 @@ import (
 	"github.com/google/knative-gcp/pkg/reconciler/identity/iam"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents"
 	psreconciler "github.com/google/knative-gcp/pkg/reconciler/intevents/pullsubscription"
-	"github.com/kelseyhightower/envconfig"
+	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
 
 	eventingduck "knative.dev/eventing/pkg/duck"
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
@@ -97,12 +98,15 @@ func newController(
 		Base: reconciler.NewBase(ctx, controllerAgentName, cmw),
 	}
 
+	pullSubscriptionLister := pullSubscriptionInformer.Lister()
+
 	r := &Reconciler{
 		Base: &psreconciler.Base{
 			PubSubBase:             pubsubBase,
 			Identity:               identity.NewIdentity(ctx, ipm, gcpas),
 			DeploymentLister:       deploymentInformer.Lister(),
-			PullSubscriptionLister: pullSubscriptionInformer.Lister(),
+			ServiceAccountLister:   serviceAccountInformer.Lister(),
+			PullSubscriptionLister: pullSubscriptionLister,
 			ReceiveAdapterImage:    env.ReceiveAdapter,
 			CreateClientFn:         pubsub.NewClient,
 			ControllerAgentName:    controllerAgentName,
@@ -126,10 +130,8 @@ func newController(
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
-	serviceAccountInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterControllerGK(v1.Kind("PullSubscription")),
-		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
-	})
+	// Watch k8s service account, if a k8s service account resource changes, enqueue qualified pullsubscriptions from the same namespace.
+	serviceAccountInformer.Informer().AddEventHandler(authtype.EnqueuePullSubscriptions(impl, pullSubscriptionLister))
 
 	r.UriResolver = resolver.NewURIResolver(ctx, impl.EnqueueKey)
 	r.ReconcileDataPlaneFn = r.ReconcileScaledObject

--- a/pkg/reconciler/intevents/pullsubscription/keda/controller.go
+++ b/pkg/reconciler/intevents/pullsubscription/keda/controller.go
@@ -38,7 +38,7 @@ import (
 	"github.com/google/knative-gcp/pkg/reconciler/identity/iam"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents"
 	psreconciler "github.com/google/knative-gcp/pkg/reconciler/intevents/pullsubscription"
-	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
+	"github.com/google/knative-gcp/pkg/utils/authcheck"
 
 	eventingduck "knative.dev/eventing/pkg/duck"
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
@@ -131,7 +131,7 @@ func newController(
 	})
 
 	// Watch k8s service account, if a k8s service account resource changes, enqueue qualified pullsubscriptions from the same namespace.
-	serviceAccountInformer.Informer().AddEventHandler(authtype.EnqueuePullSubscription(impl, pullSubscriptionLister))
+	serviceAccountInformer.Informer().AddEventHandler(authcheck.EnqueuePullSubscription(impl, pullSubscriptionLister))
 
 	r.UriResolver = resolver.NewURIResolver(ctx, impl.EnqueueKey)
 	r.ReconcileDataPlaneFn = r.ReconcileScaledObject

--- a/pkg/reconciler/intevents/pullsubscription/keda/pullsubscription_test.go
+++ b/pkg/reconciler/intevents/pullsubscription/keda/pullsubscription_test.go
@@ -24,8 +24,9 @@ import (
 
 	"cloud.google.com/go/pubsub"
 	"cloud.google.com/go/pubsub/pstest"
+
 	reconcilertestingv1 "github.com/google/knative-gcp/pkg/reconciler/testing/v1"
-	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
+	"github.com/google/knative-gcp/pkg/utils/authcheck"
 
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
@@ -1110,7 +1111,7 @@ func newReceiveAdapter(ctx context.Context, image string, transformer *apis.URL)
 		SubscriptionID:   testSubscriptionID,
 		SinkURI:          sinkURI,
 		TransformerURI:   transformer,
-		AuthType:         authtype.Secret,
+		AuthType:         authcheck.Secret,
 	}
 	return resources.MakeReceiveAdapter(ctx, args)
 }

--- a/pkg/reconciler/intevents/pullsubscription/keda/pullsubscription_test.go
+++ b/pkg/reconciler/intevents/pullsubscription/keda/pullsubscription_test.go
@@ -25,6 +25,8 @@ import (
 	"cloud.google.com/go/pubsub"
 	"cloud.google.com/go/pubsub/pstest"
 	reconcilertestingv1 "github.com/google/knative-gcp/pkg/reconciler/testing/v1"
+	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
+
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -1108,7 +1110,7 @@ func newReceiveAdapter(ctx context.Context, image string, transformer *apis.URL)
 		SubscriptionID:   testSubscriptionID,
 		SinkURI:          sinkURI,
 		TransformerURI:   transformer,
-		AuthType:         "secret",
+		AuthType:         authtype.Secret,
 	}
 	return resources.MakeReceiveAdapter(ctx, args)
 }

--- a/pkg/reconciler/intevents/pullsubscription/keda/pullsubscription_test.go
+++ b/pkg/reconciler/intevents/pullsubscription/keda/pullsubscription_test.go
@@ -1108,6 +1108,7 @@ func newReceiveAdapter(ctx context.Context, image string, transformer *apis.URL)
 		SubscriptionID:   testSubscriptionID,
 		SinkURI:          sinkURI,
 		TransformerURI:   transformer,
+		AuthType:         "secret",
 	}
 	return resources.MakeReceiveAdapter(ctx, args)
 }

--- a/pkg/reconciler/intevents/pullsubscription/reconciler.go
+++ b/pkg/reconciler/intevents/pullsubscription/reconciler.go
@@ -315,7 +315,6 @@ func (r *Base) reconcileDataPlaneResources(ctx context.Context, ps *v1.PullSubsc
 		ServiceAccountName: ps.IdentitySpec().ServiceAccountName,
 		Secret:             ps.Spec.Secret,
 	})
-
 	if err != nil {
 		ps.Status.MarkDeployedUnknown(authtype.AuthenticationCheckUnknownReason, err.Error())
 		logging.FromContext(ctx).Desugar().Error("Error getting authType", zap.Error(err))

--- a/pkg/reconciler/intevents/pullsubscription/reconciler.go
+++ b/pkg/reconciler/intevents/pullsubscription/reconciler.go
@@ -310,7 +310,7 @@ func (r *Base) reconcileDataPlaneResources(ctx context.Context, ps *v1.PullSubsc
 		logging.FromContext(ctx).Desugar().Error("Error serializing tracing config", zap.Error(err))
 	}
 
-	authType, err := authtype.GetAuthType(ctx, r.ServiceAccountLister, nil, authtype.AuthTypeArgs{
+	authType, err := authtype.GetAuthTypeForSources(ctx, r.ServiceAccountLister, authtype.AuthTypeArgs{
 		Namespace:          ps.Namespace,
 		ServiceAccountName: ps.IdentitySpec().ServiceAccountName,
 		Secret:             ps.Spec.Secret,

--- a/pkg/reconciler/intevents/pullsubscription/reconciler.go
+++ b/pkg/reconciler/intevents/pullsubscription/reconciler.go
@@ -32,8 +32,8 @@ import (
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 
-	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
 	"github.com/google/knative-gcp/pkg/utils"
+	"github.com/google/knative-gcp/pkg/utils/authcheck"
 
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -310,13 +310,13 @@ func (r *Base) reconcileDataPlaneResources(ctx context.Context, ps *v1.PullSubsc
 		logging.FromContext(ctx).Desugar().Error("Error serializing tracing config", zap.Error(err))
 	}
 
-	authType, err := authtype.GetAuthTypeForSources(ctx, r.ServiceAccountLister, authtype.AuthTypeArgs{
+	authType, err := authcheck.GetAuthTypeForSources(ctx, r.ServiceAccountLister, authcheck.AuthTypeArgs{
 		Namespace:          ps.Namespace,
 		ServiceAccountName: ps.IdentitySpec().ServiceAccountName,
 		Secret:             ps.Spec.Secret,
 	})
 	if err != nil {
-		ps.Status.MarkDeployedUnknown(authtype.AuthenticationCheckUnknownReason, err.Error())
+		ps.Status.MarkDeployedUnknown(authcheck.AuthenticationCheckUnknownReason, err.Error())
 		logging.FromContext(ctx).Desugar().Error("Error getting authType", zap.Error(err))
 		return err
 	}

--- a/pkg/reconciler/intevents/pullsubscription/resources/receive_adapter.go
+++ b/pkg/reconciler/intevents/pullsubscription/resources/receive_adapter.go
@@ -53,7 +53,7 @@ type ReceiveAdapterArgs struct {
 	LoggingConfig    string
 	TracingConfig    string
 	// There are three types: `secret`, `workload-identity-gsa` and `workload-identity`.
-	AuthType authcheck.AuthTypes
+	AuthType authcheck.AuthType
 }
 
 const (

--- a/pkg/reconciler/intevents/pullsubscription/resources/receive_adapter.go
+++ b/pkg/reconciler/intevents/pullsubscription/resources/receive_adapter.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
 	"github.com/google/knative-gcp/pkg/testing/testloggingutil"
+	"github.com/google/knative-gcp/pkg/utils/authcheck"
 
 	"go.uber.org/zap"
 
@@ -53,7 +53,7 @@ type ReceiveAdapterArgs struct {
 	LoggingConfig    string
 	TracingConfig    string
 	// There are three types: `secret`, `workload-identity-gsa` and `workload-identity`.
-	AuthType authtype.AuthTypes
+	AuthType authcheck.AuthTypes
 }
 
 const (

--- a/pkg/reconciler/intevents/pullsubscription/resources/receive_adapter.go
+++ b/pkg/reconciler/intevents/pullsubscription/resources/receive_adapter.go
@@ -51,6 +51,8 @@ type ReceiveAdapterArgs struct {
 	MetricsConfig    string
 	LoggingConfig    string
 	TracingConfig    string
+	// There are three types: `secret`, `workload-identity-gsa` and `workload-identity-ubermint`.
+	AuthType string
 }
 
 const (
@@ -154,6 +156,9 @@ func makeReceiveAdapterPodSpec(ctx context.Context, args *ReceiveAdapterArgs) *c
 		}, {
 			Name:  "METRICS_DOMAIN",
 			Value: metricsDomain,
+		}, {
+			Name:  "K_GCP_AUTH_TYPE",
+			Value: args.AuthType,
 		}},
 		Ports: []corev1.ContainerPort{{
 			Name:          "metrics",

--- a/pkg/reconciler/intevents/pullsubscription/resources/receive_adapter.go
+++ b/pkg/reconciler/intevents/pullsubscription/resources/receive_adapter.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
 	"github.com/google/knative-gcp/pkg/testing/testloggingutil"
 
 	"go.uber.org/zap"
@@ -51,8 +52,8 @@ type ReceiveAdapterArgs struct {
 	MetricsConfig    string
 	LoggingConfig    string
 	TracingConfig    string
-	// There are three types: `secret`, `workload-identity-gsa` and `workload-identity-ubermint`.
-	AuthType string
+	// There are three types: `secret`, `workload-identity-gsa` and `workload-identity`.
+	AuthType authtype.AuthTypes
 }
 
 const (
@@ -158,7 +159,7 @@ func makeReceiveAdapterPodSpec(ctx context.Context, args *ReceiveAdapterArgs) *c
 			Value: metricsDomain,
 		}, {
 			Name:  "K_GCP_AUTH_TYPE",
-			Value: args.AuthType,
+			Value: string(args.AuthType),
 		}},
 		Ports: []corev1.ContainerPort{{
 			Name:          "metrics",

--- a/pkg/reconciler/intevents/pullsubscription/resources/receive_adapter_test.go
+++ b/pkg/reconciler/intevents/pullsubscription/resources/receive_adapter_test.go
@@ -72,6 +72,7 @@ func TestMakeMinimumReceiveAdapter(t *testing.T) {
 		LoggingConfig:  "LoggingConfig-ABC123",
 		MetricsConfig:  "MetricsConfig-ABC123",
 		TracingConfig:  "TracingConfig-ABC123",
+		AuthType:       "secret",
 	})
 
 	one := int32(1)
@@ -163,6 +164,9 @@ func TestMakeMinimumReceiveAdapter(t *testing.T) {
 							Name:  "METRICS_DOMAIN",
 							Value: metricsDomain,
 						}, {
+							Name:  "K_GCP_AUTH_TYPE",
+							Value: "secret",
+						}, {
 							Name:  "GOOGLE_APPLICATION_CREDENTIALS",
 							Value: "/var/secrets/google/eventing-secret-key",
 						}, {
@@ -237,6 +241,7 @@ func TestMakeFullReceiveAdapter(t *testing.T) {
 		LoggingConfig:  "LoggingConfig-ABC123",
 		MetricsConfig:  "MetricsConfig-ABC123",
 		TracingConfig:  "TracingConfig-ABC123",
+		AuthType:       "secret",
 	})
 
 	one := int32(1)
@@ -330,6 +335,9 @@ func TestMakeFullReceiveAdapter(t *testing.T) {
 							Name:  "METRICS_DOMAIN",
 							Value: metricsDomain,
 						}, {
+							Name:  "K_GCP_AUTH_TYPE",
+							Value: "secret",
+						}, {
 							Name:  "GOOGLE_APPLICATION_CREDENTIALS",
 							Value: "/var/secrets/google/eventing-secret-key",
 						}, {
@@ -406,6 +414,7 @@ func TestMakeReceiveAdapterWithServiceAccount(t *testing.T) {
 		LoggingConfig:  "LoggingConfig-ABC123",
 		MetricsConfig:  "MetricsConfig-ABC123",
 		TracingConfig:  "TracingConfig-ABC123",
+		AuthType:       "workload-identity-gsa",
 	})
 
 	one := int32(1)
@@ -499,6 +508,9 @@ func TestMakeReceiveAdapterWithServiceAccount(t *testing.T) {
 						}, {
 							Name:  "METRICS_DOMAIN",
 							Value: metricsDomain,
+						}, {
+							Name:  "K_GCP_AUTH_TYPE",
+							Value: "workload-identity-gsa",
 						}},
 						Ports: []corev1.ContainerPort{{
 							Name:          "metrics",

--- a/pkg/reconciler/intevents/pullsubscription/resources/receive_adapter_test.go
+++ b/pkg/reconciler/intevents/pullsubscription/resources/receive_adapter_test.go
@@ -21,13 +21,14 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/google/knative-gcp/pkg/apis/duck"
 	gcpduckv1 "github.com/google/knative-gcp/pkg/apis/duck/v1"
 	"github.com/google/knative-gcp/pkg/apis/intevents"
 	intereventsv1 "github.com/google/knative-gcp/pkg/apis/intevents/v1"
 	testingmetadata "github.com/google/knative-gcp/pkg/gclient/metadata/testing"
 	"github.com/google/knative-gcp/pkg/pubsub/adapter/converters"
-	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
+	"github.com/google/knative-gcp/pkg/utils/authcheck"
 
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -73,7 +74,7 @@ func TestMakeMinimumReceiveAdapter(t *testing.T) {
 		LoggingConfig:  "LoggingConfig-ABC123",
 		MetricsConfig:  "MetricsConfig-ABC123",
 		TracingConfig:  "TracingConfig-ABC123",
-		AuthType:       authtype.Secret,
+		AuthType:       authcheck.Secret,
 	})
 
 	one := int32(1)
@@ -242,7 +243,7 @@ func TestMakeFullReceiveAdapter(t *testing.T) {
 		LoggingConfig:  "LoggingConfig-ABC123",
 		MetricsConfig:  "MetricsConfig-ABC123",
 		TracingConfig:  "TracingConfig-ABC123",
-		AuthType:       authtype.Secret,
+		AuthType:       authcheck.Secret,
 	})
 
 	one := int32(1)
@@ -415,7 +416,7 @@ func TestMakeReceiveAdapterWithServiceAccount(t *testing.T) {
 		LoggingConfig:  "LoggingConfig-ABC123",
 		MetricsConfig:  "MetricsConfig-ABC123",
 		TracingConfig:  "TracingConfig-ABC123",
-		AuthType:       authtype.WorkloadIdentityGSA,
+		AuthType:       authcheck.WorkloadIdentityGSA,
 	})
 
 	one := int32(1)
@@ -511,7 +512,7 @@ func TestMakeReceiveAdapterWithServiceAccount(t *testing.T) {
 							Value: metricsDomain,
 						}, {
 							Name:  "K_GCP_AUTH_TYPE",
-							Value: string(authtype.WorkloadIdentityGSA),
+							Value: string(authcheck.WorkloadIdentityGSA),
 						}},
 						Ports: []corev1.ContainerPort{{
 							Name:          "metrics",

--- a/pkg/reconciler/intevents/pullsubscription/resources/receive_adapter_test.go
+++ b/pkg/reconciler/intevents/pullsubscription/resources/receive_adapter_test.go
@@ -27,6 +27,7 @@ import (
 	intereventsv1 "github.com/google/knative-gcp/pkg/apis/intevents/v1"
 	testingmetadata "github.com/google/knative-gcp/pkg/gclient/metadata/testing"
 	"github.com/google/knative-gcp/pkg/pubsub/adapter/converters"
+	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
 
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -72,7 +73,7 @@ func TestMakeMinimumReceiveAdapter(t *testing.T) {
 		LoggingConfig:  "LoggingConfig-ABC123",
 		MetricsConfig:  "MetricsConfig-ABC123",
 		TracingConfig:  "TracingConfig-ABC123",
-		AuthType:       "secret",
+		AuthType:       authtype.Secret,
 	})
 
 	one := int32(1)
@@ -241,7 +242,7 @@ func TestMakeFullReceiveAdapter(t *testing.T) {
 		LoggingConfig:  "LoggingConfig-ABC123",
 		MetricsConfig:  "MetricsConfig-ABC123",
 		TracingConfig:  "TracingConfig-ABC123",
-		AuthType:       "secret",
+		AuthType:       authtype.Secret,
 	})
 
 	one := int32(1)
@@ -414,7 +415,7 @@ func TestMakeReceiveAdapterWithServiceAccount(t *testing.T) {
 		LoggingConfig:  "LoggingConfig-ABC123",
 		MetricsConfig:  "MetricsConfig-ABC123",
 		TracingConfig:  "TracingConfig-ABC123",
-		AuthType:       "workload-identity-gsa",
+		AuthType:       authtype.WorkloadIdentityGSA,
 	})
 
 	one := int32(1)
@@ -510,7 +511,7 @@ func TestMakeReceiveAdapterWithServiceAccount(t *testing.T) {
 							Value: metricsDomain,
 						}, {
 							Name:  "K_GCP_AUTH_TYPE",
-							Value: "workload-identity-gsa",
+							Value: string(authtype.WorkloadIdentityGSA),
 						}},
 						Ports: []corev1.ContainerPort{{
 							Name:          "metrics",

--- a/pkg/reconciler/intevents/pullsubscription/static/controller.go
+++ b/pkg/reconciler/intevents/pullsubscription/static/controller.go
@@ -132,7 +132,7 @@ func newController(
 	})
 
 	// Watch k8s service account, if a k8s service account resource changes, enqueue qualified pullsubscriptions from the same namespace.
-	serviceAccountInformer.Informer().AddEventHandler(authtype.EnqueuePullSubscriptions(impl, pullSubscriptionLister))
+	serviceAccountInformer.Informer().AddEventHandler(authtype.EnqueuePullSubscription(impl, pullSubscriptionLister))
 
 	r.UriResolver = resolver.NewURIResolver(ctx, impl.EnqueueKey)
 	r.ReconcileDataPlaneFn = r.ReconcileDeployment

--- a/pkg/reconciler/intevents/pullsubscription/static/controller.go
+++ b/pkg/reconciler/intevents/pullsubscription/static/controller.go
@@ -19,23 +19,12 @@ package static
 import (
 	"context"
 
-	"knative.dev/pkg/injection"
-
 	"cloud.google.com/go/pubsub"
-	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
-	"github.com/google/knative-gcp/pkg/apis/duck"
-	v1 "github.com/google/knative-gcp/pkg/apis/intevents/v1"
-	pullsubscriptioninformers "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1/pullsubscription"
-	"github.com/google/knative-gcp/pkg/reconciler"
-	"github.com/google/knative-gcp/pkg/reconciler/identity"
-	"github.com/google/knative-gcp/pkg/reconciler/identity/iam"
-	"github.com/google/knative-gcp/pkg/reconciler/intevents"
-	psreconciler "github.com/google/knative-gcp/pkg/reconciler/intevents/pullsubscription"
 	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/injection"
 
-	pullsubscriptionreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/intevents/v1/pullsubscription"
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
 	serviceaccountinformers "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount"
 	"knative.dev/pkg/configmap"
@@ -45,6 +34,18 @@ import (
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
 	tracingconfig "knative.dev/pkg/tracing/config"
+
+	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
+	"github.com/google/knative-gcp/pkg/apis/duck"
+	pullsubscriptioninformers "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1/pullsubscription"
+	"github.com/google/knative-gcp/pkg/reconciler"
+	"github.com/google/knative-gcp/pkg/reconciler/identity"
+	"github.com/google/knative-gcp/pkg/reconciler/identity/iam"
+	"github.com/google/knative-gcp/pkg/reconciler/intevents"
+	psreconciler "github.com/google/knative-gcp/pkg/reconciler/intevents/pullsubscription"
+	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
+
+	pullsubscriptionreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/intevents/v1/pullsubscription"
 )
 
 const (
@@ -65,7 +66,7 @@ type envConfig struct {
 
 type Constructor injection.ControllerConstructor
 
-// NewConstructor creates a constructor to make a static CloudBuildSource controller.
+// NewConstructor creates a constructor to make a static pullsubscription controller.
 func NewConstructor(ipm iam.IAMPolicyManager, gcpas *gcpauth.StoreSingleton) Constructor {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		return newController(ctx, cmw, ipm, gcpas.Store(ctx, cmw))
@@ -93,12 +94,15 @@ func newController(
 		Base: reconciler.NewBase(ctx, controllerAgentName, cmw),
 	}
 
+	pullSubscriptionLister := pullSubscriptionInformer.Lister()
+
 	r := &Reconciler{
 		Base: &psreconciler.Base{
 			PubSubBase:             pubsubBase,
 			Identity:               identity.NewIdentity(ctx, ipm, gcpas),
 			DeploymentLister:       deploymentInformer.Lister(),
-			PullSubscriptionLister: pullSubscriptionInformer.Lister(),
+			ServiceAccountLister:   serviceAccountInformer.Lister(),
+			PullSubscriptionLister: pullSubscriptionLister,
 			ReceiveAdapterImage:    env.ReceiveAdapter,
 			CreateClientFn:         pubsub.NewClient,
 			ControllerAgentName:    controllerAgentName,
@@ -127,10 +131,8 @@ func newController(
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
-	serviceAccountInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterControllerGK(v1.Kind("PullSubscription")),
-		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
-	})
+	// Watch k8s service account, if a k8s service account resource changes, enqueue qualified pullsubscriptions from the same namespace.
+	serviceAccountInformer.Informer().AddEventHandler(authtype.EnqueuePullSubscriptions(impl, pullSubscriptionLister))
 
 	r.UriResolver = resolver.NewURIResolver(ctx, impl.EnqueueKey)
 	r.ReconcileDataPlaneFn = r.ReconcileDeployment

--- a/pkg/reconciler/intevents/pullsubscription/static/controller.go
+++ b/pkg/reconciler/intevents/pullsubscription/static/controller.go
@@ -38,14 +38,13 @@ import (
 	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
 	"github.com/google/knative-gcp/pkg/apis/duck"
 	pullsubscriptioninformers "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1/pullsubscription"
+	pullsubscriptionreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/intevents/v1/pullsubscription"
 	"github.com/google/knative-gcp/pkg/reconciler"
 	"github.com/google/knative-gcp/pkg/reconciler/identity"
 	"github.com/google/knative-gcp/pkg/reconciler/identity/iam"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents"
 	psreconciler "github.com/google/knative-gcp/pkg/reconciler/intevents/pullsubscription"
-	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
-
-	pullsubscriptionreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/intevents/v1/pullsubscription"
+	"github.com/google/knative-gcp/pkg/utils/authcheck"
 )
 
 const (
@@ -132,7 +131,7 @@ func newController(
 	})
 
 	// Watch k8s service account, if a k8s service account resource changes, enqueue qualified pullsubscriptions from the same namespace.
-	serviceAccountInformer.Informer().AddEventHandler(authtype.EnqueuePullSubscription(impl, pullSubscriptionLister))
+	serviceAccountInformer.Informer().AddEventHandler(authcheck.EnqueuePullSubscription(impl, pullSubscriptionLister))
 
 	r.UriResolver = resolver.NewURIResolver(ctx, impl.EnqueueKey)
 	r.ReconcileDataPlaneFn = r.ReconcileDeployment

--- a/pkg/reconciler/intevents/pullsubscription/static/pullsubscription_test.go
+++ b/pkg/reconciler/intevents/pullsubscription/static/pullsubscription_test.go
@@ -25,6 +25,8 @@ import (
 	"cloud.google.com/go/pubsub"
 	"cloud.google.com/go/pubsub/pstest"
 	reconcilertestingv1 "github.com/google/knative-gcp/pkg/reconciler/testing/v1"
+	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
+
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -1177,7 +1179,7 @@ func newReceiveAdapter(ctx context.Context, image string, transformer *apis.URL)
 		SubscriptionID:   testSubscriptionID,
 		SinkURI:          sinkURI,
 		TransformerURI:   transformer,
-		AuthType:         "secret",
+		AuthType:         authtype.Secret,
 	}
 	ra := resources.MakeReceiveAdapter(ctx, args)
 	return ra

--- a/pkg/reconciler/intevents/pullsubscription/static/pullsubscription_test.go
+++ b/pkg/reconciler/intevents/pullsubscription/static/pullsubscription_test.go
@@ -24,8 +24,9 @@ import (
 
 	"cloud.google.com/go/pubsub"
 	"cloud.google.com/go/pubsub/pstest"
+
 	reconcilertestingv1 "github.com/google/knative-gcp/pkg/reconciler/testing/v1"
-	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
+	"github.com/google/knative-gcp/pkg/utils/authcheck"
 
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
@@ -1179,7 +1180,7 @@ func newReceiveAdapter(ctx context.Context, image string, transformer *apis.URL)
 		SubscriptionID:   testSubscriptionID,
 		SinkURI:          sinkURI,
 		TransformerURI:   transformer,
-		AuthType:         authtype.Secret,
+		AuthType:         authcheck.Secret,
 	}
 	ra := resources.MakeReceiveAdapter(ctx, args)
 	return ra

--- a/pkg/reconciler/intevents/pullsubscription/static/pullsubscription_test.go
+++ b/pkg/reconciler/intevents/pullsubscription/static/pullsubscription_test.go
@@ -1177,6 +1177,7 @@ func newReceiveAdapter(ctx context.Context, image string, transformer *apis.URL)
 		SubscriptionID:   testSubscriptionID,
 		SinkURI:          sinkURI,
 		TransformerURI:   transformer,
+		AuthType:         "secret",
 	}
 	ra := resources.MakeReceiveAdapter(ctx, args)
 	return ra

--- a/pkg/reconciler/intevents/reconciler.go
+++ b/pkg/reconciler/intevents/reconciler.go
@@ -22,12 +22,6 @@ import (
 
 	"github.com/google/knative-gcp/pkg/testing/testloggingutil"
 
-	duckv1 "github.com/google/knative-gcp/pkg/apis/duck/v1"
-	inteventsv1 "github.com/google/knative-gcp/pkg/apis/intevents/v1"
-	clientset "github.com/google/knative-gcp/pkg/client/clientset/versioned"
-	duck "github.com/google/knative-gcp/pkg/duck/v1"
-	"github.com/google/knative-gcp/pkg/reconciler"
-	"github.com/google/knative-gcp/pkg/reconciler/intevents/resources"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -37,6 +31,13 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
+
+	duckv1 "github.com/google/knative-gcp/pkg/apis/duck/v1"
+	inteventsv1 "github.com/google/knative-gcp/pkg/apis/intevents/v1"
+	clientset "github.com/google/knative-gcp/pkg/client/clientset/versioned"
+	duck "github.com/google/knative-gcp/pkg/duck/v1"
+	"github.com/google/knative-gcp/pkg/reconciler"
+	"github.com/google/knative-gcp/pkg/reconciler/intevents/resources"
 )
 
 const (

--- a/pkg/reconciler/intevents/topic/controller.go
+++ b/pkg/reconciler/intevents/topic/controller.go
@@ -30,19 +30,19 @@ import (
 	tracingconfig "knative.dev/pkg/tracing/config"
 
 	"cloud.google.com/go/pubsub"
+	serviceaccountinformers "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount"
+	serviceinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/service"
+
 	"github.com/google/knative-gcp/pkg/apis/configs/dataresidency"
 	"github.com/google/knative-gcp/pkg/apis/configs/gcpauth"
 	v1 "github.com/google/knative-gcp/pkg/apis/intevents/v1"
+	topicinformer "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1/topic"
+	topicreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/intevents/v1/topic"
 	"github.com/google/knative-gcp/pkg/reconciler"
 	"github.com/google/knative-gcp/pkg/reconciler/identity"
 	"github.com/google/knative-gcp/pkg/reconciler/identity/iam"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents"
-	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
-
-	topicinformer "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1/topic"
-	topicreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/intevents/v1/topic"
-	serviceaccountinformers "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount"
-	serviceinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/service"
+	"github.com/google/knative-gcp/pkg/utils/authcheck"
 )
 
 const (
@@ -116,7 +116,7 @@ func newController(
 	})
 
 	// Watch k8s service account, if a k8s service account resource changes, enqueue qualified topics from the same namespace.
-	serviceAccountInformer.Informer().AddEventHandler(authtype.EnqueueTopic(impl, topicLister))
+	serviceAccountInformer.Informer().AddEventHandler(authcheck.EnqueueTopic(impl, topicLister))
 
 	cmw.Watch(tracingconfig.ConfigName, r.UpdateFromTracingConfigMap)
 

--- a/pkg/reconciler/intevents/topic/controller.go
+++ b/pkg/reconciler/intevents/topic/controller.go
@@ -37,6 +37,7 @@ import (
 	"github.com/google/knative-gcp/pkg/reconciler/identity"
 	"github.com/google/knative-gcp/pkg/reconciler/identity/iam"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents"
+	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
 
 	topicinformer "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1/topic"
 	topicreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/intevents/v1/topic"
@@ -89,14 +90,17 @@ func newController(
 		Base: reconciler.NewBase(ctx, controllerAgentName, cmw),
 	}
 
+	topicLister := topicInformer.Lister()
+
 	r := &Reconciler{
-		PubSubBase:         pubsubBase,
-		Identity:           identity.NewIdentity(ctx, ipm, gcpas),
-		dataresidencyStore: dataresidencyStore,
-		topicLister:        topicInformer.Lister(),
-		serviceLister:      serviceInformer.Lister(),
-		publisherImage:     env.Publisher,
-		createClientFn:     pubsub.NewClient,
+		PubSubBase:           pubsubBase,
+		Identity:             identity.NewIdentity(ctx, ipm, gcpas),
+		dataresidencyStore:   dataresidencyStore,
+		topicLister:          topicLister,
+		serviceLister:        serviceInformer.Lister(),
+		serviceAccountLister: serviceAccountInformer.Lister(),
+		publisherImage:       env.Publisher,
+		createClientFn:       pubsub.NewClient,
 	}
 
 	impl := topicreconciler.NewImpl(ctx, r)
@@ -111,10 +115,8 @@ func newController(
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
-	serviceAccountInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterControllerGK(topicGK),
-		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
-	})
+	// Watch k8s service account, if a k8s service account resource changes, enqueue qualified topics from the same namespace.
+	serviceAccountInformer.Informer().AddEventHandler(authtype.EnqueueTopic(impl, topicLister))
 
 	cmw.Watch(tracingconfig.ConfigName, r.UpdateFromTracingConfigMap)
 

--- a/pkg/reconciler/intevents/topic/resources/publisher.go
+++ b/pkg/reconciler/intevents/topic/resources/publisher.go
@@ -38,7 +38,7 @@ type PublisherArgs struct {
 	Labels        map[string]string
 	TracingConfig string
 	// There are three types: `secret`, `workload-identity-gsa` and `workload-identity`.
-	AuthType authcheck.AuthTypes
+	AuthType authcheck.AuthType
 }
 
 const (

--- a/pkg/reconciler/intevents/topic/resources/publisher.go
+++ b/pkg/reconciler/intevents/topic/resources/publisher.go
@@ -19,8 +19,8 @@ package resources
 import (
 	"fmt"
 
-	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
 	"github.com/google/knative-gcp/pkg/testing/testloggingutil"
+	"github.com/google/knative-gcp/pkg/utils/authcheck"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +38,7 @@ type PublisherArgs struct {
 	Labels        map[string]string
 	TracingConfig string
 	// There are three types: `secret`, `workload-identity-gsa` and `workload-identity`.
-	AuthType authtype.AuthTypes
+	AuthType authcheck.AuthTypes
 }
 
 const (

--- a/pkg/reconciler/intevents/topic/resources/publisher.go
+++ b/pkg/reconciler/intevents/topic/resources/publisher.go
@@ -19,13 +19,15 @@ package resources
 import (
 	"fmt"
 
+	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
 	"github.com/google/knative-gcp/pkg/testing/testloggingutil"
 
-	v1 "github.com/google/knative-gcp/pkg/apis/intevents/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/kmeta"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
+
+	v1 "github.com/google/knative-gcp/pkg/apis/intevents/v1"
 )
 
 // PublisherArgs are the arguments needed to create a Topic publisher.
@@ -35,8 +37,8 @@ type PublisherArgs struct {
 	Topic         *v1.Topic
 	Labels        map[string]string
 	TracingConfig string
-	// There are three types: `secret`, `workload-identity-gsa` and `workload-identity-ubermint`.
-	AuthType string
+	// There are three types: `secret`, `workload-identity-gsa` and `workload-identity`.
+	AuthType authtype.AuthTypes
 }
 
 const (
@@ -100,7 +102,7 @@ func makePublisherPodSpec(args *PublisherArgs) *corev1.PodSpec {
 		},
 		corev1.EnvVar{
 			Name:  "K_GCP_AUTH_TYPE",
-			Value: args.AuthType,
+			Value: string(args.AuthType),
 		},
 	)
 

--- a/pkg/reconciler/intevents/topic/resources/publisher_test.go
+++ b/pkg/reconciler/intevents/topic/resources/publisher_test.go
@@ -29,6 +29,7 @@ import (
 	duckv1 "github.com/google/knative-gcp/pkg/apis/duck/v1"
 	v1 "github.com/google/knative-gcp/pkg/apis/intevents/v1"
 	testingmetadata "github.com/google/knative-gcp/pkg/gclient/metadata/testing"
+	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
 )
 
 func TestMakePublisher(t *testing.T) {
@@ -54,7 +55,7 @@ func TestMakePublisher(t *testing.T) {
 		Topic:         topic,
 		Labels:        GetLabels("controller-name", "topic-name"),
 		TracingConfig: "TracingConfig-ABC123",
-		AuthType:      "secret",
+		AuthType:      authtype.Secret,
 	})
 
 	gotb, _ := json.MarshalIndent(pub, "", "  ")

--- a/pkg/reconciler/intevents/topic/resources/publisher_test.go
+++ b/pkg/reconciler/intevents/topic/resources/publisher_test.go
@@ -25,11 +25,12 @@ import (
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/google/knative-gcp/pkg/apis/duck"
 	duckv1 "github.com/google/knative-gcp/pkg/apis/duck/v1"
 	v1 "github.com/google/knative-gcp/pkg/apis/intevents/v1"
 	testingmetadata "github.com/google/knative-gcp/pkg/gclient/metadata/testing"
-	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
+	"github.com/google/knative-gcp/pkg/utils/authcheck"
 )
 
 func TestMakePublisher(t *testing.T) {
@@ -55,7 +56,7 @@ func TestMakePublisher(t *testing.T) {
 		Topic:         topic,
 		Labels:        GetLabels("controller-name", "topic-name"),
 		TracingConfig: "TracingConfig-ABC123",
-		AuthType:      authtype.Secret,
+		AuthType:      authcheck.Secret,
 	})
 
 	gotb, _ := json.MarshalIndent(pub, "", "  ")

--- a/pkg/reconciler/intevents/topic/resources/publisher_test.go
+++ b/pkg/reconciler/intevents/topic/resources/publisher_test.go
@@ -54,6 +54,7 @@ func TestMakePublisher(t *testing.T) {
 		Topic:         topic,
 		Labels:        GetLabels("controller-name", "topic-name"),
 		TracingConfig: "TracingConfig-ABC123",
+		AuthType:      "secret",
 	})
 
 	gotb, _ := json.MarshalIndent(pub, "", "  ")
@@ -117,6 +118,10 @@ func TestMakePublisher(t *testing.T) {
               {
                 "name": "GOOGLE_APPLICATION_CREDENTIALS",
                 "value": "/var/secrets/google/eventing-secret-key"
+              },
+              {
+                "name": "K_GCP_AUTH_TYPE",
+                "value": "secret"
               }
             ],
             "resources": {},

--- a/pkg/reconciler/intevents/topic/topic.go
+++ b/pkg/reconciler/intevents/topic/topic.go
@@ -21,8 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/google/knative-gcp/pkg/testing/testloggingutil"
-
 	"cloud.google.com/go/pubsub"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
@@ -51,7 +49,9 @@ import (
 	"github.com/google/knative-gcp/pkg/reconciler/identity"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents/topic/resources"
+	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
 	reconcilerutilspubsub "github.com/google/knative-gcp/pkg/reconciler/utils/pubsub"
+	"github.com/google/knative-gcp/pkg/testing/testloggingutil"
 )
 
 const (
@@ -245,11 +245,23 @@ func (r *Reconciler) reconcilePublisher(ctx context.Context, topic *v1.Topic) (e
 		logging.FromContext(ctx).Desugar().Error("Error serializing tracing config", zap.Error(err))
 	}
 
+	authType, err := authtype.GetAuthType(ctx, r.serviceAccountLister, nil, authtype.AuthTypeArgs{
+		Namespace:          topic.Namespace,
+		ServiceAccountName: topic.IdentitySpec().ServiceAccountName,
+		Secret:             topic.Spec.Secret,
+	})
+	if err != nil {
+		topic.Status.MarkPublisherUnknown(authtype.AuthenticationCheckUnknownReason, err.Error())
+		logging.FromContext(ctx).Desugar().Error("Error getting authType", zap.Error(err))
+		return err, nil
+	}
+
 	desired := resources.MakePublisher(&resources.PublisherArgs{
 		Image:         r.publisherImage,
 		Topic:         topic,
 		Labels:        resources.GetLabels(controllerAgentName, topic.Name),
 		TracingConfig: tracingCfg,
+		AuthType:      authType,
 	})
 
 	svc := existing

--- a/pkg/reconciler/intevents/topic/topic.go
+++ b/pkg/reconciler/intevents/topic/topic.go
@@ -245,7 +245,7 @@ func (r *Reconciler) reconcilePublisher(ctx context.Context, topic *v1.Topic) (e
 		logging.FromContext(ctx).Desugar().Error("Error serializing tracing config", zap.Error(err))
 	}
 
-	authType, err := authtype.GetAuthType(ctx, r.serviceAccountLister, nil, authtype.AuthTypeArgs{
+	authType, err := authtype.GetAuthTypeForSources(ctx, r.serviceAccountLister, authtype.AuthTypeArgs{
 		Namespace:          topic.Namespace,
 		ServiceAccountName: topic.IdentitySpec().ServiceAccountName,
 		Secret:             topic.Spec.Secret,

--- a/pkg/reconciler/intevents/topic/topic.go
+++ b/pkg/reconciler/intevents/topic/topic.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/google/knative-gcp/pkg/tracing"
 	"github.com/google/knative-gcp/pkg/utils"
+	"github.com/google/knative-gcp/pkg/utils/authcheck"
 
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/reconciler"
@@ -49,7 +50,6 @@ import (
 	"github.com/google/knative-gcp/pkg/reconciler/identity"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents/topic/resources"
-	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
 	reconcilerutilspubsub "github.com/google/knative-gcp/pkg/reconciler/utils/pubsub"
 	"github.com/google/knative-gcp/pkg/testing/testloggingutil"
 )
@@ -245,13 +245,13 @@ func (r *Reconciler) reconcilePublisher(ctx context.Context, topic *v1.Topic) (e
 		logging.FromContext(ctx).Desugar().Error("Error serializing tracing config", zap.Error(err))
 	}
 
-	authType, err := authtype.GetAuthTypeForSources(ctx, r.serviceAccountLister, authtype.AuthTypeArgs{
+	authType, err := authcheck.GetAuthTypeForSources(ctx, r.serviceAccountLister, authcheck.AuthTypeArgs{
 		Namespace:          topic.Namespace,
 		ServiceAccountName: topic.IdentitySpec().ServiceAccountName,
 		Secret:             topic.Spec.Secret,
 	})
 	if err != nil {
-		topic.Status.MarkPublisherUnknown(authtype.AuthenticationCheckUnknownReason, err.Error())
+		topic.Status.MarkPublisherUnknown(authcheck.AuthenticationCheckUnknownReason, err.Error())
 		logging.FromContext(ctx).Desugar().Error("Error getting authType", zap.Error(err))
 		return err, nil
 	}

--- a/pkg/reconciler/intevents/topic/topic_test.go
+++ b/pkg/reconciler/intevents/topic/topic_test.go
@@ -925,9 +925,10 @@ func newPublisher() *servingv1.Service {
 		reconcilertestingv1.WithTopicSetDefaults,
 	)
 	args := &resources.PublisherArgs{
-		Image:  testImage,
-		Topic:  t,
-		Labels: resources.GetLabels(controllerAgentName, topicName),
+		Image:    testImage,
+		Topic:    t,
+		Labels:   resources.GetLabels(controllerAgentName, topicName),
+		AuthType: "secret",
 	}
 	return resources.MakePublisher(args)
 }

--- a/pkg/reconciler/intevents/topic/topic_test.go
+++ b/pkg/reconciler/intevents/topic/topic_test.go
@@ -26,6 +26,7 @@ import (
 	"cloud.google.com/go/pubsub/pstest"
 
 	reconcilertestingv1 "github.com/google/knative-gcp/pkg/reconciler/testing/v1"
+	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
 	reconcilerutilspubsub "github.com/google/knative-gcp/pkg/reconciler/utils/pubsub"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
@@ -928,7 +929,7 @@ func newPublisher() *servingv1.Service {
 		Image:    testImage,
 		Topic:    t,
 		Labels:   resources.GetLabels(controllerAgentName, topicName),
-		AuthType: "secret",
+		AuthType: authtype.Secret,
 	}
 	return resources.MakePublisher(args)
 }

--- a/pkg/reconciler/intevents/topic/topic_test.go
+++ b/pkg/reconciler/intevents/topic/topic_test.go
@@ -26,8 +26,9 @@ import (
 	"cloud.google.com/go/pubsub/pstest"
 
 	reconcilertestingv1 "github.com/google/knative-gcp/pkg/reconciler/testing/v1"
-	"github.com/google/knative-gcp/pkg/reconciler/utils/authtype"
 	reconcilerutilspubsub "github.com/google/knative-gcp/pkg/reconciler/utils/pubsub"
+	"github.com/google/knative-gcp/pkg/utils/authcheck"
+
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -929,7 +930,7 @@ func newPublisher() *servingv1.Service {
 		Image:    testImage,
 		Topic:    t,
 		Labels:   resources.GetLabels(controllerAgentName, topicName),
-		AuthType: authtype.Secret,
+		AuthType: authcheck.Secret,
 	}
 	return resources.MakePublisher(args)
 }

--- a/pkg/reconciler/testing/brokercell.go
+++ b/pkg/reconciler/testing/brokercell.go
@@ -92,6 +92,12 @@ func WithBrokerCellIngressFailed(reason, msg string) BrokerCellOption {
 	}
 }
 
+func WithBrokerCellIngressUnknown(reason, msg string) BrokerCellOption {
+	return func(bc *intv1alpha1.BrokerCell) {
+		bc.Status.MarkIngressUnknown(reason, msg)
+	}
+}
+
 func WithBrokerCellIngressAvailable() BrokerCellOption {
 	return func(bc *intv1alpha1.BrokerCell) {
 		bc.Status.PropagateIngressAvailability(v1alpha1.TestHelper.AvailableEndpoints())

--- a/pkg/reconciler/testing/listers.go
+++ b/pkg/reconciler/testing/listers.go
@@ -158,6 +158,10 @@ func (l *Listers) GetDeploymentLister() appsv1listers.DeploymentLister {
 	return appsv1listers.NewDeploymentLister(l.indexerFor(&appsv1.Deployment{}))
 }
 
+func (l *Listers) GetSecretLister() corev1listers.SecretLister {
+	return corev1listers.NewSecretLister(l.indexerFor(&corev1.Secret{}))
+}
+
 func (l *Listers) GetK8sServiceLister() corev1listers.ServiceLister {
 	return corev1listers.NewServiceLister(l.indexerFor(&corev1.Service{}))
 }

--- a/pkg/reconciler/testing/secret.go
+++ b/pkg/reconciler/testing/secret.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Knative Authors
+Copyright 2020 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/reconciler/testing/secret.go
+++ b/pkg/reconciler/testing/secret.go
@@ -23,7 +23,7 @@ import (
 
 type SecretOption func(*corev1.Secret)
 
-// NewSecret creates a Secret
+// NewSecret creates a Secret.
 func NewSecret(name, namespace string, so ...SecretOption) *corev1.Secret {
 	sa := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/testing/secret.go
+++ b/pkg/reconciler/testing/secret.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type SecretOption func(*corev1.Secret)
+
+// NewSecret creates a Secret
+func NewSecret(name, namespace string, so ...SecretOption) *corev1.Secret {
+	sa := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	for _, opt := range so {
+		opt(sa)
+	}
+	return sa
+}
+
+func WithData(data map[string][]byte) SecretOption {
+	return func(s *corev1.Secret) {
+		s.Data = data
+	}
+}

--- a/pkg/reconciler/testing/v1/topic.go
+++ b/pkg/reconciler/testing/v1/topic.go
@@ -100,6 +100,12 @@ func WithTopicSpec(spec v1.TopicSpec) TopicOption {
 	}
 }
 
+func WithTopicServiceAccountName(serviceAccountName string) TopicOption {
+	return func(t *v1.Topic) {
+		t.Spec.ServiceAccountName = serviceAccountName
+	}
+}
+
 func WithTopicPublisherDeployed(t *v1.Topic) {
 	t.Status.MarkPublisherDeployed()
 }

--- a/pkg/reconciler/utils/authtype/authtype.go
+++ b/pkg/reconciler/utils/authtype/authtype.go
@@ -20,61 +20,96 @@ import (
 	"context"
 	"fmt"
 
-	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
-	kubeclient "knative.dev/pkg/client/injection/kube/client"
 
 	"github.com/google/knative-gcp/pkg/reconciler/identity/resources"
 )
 
 const (
 	AuthenticationCheckUnknownReason = "AuthenticationCheckPending"
-	controlPlaneNamespace            = "cloud-run-events"
+	ControlPlaneNamespace            = "cloud-run-events"
+	BrokerServiceAccountName         = "broker"
 )
 
-type AuthTypeArgs struct {
-	Namespace           string
-	ServiceAccountName  string
-	Secret              *corev1.SecretKeySelector
+var BrokerSecret = &corev1.SecretKeySelector{
+	LocalObjectReference: corev1.LocalObjectReference{
+		Name: "google-broker-key",
+	},
+	Key: "key.json",
 }
 
-// needs to input a service account name lister and a secret lister
+type AuthTypeArgs struct {
+	Namespace          string
+	ServiceAccountName string
+	Secret             *corev1.SecretKeySelector
+}
+
 func GetAuthType(ctx context.Context, serviceAccountLister corev1listers.ServiceAccountLister,
 	secretLister corev1listers.SecretLister, args AuthTypeArgs) (string, error) {
-	if args.ServiceAccountName != "" {
-		GetAuthTypeForWorkloadIdentity(ctx, serviceAccountLister, args)
+	// For AuthTypeArgs from Sources, either ServiceAccountName or Secret will be empty,
+	// because of the IdentitySpec validation from Webhook.
+	// For AuthTypeArgs from BrokerCell, ServiceAccountName and Secret will be both presented.
+	// We need to revisit this function after https://github.com/google/knative-gcp/issues/1888 lands,
+	// which will add IdentitySpec to BrokerCell.
+	// For AuthTypeArgs from BrokerCell.
+	if args.ServiceAccountName != "" && args.Secret != nil {
+		if authType, err := GetAuthTypeForSecret(ctx, secretLister, args); authType != "" {
+			return authType, err
+		} else if authType, err := GetAuthTypeForWorkloadIdentity(ctx, serviceAccountLister, args); authType != "" {
+			return authType, err
+		} else {
+			return "", fmt.Errorf("authentication is not configured, Secret doesn't present, ServiceAccountName doesn't have required annotation")
+		}
 	}
 
-	if args.Secret != "" {
-		GetAuthTypeForSecret(secretLister, args)
+	// For AuthTypeArgs from Sources which has serviceAccountName.
+	if args.ServiceAccountName != "" {
+		return GetAuthTypeForWorkloadIdentity(ctx, serviceAccountLister, args)
 	}
+
+	// For AuthTypeArgs from Sources which has secret.
+	if args.Secret != nil {
+		return GetAuthTypeForSecret(ctx, secretLister, args)
+	}
+
+	return "", fmt.Errorf("invalid AuthTypeArgs, neither ServiceAccountName nor Secret are provided")
 }
 
 func GetAuthTypeForWorkloadIdentity(ctx context.Context, serviceAccountLister corev1listers.ServiceAccountLister, args AuthTypeArgs) (string, error) {
 	kServiceAccount, err := serviceAccountLister.ServiceAccounts(args.Namespace).Get(args.ServiceAccountName)
 	if err != nil {
 		if apierrs.IsNotFound(err) {
-			return kServiceAccount, nil
+			return "", fmt.Errorf("using Workload Identity for authentication configuration, " +
+				"can't find Kubernetes Service Account " + args.ServiceAccountName)
 		}
-	} else if {
-
-
-	} else {
-
+		return "workload-identity", fmt.Errorf("error getting Kubernests Service Account: %s", err.Error())
+	} else if kServiceAccount.Annotations[resources.WorkloadIdentityKey] != "" {
+		return "workload-identity-gsa", nil
 	}
+	// Once workload-identity-ubermint lands, we should also include the annotation check for it.
+	return "", fmt.Errorf("using Workload Identity for authentication configuration, " +
+		"Kubernetes Service Account " + args.ServiceAccountName + " doesn't have the required annotation")
 }
 
-func GetAuthTypeForSecret(secretLister corev1listers.SecretLister, args AuthTypeArgs) (string, error) {
+func GetAuthTypeForSecret(ctx context.Context, secretLister corev1listers.SecretLister, args AuthTypeArgs) (string, error) {
 	// Controller doesn't have the permission to check the existence of a secret in namespaces
 	// other than the control plane's namespace.
-	if args.Namespace != controlPlaneNamespace {
+	if args.Namespace != ControlPlaneNamespace {
 		return "secret", nil
 	}
-
-	// If current namespace is control plane's namespace, check the existence of the secret.
-
+	// If current namespace is control plane's namespace, check the existence of the secret and its key.
+	secret, err := secretLister.Secrets(args.Namespace).Get(args.Secret.Name)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			return "", fmt.Errorf("using Secret for authentication configuration, " +
+				"can't find Kubernests Secret " + args.Secret.Name)
+		}
+		return "secret", fmt.Errorf("error getting Kubernests Secret: %s", err.Error())
+	} else if secret.Data[args.Secret.Key] == nil {
+		return "secret", fmt.Errorf("using Secret for authentication configuration, " +
+			"Kubernests Secret " + args.Secret.Name + " doesn't have required key " + args.Secret.Key)
+	}
+	return "secret", nil
 }

--- a/pkg/reconciler/utils/authtype/authtype.go
+++ b/pkg/reconciler/utils/authtype/authtype.go
@@ -55,9 +55,9 @@ func GetAuthType(ctx context.Context, serviceAccountLister corev1listers.Service
 	// which will add IdentitySpec to BrokerCell.
 	// For AuthTypeArgs from BrokerCell.
 	if args.ServiceAccountName != "" && args.Secret != nil {
-		if authType, err := GetAuthTypeForSecret(ctx, secretLister, args); authType != "" {
+		if authType, err := GetAuthTypeForWorkloadIdentity(ctx, serviceAccountLister, args); authType != "" {
 			return authType, err
-		} else if authType, err := GetAuthTypeForWorkloadIdentity(ctx, serviceAccountLister, args); authType != "" {
+		} else if authType, err := GetAuthTypeForSecret(ctx, secretLister, args); authType != "" {
 			return authType, err
 		} else {
 			return "", fmt.Errorf("authentication is not configured, Secret doesn't present, ServiceAccountName doesn't have required annotation")

--- a/pkg/reconciler/utils/authtype/authtype.go
+++ b/pkg/reconciler/utils/authtype/authtype.go
@@ -37,12 +37,16 @@ type AuthTypeArgs struct {
 }
 
 const (
-	AuthenticationCheckUnknownReason           = "AuthenticationCheckPending"
-	ControlPlaneNamespace                      = "cloud-run-events"
-	BrokerServiceAccountName                   = "broker"
-	Secret                           AuthTypes = "secret"
-	WorkloadIdentityGSA              AuthTypes = "workload-identity-gsa"
-	WorkloadIdentity                 AuthTypes = "workload-identity"
+	AuthenticationCheckUnknownReason = "AuthenticationCheckPending"
+	ControlPlaneNamespace            = "cloud-run-events"
+	BrokerServiceAccountName         = "broker"
+	// Secret option is referring to authentication configuration for secret.
+	// https://cloud.google.com/kubernetes-engine/docs/tutorials/authenticating-to-cloud-platform#importing_credentials_as_a_secret
+	Secret AuthTypes = "secret"
+	// WorkloadIdentityGSA option is referring to authentication configuration for Workload Identity using GSA
+	// https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
+	WorkloadIdentityGSA AuthTypes = "workload-identity-gsa"
+	WorkloadIdentity    AuthTypes = "workload-identity"
 )
 
 var BrokerSecret = &corev1.SecretKeySelector{
@@ -52,6 +56,7 @@ var BrokerSecret = &corev1.SecretKeySelector{
 	Key: "key.json",
 }
 
+// GetAuthTypeForBrokerCell will get authType for BrokerCell.
 func GetAuthTypeForBrokerCell(ctx context.Context, serviceAccountLister corev1listers.ServiceAccountLister,
 	secretLister corev1listers.SecretLister, args AuthTypeArgs) (AuthTypes, error) {
 	// For AuthTypeArgs from BrokerCell, ServiceAccountName and Secret will be both presented.
@@ -71,6 +76,7 @@ func GetAuthTypeForBrokerCell(ctx context.Context, serviceAccountLister corev1li
 	}
 }
 
+// GetAuthTypeForSources will get authType for Sources.
 func GetAuthTypeForSources(ctx context.Context, serviceAccountLister corev1listers.ServiceAccountLister, args AuthTypeArgs) (AuthTypes, error) {
 	// For AuthTypeArgs from Sources, either ServiceAccountName or Secret will be empty,
 	// because of the IdentitySpec validation from Webhook.

--- a/pkg/reconciler/utils/authtype/authtype.go
+++ b/pkg/reconciler/utils/authtype/authtype.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authtype
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+
+	"github.com/google/knative-gcp/pkg/reconciler/identity/resources"
+)
+
+const (
+	AuthenticationCheckUnknownReason = "AuthenticationCheckPending"
+	controlPlaneNamespace            = "cloud-run-events"
+)
+
+type AuthTypeArgs struct {
+	Namespace           string
+	ServiceAccountName  string
+	Secret              *corev1.SecretKeySelector
+}
+
+// needs to input a service account name lister and a secret lister
+func GetAuthType(ctx context.Context, serviceAccountLister corev1listers.ServiceAccountLister,
+	secretLister corev1listers.SecretLister, args AuthTypeArgs) (string, error) {
+	if args.ServiceAccountName != "" {
+		GetAuthTypeForWorkloadIdentity(ctx, serviceAccountLister, args)
+	}
+
+	if args.Secret != "" {
+		GetAuthTypeForSecret(secretLister, args)
+	}
+}
+
+func GetAuthTypeForWorkloadIdentity(ctx context.Context, serviceAccountLister corev1listers.ServiceAccountLister, args AuthTypeArgs) (string, error) {
+	kServiceAccount, err := serviceAccountLister.ServiceAccounts(args.Namespace).Get(args.ServiceAccountName)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			return kServiceAccount, nil
+		}
+	} else if {
+
+
+	} else {
+
+	}
+}
+
+func GetAuthTypeForSecret(secretLister corev1listers.SecretLister, args AuthTypeArgs) (string, error) {
+	// Controller doesn't have the permission to check the existence of a secret in namespaces
+	// other than the control plane's namespace.
+	if args.Namespace != controlPlaneNamespace {
+		return "secret", nil
+	}
+
+	// If current namespace is control plane's namespace, check the existence of the secret.
+
+}

--- a/pkg/reconciler/utils/authtype/authtype_test.go
+++ b/pkg/reconciler/utils/authtype/authtype_test.go
@@ -101,7 +101,7 @@ func TestGetAuthTypeForSources(t *testing.T) {
 			args:         serviceAccountArgs,
 			wantAuthType: "",
 			wantError: fmt.Errorf("using Workload Identity for authentication configuration: " +
-				"the Kubernetes Service Account " + serviceAccountName + " doesn't have the required annotation"),
+				"the Kubernetes Service Account " + serviceAccountName + " does not have the required annotation"),
 		},
 		{
 			name: "successfully get authType for secret (not in broker namespace)",
@@ -155,7 +155,7 @@ func TestGetAuthTypeForBrokerCell(t *testing.T) {
 			args:         brokerArgs,
 			wantAuthType: "",
 			wantError: fmt.Errorf("authentication is not configured, " +
-				"when checking Kubernetes Service Account broker, got error: the Kubernetes Service Account broker doesn't have the required annotation, " +
+				"when checking Kubernetes Service Account broker, got error: the Kubernetes Service Account broker does not have the required annotation, " +
 				"when checking Kubernetes Secret google-broker-key, got error: can't find Kubernetes Secret google-broker-key"),
 		},
 		{

--- a/pkg/reconciler/utils/authtype/authtype_test.go
+++ b/pkg/reconciler/utils/authtype/authtype_test.go
@@ -17,9 +17,155 @@ limitations under the License.
 package authtype
 
 import (
+	"context"
+	"fmt"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	pkgtesting "github.com/google/knative-gcp/pkg/reconciler/testing"
+)
+
+const (
+	testNS                   = "test"
+	testBrokerNS             = "cloud-run-events"
+	serviceAccountName       = "test-ksa"
+	secretName               = "test-secret"
+	brokerServiceAccountName = "broker"
+	brokerSecretName         = "google-broker-key"
+)
+
+var (
+	serviceAccountArgs = AuthTypeArgs{
+		Namespace:          testNS,
+		ServiceAccountName: serviceAccountName,
+	}
+
+	secretArgs = AuthTypeArgs{
+		Namespace: testNS,
+		Secret: &v1.SecretKeySelector{
+			LocalObjectReference: v1.LocalObjectReference{
+				Name: secretName,
+			},
+			Key: "key.json",
+		},
+	}
+
+	brokerArgs = AuthTypeArgs{
+		Namespace:          testBrokerNS,
+		ServiceAccountName: brokerServiceAccountName,
+		Secret: &v1.SecretKeySelector{
+			LocalObjectReference: v1.LocalObjectReference{
+				Name: brokerSecretName,
+			},
+			Key: "key.json",
+		},
+	}
 )
 
 func TestGetAuthTypeForWorkloadIdentity(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name         string
+		objects      []runtime.Object
+		args         AuthTypeArgs
+		wantAuthType string
+		wantError    error
+	}{
+		{
+			name: "successfully get authType for workload identity",
+			objects: []runtime.Object{
+				pkgtesting.NewServiceAccount(serviceAccountName, testNS,
+					pkgtesting.WithServiceAccountAnnotation("name"),
+				),
+			},
+			args:         serviceAccountArgs,
+			wantAuthType: "workload-identity-gsa",
+			wantError:    nil,
+		},
+		{
+			name:         "error get authType, service account doesn't exist",
+			objects:      []runtime.Object{},
+			args:         serviceAccountArgs,
+			wantAuthType: "",
+			wantError: fmt.Errorf("using Workload Identity for authentication configuration, " +
+				"can't find Kubernetes Service Account " + serviceAccountName),
+		},
+		{
+			name: "error get authType, service account doesn't have required annotation",
+			objects: []runtime.Object{
+				pkgtesting.NewServiceAccount(serviceAccountName, testNS),
+			},
+			args:         serviceAccountArgs,
+			wantAuthType: "",
+			wantError: fmt.Errorf("using Workload Identity for authentication configuration, " +
+				"Kubernetes Service Account " + serviceAccountName + " doesn't have the required annotation"),
+		},
+		{
+			name: "successfully get authType for secret (not in broker namespace)",
+			objects: []runtime.Object{
+				pkgtesting.NewSecret(secretName, testNS),
+			},
+			args:         secretArgs,
+			wantAuthType: "secret",
+			wantError:    nil,
+		},
+		{
+			name: "error get authType, secret doesn't exist in broker namespace",
+			objects: []runtime.Object{
+				pkgtesting.NewServiceAccount(brokerServiceAccountName, testBrokerNS),
+			},
+			args:         brokerArgs,
+			wantAuthType: "",
+			wantError: fmt.Errorf("authentication is not configured, " +
+				"Secret doesn't present, ServiceAccountName doesn't have required annotation"),
+		},
+		{
+			name: "error get authType, secret doesn't have required key in broker namespace",
+			objects: []runtime.Object{
+				pkgtesting.NewSecret(brokerSecretName, testBrokerNS),
+			},
+			args:         brokerArgs,
+			wantAuthType: "secret",
+			wantError: fmt.Errorf("using Secret for authentication configuration, " +
+				"Kubernests Secret " + brokerSecretName + " doesn't have required key key.json"),
+		},
+		{
+			name: "successfully get authType in broker namespace",
+			objects: []runtime.Object{
+				pkgtesting.NewSecret(brokerSecretName, testBrokerNS,
+					pkgtesting.WithData(map[string][]byte{
+						"key.json": make([]byte, 5, 5),
+					})),
+			},
+			args:         brokerArgs,
+			wantAuthType: "secret",
+			wantError:    nil,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
+			lister := pkgtesting.NewListers(tc.objects)
+
+			gotAuthType, gotError := GetAuthType(ctx, lister.GetServiceAccountLister(), lister.GetSecretLister(), tc.args)
+
+			if diff := cmp.Diff(tc.wantAuthType, gotAuthType); diff != "" {
+				t.Errorf("unexpected authType (-want, +got) = %v", diff)
+			}
+			if tc.wantError != nil {
+				if gotError == nil {
+					t.Errorf("unexpected authType error (-want %v, +got %v)", tc.wantError.Error(), "")
+				} else if diff := cmp.Diff(tc.wantError.Error(), gotError.Error()); diff != "" {
+					t.Errorf("unexpected authType (-want, +got) = %v", diff)
+				}
+			}
+		})
+	}
 }

--- a/pkg/reconciler/utils/authtype/authtype_test.go
+++ b/pkg/reconciler/utils/authtype/authtype_test.go
@@ -157,13 +157,13 @@ func TestGetAuthTypeForWorkloadIdentity(t *testing.T) {
 			gotAuthType, gotError := GetAuthType(ctx, lister.GetServiceAccountLister(), lister.GetSecretLister(), tc.args)
 
 			if diff := cmp.Diff(tc.wantAuthType, gotAuthType); diff != "" {
-				t.Errorf("unexpected authType (-want, +got) = %v", diff)
+				t.Error("unexpected authType (-want, +got) = ", diff)
 			}
 			if tc.wantError != nil {
 				if gotError == nil {
 					t.Errorf("unexpected authType error (-want %v, +got %v)", tc.wantError.Error(), "")
 				} else if diff := cmp.Diff(tc.wantError.Error(), gotError.Error()); diff != "" {
-					t.Errorf("unexpected authType (-want, +got) = %v", diff)
+					t.Error("unexpected authType (-want, +got) = ", diff)
 				}
 			}
 		})

--- a/pkg/reconciler/utils/authtype/authtype_test.go
+++ b/pkg/reconciler/utils/authtype/authtype_test.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authtype
+
+import (
+	"testing"
+)
+
+func TestGetAuthTypeForWorkloadIdentity(t *testing.T) {
+
+}

--- a/pkg/reconciler/utils/authtype/enqueue.go
+++ b/pkg/reconciler/utils/authtype/enqueue.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authtype
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/kmeta"
+
+	listers "github.com/google/knative-gcp/pkg/client/listers/intevents/v1"
+	"github.com/google/knative-gcp/pkg/client/listers/intevents/v1alpha1"
+)
+
+// EnqueuePullSubscriptions returns an event handler for resources which are not created/owned by pullsubscription.
+// It is used for serviceAccountInformer.
+func EnqueuePullSubscriptions(impl *controller.Impl, pullSubscriptionLister listers.PullSubscriptionLister) cache.ResourceEventHandler {
+	return controller.HandleAll(func(obj interface{}) {
+		object, err := kmeta.DeletionHandlingAccessor(obj)
+		if err != nil {
+			return
+		}
+		// Get pullsubscriptions which are in the same namespace as the object.
+		psList, err := pullSubscriptionLister.PullSubscriptions(object.GetNamespace()).List(labels.Everything())
+		if err != nil {
+			return
+		}
+		// Convert pullsubscriptions  with qualified serviceAccountName into namespace/name strings, and pass them to EnqueueKey.
+		for _, ps := range psList {
+			if ps.Spec.ServiceAccountName == object.GetName() {
+				impl.EnqueueKey(types.NamespacedName{Namespace: object.GetNamespace(), Name: ps.Name})
+			}
+		}
+	})
+}
+
+// EnqueueTopic returns an event handler for resources which are not created/owned by topic.
+// It is used for serviceAccountInformer.
+func EnqueueTopic(impl *controller.Impl, topicLister listers.TopicLister) cache.ResourceEventHandler {
+	return controller.HandleAll(func(obj interface{}) {
+		object, err := kmeta.DeletionHandlingAccessor(obj)
+		if err != nil {
+			return
+		}
+		// Get topics which are in the same namespace as the object.
+		topicList, err := topicLister.Topics(object.GetNamespace()).List(labels.Everything())
+		if err != nil {
+			return
+		}
+		// Convert topics with qualified serviceAccountName into namespace/name strings, and pass them to EnqueueKey.
+		for _, t := range topicList {
+			if t.Spec.ServiceAccountName == object.GetName() {
+				impl.EnqueueKey(types.NamespacedName{Namespace: object.GetNamespace(), Name: t.Name})
+			}
+		}
+	})
+}
+
+// EnqueueBrokerCell returns an event handler for resources which are not created/owned by brokercell.
+// It is used for serviceAccountInformer and secretinformer.
+func EnqueueBrokerCell(impl *controller.Impl, brokercellLister v1alpha1.BrokerCellLister) cache.ResourceEventHandler {
+	return controller.HandleAll(func(obj interface{}) {
+		object, err := kmeta.DeletionHandlingAccessor(obj)
+		if err != nil {
+			return
+		}
+		// Get brokercells which are in the same namespace as the object.
+		brokercellList, err := brokercellLister.BrokerCells(object.GetNamespace()).List(labels.Everything())
+		if err != nil {
+			return
+		}
+		// Convert brokercells into namespace/name strings, and pass them to EnqueueKey.
+		for _, bc := range brokercellList {
+			impl.EnqueueKey(types.NamespacedName{Namespace: object.GetNamespace(), Name: bc.Name})
+		}
+	})
+}

--- a/pkg/reconciler/utils/authtype/enqueue.go
+++ b/pkg/reconciler/utils/authtype/enqueue.go
@@ -40,7 +40,7 @@ func EnqueuePullSubscription(impl *controller.Impl, pullSubscriptionLister liste
 		if err != nil {
 			return
 		}
-		// Convert pullsubscriptions  with qualified serviceAccountName into namespace/name strings, and pass them to EnqueueKey.
+		// Convert pullsubscriptions with qualified serviceAccountName into namespace/name strings, and pass them to EnqueueKey.
 		for _, ps := range psList {
 			if ps.Spec.ServiceAccountName == object.GetName() {
 				impl.EnqueueKey(types.NamespacedName{Namespace: object.GetNamespace(), Name: ps.Name})

--- a/pkg/reconciler/utils/authtype/enqueue.go
+++ b/pkg/reconciler/utils/authtype/enqueue.go
@@ -27,9 +27,9 @@ import (
 	"github.com/google/knative-gcp/pkg/client/listers/intevents/v1alpha1"
 )
 
-// EnqueuePullSubscriptions returns an event handler for resources which are not created/owned by pullsubscription.
+// EnqueuePullSubscription returns an event handler for resources which are not created/owned by pullsubscription.
 // It is used for serviceAccountInformer.
-func EnqueuePullSubscriptions(impl *controller.Impl, pullSubscriptionLister listers.PullSubscriptionLister) cache.ResourceEventHandler {
+func EnqueuePullSubscription(impl *controller.Impl, pullSubscriptionLister listers.PullSubscriptionLister) cache.ResourceEventHandler {
 	return controller.HandleAll(func(obj interface{}) {
 		object, err := kmeta.DeletionHandlingAccessor(obj)
 		if err != nil {

--- a/pkg/reconciler/utils/authtype/enqueue.go
+++ b/pkg/reconciler/utils/authtype/enqueue.go
@@ -73,19 +73,19 @@ func EnqueueTopic(impl *controller.Impl, topicLister listers.TopicLister) cache.
 
 // EnqueueBrokerCell returns an event handler for resources which are not created/owned by brokercell.
 // It is used for serviceAccountInformer and secretinformer.
-func EnqueueBrokerCell(impl *controller.Impl, brokercellLister v1alpha1.BrokerCellLister) cache.ResourceEventHandler {
+func EnqueueBrokerCell(impl *controller.Impl, brokerCellLister v1alpha1.BrokerCellLister) cache.ResourceEventHandler {
 	return controller.HandleAll(func(obj interface{}) {
 		object, err := kmeta.DeletionHandlingAccessor(obj)
 		if err != nil {
 			return
 		}
 		// Get brokercells which are in the same namespace as the object.
-		brokercellList, err := brokercellLister.BrokerCells(object.GetNamespace()).List(labels.Everything())
+		brokerCellList, err := brokerCellLister.BrokerCells(object.GetNamespace()).List(labels.Everything())
 		if err != nil {
 			return
 		}
 		// Convert brokercells into namespace/name strings, and pass them to EnqueueKey.
-		for _, bc := range brokercellList {
+		for _, bc := range brokerCellList {
 			impl.EnqueueKey(types.NamespacedName{Namespace: object.GetNamespace(), Name: bc.Name})
 		}
 	})

--- a/pkg/reconciler/utils/authtype/enqueue_test.go
+++ b/pkg/reconciler/utils/authtype/enqueue_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authtype

--- a/pkg/reconciler/utils/authtype/enqueue_test.go
+++ b/pkg/reconciler/utils/authtype/enqueue_test.go
@@ -231,14 +231,14 @@ func TestEnqueueBrokerCells(t *testing.T) {
 			serviceaccountInformer := serviceaccountinfomer.Get(ctx)
 			// Get brokercell lister from tc.objects.
 			lister := gcptesting.NewListers(tc.objects)
-			brokercellLister := lister.GetBrokerCellLister()
+			brokerCellLister := lister.GetBrokerCellLister()
 			// Create a fake controller implementation.
 			logger := logging.FromContext(ctx).Sugar()
 			r := newFakeReconciler()
 			impl := controller.NewImplFull(r, controller.ControllerOptions{WorkQueueName: "test-brokercell-queue", Logger: logger})
 
 			// Configure event handler for serviceaccount informer.
-			serviceaccountInformer.Informer().AddEventHandler(EnqueueBrokerCell(impl, brokercellLister))
+			serviceaccountInformer.Informer().AddEventHandler(EnqueueBrokerCell(impl, brokerCellLister))
 
 			// Put object into store to simulate the process of
 			// reflector syncing a newly changed object into the local Store.

--- a/pkg/reconciler/utils/authtype/enqueue_test.go
+++ b/pkg/reconciler/utils/authtype/enqueue_test.go
@@ -15,3 +15,283 @@ limitations under the License.
 */
 
 package authtype
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/controller"
+	pkgtesting "knative.dev/pkg/reconciler/testing"
+
+	serviceaccountinfomer "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
+
+	"github.com/google/knative-gcp/pkg/logging"
+	gcptesting "github.com/google/knative-gcp/pkg/reconciler/testing"
+	v1 "github.com/google/knative-gcp/pkg/reconciler/testing/v1"
+)
+
+const (
+	pullsubscriptionName = "test-pullsubscription"
+	topicName            = "test-topic"
+	brokercellName       = "test-brokercell"
+)
+
+func TestEnqueuePullSubscriptions(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name           string
+		objects        []runtime.Object
+		serviceAccount *corev1.ServiceAccount
+		wantKey        []string
+	}{
+		{
+			name: "one pullsubcription in the same namespace as the k8s service account successfully enqueue.",
+			objects: []runtime.Object{
+				v1.NewPullSubscription(pullsubscriptionName, testNS, v1.WithPullSubscriptionServiceAccount(serviceAccountName)),
+			},
+			serviceAccount: gcptesting.NewServiceAccount(serviceAccountName, testNS),
+			wantKey: []string{
+				fmt.Sprintf("%s/%s", testNS, pullsubscriptionName),
+			},
+		},
+		{
+			name: "no pullsubcription in the same namespace as the k8s service account.",
+			objects: []runtime.Object{
+				v1.NewPullSubscription(pullsubscriptionName, testNS+"-diff", v1.WithPullSubscriptionServiceAccount(serviceAccountName)),
+			},
+			serviceAccount: gcptesting.NewServiceAccount(serviceAccountName, testNS),
+			wantKey:        []string{},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			//  Sets up the the Context and the fake informers for the tests.
+			ctx, cancel, _ := pkgtesting.SetupFakeContextWithCancel(t)
+			defer cancel()
+			// Get serviceaccount Informer from fake ctx.
+			serviceaccountInformer := serviceaccountinfomer.Get(ctx)
+			// Get pullsubscription lister from tc.objects.
+			lister := gcptesting.NewListers(tc.objects)
+			pullsubscriptionLister := lister.GetPullSubscriptionLister()
+			// Create a fake controller implementation.
+			logger := logging.FromContext(ctx).Sugar()
+			r := newFakeReconciler()
+			impl := controller.NewImplFull(r, controller.ControllerOptions{WorkQueueName: "test-pullsubscription-queue", Logger: logger})
+
+			// Configure event handler for serviceaccount informer.
+			serviceaccountInformer.Informer().AddEventHandler(EnqueuePullSubscription(impl, pullsubscriptionLister))
+
+			// Put object into store to simulate the process of
+			// reflector syncing a newly changed object into the local store.
+			serviceaccountInformer.Informer().GetStore().Add(tc.serviceAccount)
+
+			go func() {
+				// Run the service account informer, it will stop when ctx is cancelled.
+				serviceaccountInformer.Informer().Run(stopCh(ctx))
+			}()
+
+			time.Sleep(1 * time.Second)
+
+			// Get keys enqueued to the workqueue from service account informer event handler.
+			gotKey := []string{}
+			for impl.WorkQueue().Len() != 0 {
+				obj, quit := impl.WorkQueue().Get()
+				if quit {
+					continue
+				}
+				key := obj.(types.NamespacedName)
+				gotKey = append(gotKey, key.String())
+			}
+
+			if diff := cmp.Diff(tc.wantKey, gotKey); diff != "" {
+				t.Error("unexpected authType (-want, +got) = ", diff)
+			}
+		})
+	}
+}
+
+func TestEnqueueTopics(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name           string
+		objects        []runtime.Object
+		serviceAccount *corev1.ServiceAccount
+		wantKey        []string
+	}{
+		{
+			name: "one topic in the same namespace as the k8s service account successfully enqueue.",
+			objects: []runtime.Object{
+				v1.NewTopic(topicName, testNS, v1.WithTopicServiceAccountName(serviceAccountName)),
+			},
+			serviceAccount: gcptesting.NewServiceAccount(serviceAccountName, testNS),
+			wantKey: []string{
+				fmt.Sprintf("%s/%s", testNS, topicName),
+			},
+		},
+		{
+			name: "no topic in the same namespace as the k8s service account.",
+			objects: []runtime.Object{
+				v1.NewTopic(topicName, testNS+"-diff", v1.WithTopicServiceAccountName(serviceAccountName)),
+			},
+			serviceAccount: gcptesting.NewServiceAccount(serviceAccountName, testNS),
+			wantKey:        []string{},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			//  Sets up the the Context and the fake informers for the tests.
+			ctx, cancel, _ := pkgtesting.SetupFakeContextWithCancel(t)
+			defer cancel()
+			// Get serviceaccount Informer from fake ctx.
+			serviceaccountInformer := serviceaccountinfomer.Get(ctx)
+			// Get topic lister from tc.objects.
+			lister := gcptesting.NewListers(tc.objects)
+			topicLister := lister.GetTopicLister()
+			// Create a fake controller implementation.
+			logger := logging.FromContext(ctx).Sugar()
+			r := newFakeReconciler()
+			impl := controller.NewImplFull(r, controller.ControllerOptions{WorkQueueName: "test-topic-queue", Logger: logger})
+
+			// Configure event handler for serviceaccount informer.
+			serviceaccountInformer.Informer().AddEventHandler(EnqueueTopic(impl, topicLister))
+
+			// Put object into store to simulate the process of
+			// reflector syncing a newly changed object into the local Store.
+			serviceaccountInformer.Informer().GetStore().Add(tc.serviceAccount)
+
+			go func() {
+				// Run the service account informer, it will stop when ctx is cancelled.
+				serviceaccountInformer.Informer().Run(stopCh(ctx))
+			}()
+
+			time.Sleep(1 * time.Second)
+
+			// Get keys enqueued to the workqueue from service account informer event handler.
+			gotKey := []string{}
+			for impl.WorkQueue().Len() != 0 {
+				obj, quit := impl.WorkQueue().Get()
+				if quit {
+					continue
+				}
+				key := obj.(types.NamespacedName)
+				gotKey = append(gotKey, key.String())
+			}
+
+			if diff := cmp.Diff(tc.wantKey, gotKey); diff != "" {
+				t.Error("unexpected authType (-want, +got) = ", diff)
+			}
+		})
+	}
+}
+func TestEnqueueBrokerCells(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name           string
+		objects        []runtime.Object
+		serviceAccount *corev1.ServiceAccount
+		wantKey        []string
+	}{
+		{
+			name: "one brokercell in the same namespace as the k8s service account successfully enqueue.",
+			objects: []runtime.Object{
+				gcptesting.NewBrokerCell(brokercellName, testNS),
+			},
+			serviceAccount: gcptesting.NewServiceAccount(serviceAccountName, testNS),
+			wantKey: []string{
+				fmt.Sprintf("%s/%s", testNS, brokercellName),
+			},
+		},
+		{
+			name: "no brokercells in the same namespace as the k8s service account.",
+			objects: []runtime.Object{
+				gcptesting.NewBrokerCell(brokercellName, testNS+"diff"),
+			},
+			serviceAccount: gcptesting.NewServiceAccount(serviceAccountName, testNS),
+			wantKey:        []string{},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			//  Sets up the the Context and the fake informers for the tests.
+			ctx, cancel, _ := pkgtesting.SetupFakeContextWithCancel(t)
+			defer cancel()
+			// Get serviceaccount Informer from fake ctx.
+			serviceaccountInformer := serviceaccountinfomer.Get(ctx)
+			// Get brokercell lister from tc.objects.
+			lister := gcptesting.NewListers(tc.objects)
+			brokercellLister := lister.GetBrokerCellLister()
+			// Create a fake controller implementation.
+			logger := logging.FromContext(ctx).Sugar()
+			r := newFakeReconciler()
+			impl := controller.NewImplFull(r, controller.ControllerOptions{WorkQueueName: "test-brokercell-queue", Logger: logger})
+
+			// Configure event handler for serviceaccount informer.
+			serviceaccountInformer.Informer().AddEventHandler(EnqueueBrokerCell(impl, brokercellLister))
+
+			// Put object into store to simulate the process of
+			// reflector syncing a newly changed object into the local Store.
+			serviceaccountInformer.Informer().GetStore().Add(tc.serviceAccount)
+
+			go func() {
+				// Run the service account informer, it will stop when ctx is cancelled.
+				serviceaccountInformer.Informer().Run(stopCh(ctx))
+			}()
+
+			time.Sleep(1 * time.Second)
+
+			// Get keys enqueued to the workqueue from service account informer event handler.
+			gotKey := []string{}
+			for impl.WorkQueue().Len() != 0 {
+				obj, quit := impl.WorkQueue().Get()
+				if quit {
+					continue
+				}
+				key := obj.(types.NamespacedName)
+				gotKey = append(gotKey, key.String())
+			}
+
+			if diff := cmp.Diff(tc.wantKey, gotKey); diff != "" {
+				t.Error("unexpected authType (-want, +got) = ", diff)
+			}
+		})
+	}
+}
+
+// Fake reconciler for testing.
+type fakeReconciler struct {
+	Reconciler controller.Reconciler
+}
+
+func (fr *fakeReconciler) Reconcile(ctx context.Context, key string) error {
+	return nil
+}
+
+func newFakeReconciler() controller.Reconciler {
+	return fakeReconciler{}.Reconciler
+}
+
+// stopCh will receive termination signal when ctx is cancelled.
+func stopCh(ctx context.Context) chan struct{} {
+	ch := make(chan struct{}, 1)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return ch
+}

--- a/pkg/utils/authcheck/authtype.go
+++ b/pkg/utils/authcheck/authtype.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package authtype
+package authcheck
 
 import (
 	"context"

--- a/pkg/utils/authcheck/authtype_test.go
+++ b/pkg/utils/authcheck/authtype_test.go
@@ -71,7 +71,7 @@ func TestGetAuthTypeForSources(t *testing.T) {
 		name         string
 		objects      []runtime.Object
 		args         AuthTypeArgs
-		wantAuthType AuthTypes
+		wantAuthType AuthType
 		wantError    error
 	}{
 		{
@@ -144,7 +144,7 @@ func TestGetAuthTypeForBrokerCell(t *testing.T) {
 		name         string
 		objects      []runtime.Object
 		args         AuthTypeArgs
-		wantAuthType AuthTypes
+		wantAuthType AuthType
 		wantError    error
 	}{
 		{

--- a/pkg/utils/authcheck/authtype_test.go
+++ b/pkg/utils/authcheck/authtype_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package authtype
+package authcheck
 
 import (
 	"context"

--- a/pkg/utils/authcheck/enqueue.go
+++ b/pkg/utils/authcheck/enqueue.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package authtype
+package authcheck
 
 import (
 	"k8s.io/apimachinery/pkg/labels"

--- a/pkg/utils/authcheck/enqueue_test.go
+++ b/pkg/utils/authcheck/enqueue_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package authtype
+package authcheck
 
 import (
 	"context"


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- First of the three steps to add the authentication check
1. **Environment variable to differentiate authentication mode** (<-this one)
2. Authentication check running inside the Pod
3. Additional k8s Event check for Secret absence

- Functionality includes:
1. Differentiate auth mode and pass K_GCP_AUTH_TYPE into underlying pods
2. Error out auth issue if required secret/k8s service account doesn't exist
3. Customized Event handler added for pullsubscription/topic/brokercell, so that once missing secret/k8s service account are added back, resources can immediately reconcile. 

- Needs to add more UTs.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🎁  Use K_GCP_AUTH_TYPE to differentiate authentication mode (first step for adding authentication check for source and broker)
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
