### PR TITLE
Update out-dated installation doc for installing from a release

### DIFF
--- a/docs/install/install-knative-gcp.md
+++ b/docs/install/install-knative-gcp.md
@@ -82,21 +82,24 @@ ko apply -f ./config
    export KGCP_VERSION=v0.19.0
    ```
 
-1. First install the CRDs by running the `kubectl apply` for `cloud-run-events-pre-install-jobs.yaml`.
-This prevents race conditions during the installation, which
-   cause intermittent errors:
+1. First install the CRDs by running the `kubectl apply` for `cloud-run-events-pre-install-jobs.yaml`
+and `cloud-run-events.yaml` with selector. This prevents race conditions during the installation, which
+cause intermittent errors:
 
    ```shell
    kubectl apply --filename https://github.com/google/knative-gcp/releases/download/${KGCP_VERSION}/cloud-run-events-pre-install-jobs.yaml
+   kubectl apply --selector events.cloud.google.com/crd-install=true \
+   --filename https://github.com/google/knative-gcp/releases/download/${KGCP_VERSION}/cloud-run-events.yaml
    ```
 
-1. To complete the installation, run the `kubectl apply` for `cloud-run-events.yaml`:
+1. To complete the installation, run the `kubectl apply` again for `cloud-run-events.yaml` without selector:
 
    ```shell
    kubectl apply --filename https://github.com/google/knative-gcp/releases/download/${KGCP_VERSION}/cloud-run-events.yaml
    ```
-**Notes:** For different releases, the installation files may be different (e.g. some old releases don't have `cloud-run-events-pre-install-jobs.yaml`).
-Above commands are just for the general case. For one specific release, to make sure it contains all those files,
+**Notes:** Above commands are just for the general case. For different releases, the installation files may be different
+(e.g. some old releases don't have `cloud-run-events-pre-install-jobs.yaml`, then you can just ignore related command).
+For one specific release, to make sure it contains all those files,
 please check the assets under the [release tag]((https://github.com/google/knative-gcp/releases)) before applying the above commands.
 
 ## Configure the Authentication Mechanism for GCP (the Control Plane)

--- a/docs/install/install-knative-gcp.md
+++ b/docs/install/install-knative-gcp.md
@@ -82,12 +82,15 @@ ko apply -f ./config
    export KGCP_VERSION=v0.19.0
    ```
 
-1. First install the CRDs by running the `kubectl apply` for `cloud-run-events-pre-install-jobs.yaml`
-and `cloud-run-events.yaml` with selector. This prevents race conditions during the installation, which
+1. First install the pre-install job by running the `kubectl apply` for `cloud-run-events-pre-install-jobs.yaml`.
+Skip this step if you are installing a release before v0.18.0.
+   ```shell
+   kubectl apply --filename https://github.com/google/knative-gcp/releases/download/${KGCP_VERSION}/cloud-run-events-pre-install-jobs.yaml
+   ```
+1. Install the CRDs by running the `kubectl apply` for `cloud-run-events.yaml` with selector. This prevents race conditions during the installation, which
 cause intermittent errors:
 
    ```shell
-   kubectl apply --filename https://github.com/google/knative-gcp/releases/download/${KGCP_VERSION}/cloud-run-events-pre-install-jobs.yaml
    kubectl apply --selector events.cloud.google.com/crd-install=true \
    --filename https://github.com/google/knative-gcp/releases/download/${KGCP_VERSION}/cloud-run-events.yaml
    ```
@@ -97,11 +100,7 @@ cause intermittent errors:
    ```shell
    kubectl apply --filename https://github.com/google/knative-gcp/releases/download/${KGCP_VERSION}/cloud-run-events.yaml
    ```
-**Notes:** Above commands are just for the general case. For different releases, the installation files may be different
-(e.g. some old releases don't have `cloud-run-events-pre-install-jobs.yaml`, then you can just ignore related command).
-For one specific release, to make sure it contains all those files,
-please check the assets under the [release tag]((https://github.com/google/knative-gcp/releases)) before applying the above commands.
-
+   
 ## Configure the Authentication Mechanism for GCP (the Control Plane)
 
 Currently, we support two methods: Workload Identity and Kubernetes Secret. The

--- a/docs/install/install-knative-gcp.md
+++ b/docs/install/install-knative-gcp.md
@@ -79,26 +79,25 @@ ko apply -f ./config
 1. Pick a knative-gcp release version:
 
    ```shell
-   export KGCP_VERSION=v0.15.0
+   export KGCP_VERSION=v0.19.0
    ```
 
-1. First install the CRDs by running the `kubectl apply` command with the
-   `--selector` flag. This prevents race conditions during the install, which
+1. First install the CRDs by running the `kubectl apply` for `cloud-run-events-pre-install-jobs.yaml`.
+This prevents race conditions during the installation, which
    cause intermittent errors:
 
    ```shell
-   kubectl apply --selector messaging.cloud.google.com/crd-install=true \
-   --filename https://github.com/google/knative-gcp/releases/download/${KGCP_VERSION}/cloud-run-events.yaml
-   kubectl apply --selector events.cloud.google.com/crd-install=true \
-   --filename https://github.com/google/knative-gcp/releases/download/${KGCP_VERSION}/cloud-run-events.yaml
+   kubectl apply --filename https://github.com/google/knative-gcp/releases/download/${KGCP_VERSION}/cloud-run-events-pre-install-jobs.yaml
    ```
 
-1. To complete the install run the `kubectl apply` command again, this time
-   without the `--selector` flags:
+1. To complete the installation, run the `kubectl apply` for `cloud-run-events.yaml`:
 
    ```shell
    kubectl apply --filename https://github.com/google/knative-gcp/releases/download/${KGCP_VERSION}/cloud-run-events.yaml
    ```
+**Notes:** For different releases, the installation files may be different (e.g. some old releases don't have `cloud-run-events-pre-install-jobs.yaml`).
+Above commands are just for the general case. For one specific release, to make sure it contains all those files,
+please check the assets under the [release tag]((https://github.com/google/knative-gcp/releases)) before applying the above commands.
 
 ## Configure the Authentication Mechanism for GCP (the Control Plane)
 

--- a/docs/install/install-knative-gcp.md
+++ b/docs/install/install-knative-gcp.md
@@ -100,7 +100,7 @@ cause intermittent errors:
    ```shell
    kubectl apply --filename https://github.com/google/knative-gcp/releases/download/${KGCP_VERSION}/cloud-run-events.yaml
    ```
-   
+
 ## Configure the Authentication Mechanism for GCP (the Control Plane)
 
 Currently, we support two methods: Workload Identity and Kubernetes Secret. The


### PR DESCRIPTION
Fixes #1952

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- installation doc for knative-gcp is out-dated, update it with removing selector flag
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
