### PR TITLE
Mark broker failed for trigger if the broker doesn't exist

### DIFF
--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -99,7 +99,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *brokerv1beta1.Trigger
 	}
 
 	if apierrs.IsNotFound(err) {
-		logging.FromContext(ctx).Error(fmt.Sprintf("Trigger %s/%s has no broker %s", t.Namespace, t.Name, t.Spec.Broker))
+		logging.FromContext(ctx).Error("Trigger does not have broker", zap.String("namespace", t.Namespace), zap.String("trigger", t.Name), zap.String("broker", t.Spec.Broker))
 		t.Status.MarkBrokerFailed("BrokerDoesNotExist", "Broker %s does not exist", t.Spec.Broker)
 	}
 

--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -98,6 +98,11 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *brokerv1beta1.Trigger
 		return err
 	}
 
+	if apierrs.IsNotFound(err) {
+		logging.FromContext(ctx).Error(fmt.Sprintf("Trigger %s/%s has no broker %s", t.Namespace, t.Name, t.Spec.Broker))
+		t.Status.MarkBrokerFailed("BrokerDoesNotExist", "Broker %s does not exist", t.Spec.Broker)
+	}
+
 	// If the broker has been or is being deleted, we clean up resources created by this controller
 	// for the given trigger.
 	if apierrs.IsNotFound(err) || !b.GetDeletionTimestamp().IsZero() {

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -197,6 +197,15 @@ func TestAllCasesTrigger(t *testing.T) {
 					TopicAndSub("cre-tgr_testnamespace_test-trigger_abc123", "cre-tgr_testnamespace_test-trigger_abc123"),
 				},
 			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewTrigger(triggerName, testNS, brokerName,
+					WithTriggerUID(testUID),
+					WithTriggerFinalizers(finalizerName),
+					WithTriggerSetDefaults,
+					WithInitTriggerConditions,
+					WithTriggerBrokerFailed("BrokerDoesNotExist", "Broker test-broker does not exist"),
+				),
+			}},
 		},
 		{
 			Name: "Broker is being deleted, Trigger with finalizer should be finalized",


### PR DESCRIPTION
Fixes #
Before this change the trigger would show `BrokerReady` even when the broker doesn't exist which doesn't comply with the [spec](https://github.com/knative/eventing/blob/master/docs/spec/spec.md)

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
