### PR TITLE
Revert "[Automated] Update actions"

### DIFF
--- a/.github/workflows/knative-releasability.yaml
+++ b/.github/workflows/knative-releasability.yaml
@@ -142,7 +142,7 @@ jobs:
           echo 'SLACK_TITLE=Releasability for ${{ github.repository }} @ ${{ env.RELEASE }} is NO-GO!' >> $GITHUB_ENV
 
       - name: Post status to Slack
-        if: ${{ secrets.SLACK_WEBHOOK != '' && steps.exists.outputs.release-branch == 'false' }}
+        if: steps.exists.outputs.release-branch == 'false'
         uses: rtCamp/action-slack-notify@v2.1.0
         env:
           SLACK_ICON: http://github.com/knative.png?size=48

--- a/.github/workflows/knative-style.yaml
+++ b/.github/workflows/knative-style.yaml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Install Tools
         env:
-          WOKE_VERSION: v0.4.1
+          WOKE_VERSION: v0.1.15
         run: |
           TEMP_PATH="$(mktemp -d)"
           cd $TEMP_PATH


### PR DESCRIPTION
Reverts google/knative-gcp#1970

The update to the `woke` script is causing failures due to the substring "native" in "knative", e.g., https://github.com/google/knative-gcp/commit/1ed02d21751b944fa5ae55467dc64a62d59fb467#annotation_661149281