### PR TITLE
[release-0.19] Upgrade trigger's serving subscriber version to v1

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.1
-    - uses: actions/setup-go@v2.1.0
+    - uses: actions/setup-go@v2.1.3
       with:
         go-version: 1.14.4
     - name: gofmt

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -53,7 +53,8 @@ import (
 
 var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 	// For group eventing.knative.dev.
-	brokerv1beta1.SchemeGroupVersion.WithKind("Broker"): &brokerv1beta1.Broker{},
+	brokerv1beta1.SchemeGroupVersion.WithKind("Broker"):  &brokerv1beta1.Broker{},
+	brokerv1beta1.SchemeGroupVersion.WithKind("Trigger"): &brokerv1beta1.Trigger{},
 
 	// For group messaging.cloud.google.com.
 	messagingv1beta1.SchemeGroupVersion.WithKind("Channel"): &messagingv1beta1.Channel{},

--- a/pkg/apis/broker/v1beta1/trigger_defaults.go
+++ b/pkg/apis/broker/v1beta1/trigger_defaults.go
@@ -20,8 +20,16 @@ import (
 	"context"
 )
 
+const (
+	knativeServingV1ApiVersion       = "serving.knative.dev/v1"
+	knativeServingV1Alpha1ApiVersion = "serving.knative.dev/v1alpha1"
+)
+
 // SetDefaults sets the default field values for a Trigger.
 func (t *Trigger) SetDefaults(ctx context.Context) {
-	// The Google Cloud Broker doesn't have any custom defaults. The
-	// eventing webhook will add the usual defaults.
+	// This upgrades the `ApiVersion` of the knative serving subscriber form v1alpha1 to v1, this is intended to
+	// help users who are lagging in their transition to knative serving v1.
+	if t.Spec.Subscriber.Ref != nil && t.Spec.Subscriber.Ref.APIVersion == knativeServingV1Alpha1ApiVersion {
+		t.Spec.Subscriber.Ref.APIVersion = knativeServingV1ApiVersion
+	}
 }

--- a/pkg/apis/broker/v1beta1/trigger_defaults_test.go
+++ b/pkg/apis/broker/v1beta1/trigger_defaults_test.go
@@ -19,9 +19,63 @@ package v1beta1
 import (
 	"context"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	eventingv1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
-func TestTrigger_SetDefaults(t *testing.T) {
-	trig := Trigger{}
-	trig.SetDefaults(context.TODO())
+func TestTriggerDefaults(t *testing.T) {
+	testCases := map[string]struct {
+		initial  Trigger
+		expected Trigger
+	}{
+		"non-knative v1alpha1 service subscriber": {
+			initial: Trigger{
+				Spec: eventingv1beta1.TriggerSpec{
+					Subscriber: duckv1.Destination{
+						Ref: &duckv1.KReference{
+							APIVersion: "serving.knative.dev/v1",
+							Kind:       "Service",
+						},
+					},
+				}},
+			expected: Trigger{
+				Spec: eventingv1beta1.TriggerSpec{
+					Subscriber: duckv1.Destination{
+						Ref: &duckv1.KReference{
+							APIVersion: "serving.knative.dev/v1",
+							Kind:       "Service",
+						},
+					}}},
+		},
+		"knative v1alpha1 service subscriber": {
+			initial: Trigger{
+				Spec: eventingv1beta1.TriggerSpec{
+					Subscriber: duckv1.Destination{
+						Ref: &duckv1.KReference{
+							APIVersion: "serving.knative.dev/v1alpha1",
+							Kind:       "Service",
+						},
+					},
+				}},
+			expected: Trigger{
+				Spec: eventingv1beta1.TriggerSpec{
+					Subscriber: duckv1.Destination{
+						Ref: &duckv1.KReference{
+							APIVersion: "serving.knative.dev/v1",
+							Kind:       "Service",
+						},
+					}}},
+		},
+	}
+
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			tc.initial.SetDefaults(context.Background())
+			if diff := cmp.Diff(tc.expected, tc.initial); diff != "" {
+				t.Fatal("Unexpected defaults (-want, +got):", diff)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Fixes #

This is to handle an issue related to setting the ApiVersion of the trigger's subscriber (knative service) to an unsupported version

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
