### PR TITLE
Fix issue to run broker gcp perf test locally

### DIFF
--- a/test/performance/benchmarks/broker-gcp/200-broker-gcp.yaml
+++ b/test/performance/benchmarks/broker-gcp/200-broker-gcp.yaml
@@ -41,14 +41,16 @@ spec:
           - "--aggregator=broker-gcp-aggregator:10000"
           - "--pace=100:10,200:20,400:30,500:60,600:60"
         env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
+        - name: GOGC
+          value: "off"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         resources:
           requests:
             cpu: 1000m
@@ -77,6 +79,17 @@ spec:
     - "--roles=aggregator"
       # set to the number of sender + receiver (same image that does both counts 2)
     - "--expect-records=2"
+    env:
+      - name: GOGC
+        value: "off"
+      - name: POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: POD_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
     ports:
     - name: grpc
       containerPort: 10000

--- a/test/performance/benchmarks/broker-gcp/dev.config
+++ b/test/performance/benchmarks/broker-gcp/dev.config
@@ -24,6 +24,7 @@ owner_list: "ngiraldo@google.com"
 owner_list: "rustemb@google.com"
 owner_list: "xiyue@google.com"
 owner_list: "zar@google.com"
+owner_list: "zhongduo@google.com"
 
 # Anyone can add their IAM robot here to publish to this benchmark.
 owner_list: "mako-job@knative-performance.iam.gserviceaccount.com"
@@ -34,6 +35,7 @@ owner_list: "mako-upload@gracegao-knative-gcp-testing.iam.gserviceaccount.com"
 owner_list: "mako-upload@knative-project-228222.iam.gserviceaccount.com"
 owner_list: "mako-upload@ngiraldo-knative-dev.iam.gserviceaccount.com"
 owner_list: "mako-upload@xiyue-knative-project.iam.gserviceaccount.com"
+owner_list: "mako-upload@jimmy-knative-dev.iam.gserviceaccount.com"
 
 # Define the name and type for x-axis of run charts
 input_value_info: {

--- a/test/performance/benchmarks/broker-gcp/prod.config
+++ b/test/performance/benchmarks/broker-gcp/prod.config
@@ -24,6 +24,7 @@ owner_list: "ngiraldo@google.com"
 owner_list: "rustemb@google.com"
 owner_list: "xiyue@google.com"
 owner_list: "zar@google.com"
+owner_list: "zhongduo@google.com"
 
 # GCP Service Accounts that can publish data to Mako. Since this is a prod
 # benchmark, only the CI account should be listed here.

--- a/test/performance/benchmarks/channel-pubsub/dev.config
+++ b/test/performance/benchmarks/channel-pubsub/dev.config
@@ -24,6 +24,7 @@ owner_list: "ngiraldo@google.com"
 owner_list: "rustemb@google.com"
 owner_list: "xiyue@google.com"
 owner_list: "zar@google.com"
+owner_list: "zhongduo@google.com"
 
 # Anyone can add their IAM robot here to publish to this benchmark.
 owner_list: "mako-job@knative-performance.iam.gserviceaccount.com"
@@ -33,6 +34,7 @@ owner_list: "mako-upload@grantrodgers-crd.iam.gserviceaccount.com"
 owner_list: "mako-upload@gracegao-knative-gcp-testing.iam.gserviceaccount.com"
 owner_list: "mako-upload@ngiraldo-knative-dev.iam.gserviceaccount.com"
 owner_list: "mako-upload@xiyue-knative-project.iam.gserviceaccount.com"
+owner_list: "mako-upload@jimmy-knative-dev.iam.gserviceaccount.com"
 
 # Define the name and type for x-axis of run charts
 input_value_info: {

--- a/test/performance/benchmarks/channel-pubsub/prod.config
+++ b/test/performance/benchmarks/channel-pubsub/prod.config
@@ -24,6 +24,7 @@ owner_list: "ngiraldo@google.com"
 owner_list: "rustemb@google.com"
 owner_list: "xiyue@google.com"
 owner_list: "zar@google.com"
+owner_list: "zhongduo@google.com"
 
 # GCP Service Accounts that can publish data to Mako. Since this is a prod
 # benchmark, only the CI account should be listed here.


### PR DESCRIPTION
After this PR, the gcp broker perf test can be run locally with https://github.com/knative/pkg/pull/1930

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add zhongduo to owner list
- Fix yaml for running perf test locally
-
