### PR TITLE
Configure webhook port in yaml

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -261,7 +261,7 @@ func main() {
 	// Set up a signal context with our webhook options
 	ctx := webhook.WithOptions(signals.NewContext(), webhook.Options{
 		ServiceName: webhook.NameFromEnv(),
-		Port:        8443,
+		Port:        webhook.PortFromEnv(8443),
 		// SecretName must match the name of the Secret created in the configuration.
 		SecretName: "webhook-certs",
 	})

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -61,3 +61,5 @@ spec:
               value: cloud.google.com/events
             - name: WEBHOOK_NAME
               value: webhook
+            - name: WEBHOOK_PORT
+              value: "8443"


### PR DESCRIPTION
This is how Eventing configures its webhook. Keeps us closer to the Eventing state and adds some flexibility to the port the webhook runs on.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use the webhook port set in `WEBHOOK_PORT` if configured

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
:gift: The webhook now listens on the port set in the WEBHOOK_PORT environment variable or 8443 if unset.
```
