### PR TITLE
feat/dataresidency: use cluster region as default setting

### DIFF
--- a/config/core/configmaps/data-residency.yaml
+++ b/config/core/configmaps/data-residency.yaml
@@ -18,7 +18,7 @@ metadata:
   name: config-dataresidency
   namespace: cloud-run-events
   annotations:
-    knative.dev/example-checksum: "16b18753"
+    knative.dev/example-checksum: "3c0011c5"
 data:
   default-dataresidency-config: |
     clusterDefaults:
@@ -48,7 +48,10 @@ data:
       # clusterDefaults are the defaults to apply to every namespace in the
       # cluster
       clusterDefaults:
-        # messagestoragepolicy.global will set to the Org Policy
+        # messagestoragepolicy.global determines whether Global PubSub Topics are allowed.
+        # If set to false, then the PubSub Topic will be regional, based on the region the
+        # GKE cluster is running in. If set to true, then the PubSub Topic is allowed to be
+        # Global, as long as messagestoragepolicy.allowedpersistenceregions is empty and no GCP Org Policy forbids it.
         messagestoragepolicy.global: false
         # messagestoragepolicy.allowedpersistenceregions field specifies
         # all the allowed regions for data residency. The default or an empty value will

--- a/config/core/configmaps/data-residency.yaml
+++ b/config/core/configmaps/data-residency.yaml
@@ -18,10 +18,11 @@ metadata:
   name: config-dataresidency
   namespace: cloud-run-events
   annotations:
-    knative.dev/example-checksum: "809e8f92"
+    knative.dev/example-checksum: "f9aa8a13"
 data:
   default-dataresidency-config: |
     clusterDefaults:
+      messagestoragepolicy.global: false
       messagestoragepolicy.allowedpersistenceregions: []
   _example: |
     ################################
@@ -40,14 +41,16 @@ data:
     # to actually change the configuration.
 
     # default-dataresidency-config is the configuration for determining the default
-    # data residency to apply to all objects that require data residency.
-    # This is expected to be Channels and Sources and Brokers.
+    # data residency to apply to all objects that require data residency but,
+    # do not specify it. This is expected to be Channels and Sources.
     #
     # We only support cluster scoped now
     default-dataresidency-config: |
       # clusterDefaults are the defaults to apply to every namespace in the
       # cluster
       clusterDefaults:
+        # messagestoragepolicy.global will set to the Org Policy
+        messagestoragepolicy.global: false
         # messagestoragepolicy.allowedpersistenceregions field specifies
         # all the allowed regions for data residency. The default or an empty value will
         # mean no data residency requirement.

--- a/config/core/configmaps/data-residency.yaml
+++ b/config/core/configmaps/data-residency.yaml
@@ -18,11 +18,10 @@ metadata:
   name: config-dataresidency
   namespace: cloud-run-events
   annotations:
-    knative.dev/example-checksum: "f9aa8a13"
+    knative.dev/example-checksum: "16b18753"
 data:
   default-dataresidency-config: |
     clusterDefaults:
-      messagestoragepolicy.global: false
       messagestoragepolicy.allowedpersistenceregions: []
   _example: |
     ################################
@@ -41,8 +40,8 @@ data:
     # to actually change the configuration.
 
     # default-dataresidency-config is the configuration for determining the default
-    # data residency to apply to all objects that require data residency but,
-    # do not specify it. This is expected to be Channels and Sources.
+    # data residency to apply to all objects that require data residency.
+    # This is expected to be Channels and Sources and Brokers.
     #
     # We only support cluster scoped now
     default-dataresidency-config: |

--- a/pkg/apis/configs/dataresidency/dataresidency_defaults_test.go
+++ b/pkg/apis/configs/dataresidency/dataresidency_defaults_test.go
@@ -74,23 +74,20 @@ func TestComputeAllowedPersistenceRegions(t *testing.T) {
 		dsRegions          []string
 		expectedRegions    []string
 		global             bool
-		err                bool
 		updated            bool
 	}{
 		{
 			ns:                 "subset",
 			topicConfigRegions: []string{"us-east1", "us-west1"},
 			dsRegions:          []string{"us-west1"},
-			expectedRegions:    []string{"us-west1"},
-			err:                true,
+			expectedRegions:    []string{"us-east1", "us-west1"},
 			updated:            false,
 		},
 		{
 			ns:                 "conflict",
 			topicConfigRegions: []string{"us-east1"},
 			dsRegions:          []string{"us-west1"},
-			expectedRegions:    []string{"us-west1"},
-			err:                true,
+			expectedRegions:    []string{"us-east1"},
 			updated:            false,
 		},
 		{
@@ -98,7 +95,6 @@ func TestComputeAllowedPersistenceRegions(t *testing.T) {
 			topicConfigRegions: nil,
 			dsRegions:          []string{"us-west1"},
 			expectedRegions:    []string{"us-west1"},
-			err:                false,
 			updated:            true,
 		},
 		{
@@ -106,7 +102,6 @@ func TestComputeAllowedPersistenceRegions(t *testing.T) {
 			topicConfigRegions: nil,
 			dsRegions:          []string{},
 			expectedRegions:    []string{clusterRegion},
-			err:                false,
 			updated:            true,
 		},
 		{
@@ -114,7 +109,6 @@ func TestComputeAllowedPersistenceRegions(t *testing.T) {
 			topicConfigRegions: nil,
 			dsRegions:          nil,
 			expectedRegions:    []string{clusterRegion},
-			err:                true,
 			updated:            true,
 		},
 		{
@@ -123,12 +117,8 @@ func TestComputeAllowedPersistenceRegions(t *testing.T) {
 			topicConfigRegions: nil,
 			dsRegions:          nil,
 			expectedRegions:    nil,
-			err:                false,
 			updated:            false,
 		},
-	}
-	clusterRegionGetter := func() (string, error) {
-		return clusterRegion, nil
 	}
 	for _, tc := range testCases {
 		t.Run(tc.ns, func(t *testing.T) {
@@ -137,13 +127,7 @@ func TestComputeAllowedPersistenceRegions(t *testing.T) {
 			defaults.ClusterDefaults.Global = tc.global
 			topicConfig := &pubsub.TopicConfig{}
 			topicConfig.MessageStoragePolicy.AllowedPersistenceRegions = tc.topicConfigRegions
-			updated, err := defaults.ComputeAllowedPersistenceRegions(topicConfig, clusterRegionGetter)
-			if err != nil {
-				if !tc.err {
-					t.Error("Unexpected error: ", err)
-				}
-				return
-			}
+			updated := defaults.ComputeAllowedPersistenceRegions(topicConfig, clusterRegion)
 			if updated != tc.updated {
 				t.Errorf("Unexpected updated value, expected: %v, got %v", tc.updated, updated)
 			}

--- a/pkg/apis/configs/dataresidency/dataresidency_defaults_test.go
+++ b/pkg/apis/configs/dataresidency/dataresidency_defaults_test.go
@@ -119,6 +119,14 @@ func TestComputeAllowedPersistenceRegions(t *testing.T) {
 			expectedRegions:    nil,
 			updated:            false,
 		},
+		{
+			ns:                 "ds-global-and-regions",
+			global:             true,
+			topicConfigRegions: nil,
+			dsRegions:          []string{"us-east1"},
+			expectedRegions:    []string{"us-east1"},
+			updated:            true,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.ns, func(t *testing.T) {

--- a/pkg/apis/configs/dataresidency/dataresidency_defaults_test.go
+++ b/pkg/apis/configs/dataresidency/dataresidency_defaults_test.go
@@ -65,6 +65,7 @@ func TestNewDefaultsConfigFromConfigMap(t *testing.T) {
 }
 
 func TestComputeAllowedPersistenceRegions(t *testing.T) {
+	const clusterRegion = "us-central1"
 	// Only cluster wide configuration is supported now, but we use the namespace
 	// as the test name and for future extension.
 	testCases := []struct {
@@ -72,37 +73,46 @@ func TestComputeAllowedPersistenceRegions(t *testing.T) {
 		topicConfigRegions []string
 		dsRegions          []string
 		expectedRegions    []string
+		err                bool
 	}{
 		{
 			ns:                 "subset",
 			topicConfigRegions: []string{"us-east1", "us-west1"},
 			dsRegions:          []string{"us-west1"},
 			expectedRegions:    []string{"us-west1"},
+			err:                true,
 		},
 		{
 			ns:                 "conflict",
 			topicConfigRegions: []string{"us-east1"},
 			dsRegions:          []string{"us-west1"},
 			expectedRegions:    []string{"us-west1"},
+			err:                true,
 		},
 		{
 			ns:                 "topic-nil",
 			topicConfigRegions: nil,
 			dsRegions:          []string{"us-west1"},
 			expectedRegions:    []string{"us-west1"},
+			err:                false,
 		},
 		{
 			ns:                 "topic-nil-ds-empty",
 			topicConfigRegions: nil,
 			dsRegions:          []string{},
-			expectedRegions:    nil,
+			expectedRegions:    []string{clusterRegion},
+			err:                false,
 		},
 		{
-			ns:                 "ds-empty",
-			topicConfigRegions: []string{"us-east1"},
-			dsRegions:          []string{},
-			expectedRegions:    []string{"us-east1"},
+			ns:                 "topic-nil-ds-empty",
+			topicConfigRegions: nil,
+			dsRegions:          nil,
+			expectedRegions:    []string{clusterRegion},
+			err:                true,
 		},
+	}
+	clusterRegionGetter := func() (string, error) {
+		return clusterRegion, nil
 	}
 	for _, tc := range testCases {
 		t.Run(tc.ns, func(t *testing.T) {
@@ -110,7 +120,13 @@ func TestComputeAllowedPersistenceRegions(t *testing.T) {
 			defaults.ClusterDefaults.AllowedPersistenceRegions = tc.dsRegions
 			topicConfig := &pubsub.TopicConfig{}
 			topicConfig.MessageStoragePolicy.AllowedPersistenceRegions = tc.topicConfigRegions
-			defaults.ComputeAllowedPersistenceRegions(topicConfig)
+			_, err := defaults.ComputeAllowedPersistenceRegions(topicConfig, clusterRegionGetter)
+			if err != nil {
+				if !tc.err {
+					t.Error("Unexpected error: ", err)
+				}
+				return
+			}
 			if diff := cmp.Diff(tc.expectedRegions, topicConfig.MessageStoragePolicy.AllowedPersistenceRegions); diff != "" {
 				t.Errorf("Unexpected value (-want +got): %s", diff)
 			}

--- a/pkg/apis/configs/dataresidency/defaults.go
+++ b/pkg/apis/configs/dataresidency/defaults.go
@@ -62,17 +62,17 @@ func (d *Defaults) ComputeAllowedPersistenceRegions(topicConfig *pubsub.TopicCon
 		// Don't try to change anything if it is not empty
 		return false
 	}
-	if d.Global() {
-		// Not setting means same as Org Policy
-		return false
-	}
 	// We can do subset of both in the future, but for now, we just overwrite the
 	// configuration as the relationship between region and zones are not clear to handle,
 	// eg. us-east1 vs us-east1-a. Important note: setting the AllowedPersistenceRegions
 	// to empty string slice is an error, should set it to nil for all regions.
 	allowedRegions := d.AllowedPersistenceRegions()
 	// overwrite empty allowedRegions to nil
-	if allowedRegions != nil && len(allowedRegions) == 0 {
+	if len(allowedRegions) == 0 {
+		if d.Global() {
+			// Not setting means same as Org Policy
+			return false
+		}
 		allowedRegions = nil
 	}
 	if clusterRegion != "" && allowedRegions == nil {

--- a/pkg/apis/configs/dataresidency/store.go
+++ b/pkg/apis/configs/dataresidency/store.go
@@ -19,9 +19,6 @@ package dataresidency
 import (
 	"context"
 
-	"cloud.google.com/go/pubsub"
-	"github.com/google/knative-gcp/pkg/gclient/metadata"
-	"github.com/google/knative-gcp/pkg/utils"
 	"knative.dev/pkg/configmap"
 )
 
@@ -92,28 +89,4 @@ func (s *Store) Load() *Config {
 	return &Config{
 		DataResidencyDefaults: s.UntypedLoad(ConfigMapName()).(*Defaults).DeepCopy(),
 	}
-}
-
-// ComputeAllowedPersistenceRegions computes the final message storage policy in
-// topicConfig. When the store is nil, default to the cluster zone
-func (s *Store) ComputeAllowedPersistenceRegions(topicConfig *pubsub.TopicConfig, metadataClientCreator func() metadata.Client) (bool, error) {
-	if s != nil {
-		if cfg := s.Load(); cfg != nil {
-			return cfg.DataResidencyDefaults.ComputeAllowedPersistenceRegions(topicConfig), nil
-		}
-	} else {
-		// defualt to cluster zone
-		zone, err := metadataClientCreator().Zone()
-		if err != nil {
-			return false, err
-		}
-		region, err := utils.ZoneToRegion(zone)
-		if err != nil {
-			return false, err
-		}
-		topicConfig.MessageStoragePolicy.AllowedPersistenceRegions = []string{region}
-		return true, nil
-
-	}
-	return false, nil
 }

--- a/pkg/apis/configs/dataresidency/store.go
+++ b/pkg/apis/configs/dataresidency/store.go
@@ -19,6 +19,9 @@ package dataresidency
 import (
 	"context"
 
+	"cloud.google.com/go/pubsub"
+	"github.com/google/knative-gcp/pkg/gclient/metadata"
+	"github.com/google/knative-gcp/pkg/utils"
 	"knative.dev/pkg/configmap"
 )
 
@@ -89,4 +92,28 @@ func (s *Store) Load() *Config {
 	return &Config{
 		DataResidencyDefaults: s.UntypedLoad(ConfigMapName()).(*Defaults).DeepCopy(),
 	}
+}
+
+// ComputeAllowedPersistenceRegions computes the final message storage policy in
+// topicConfig. When the store is nil, default to the cluster zone
+func (s *Store) ComputeAllowedPersistenceRegions(topicConfig *pubsub.TopicConfig, metadataClientCreator func() metadata.Client) (bool, error) {
+	if s != nil {
+		if cfg := s.Load(); cfg != nil {
+			return cfg.DataResidencyDefaults.ComputeAllowedPersistenceRegions(topicConfig), nil
+		}
+	} else {
+		// defualt to cluster zone
+		zone, err := metadataClientCreator().Zone()
+		if err != nil {
+			return false, err
+		}
+		region, err := utils.ZoneToRegion(zone)
+		if err != nil {
+			return false, err
+		}
+		topicConfig.MessageStoragePolicy.AllowedPersistenceRegions = []string{region}
+		return true, nil
+
+	}
+	return false, nil
 }

--- a/pkg/apis/configs/dataresidency/testdata/config-dataresidency.yaml
+++ b/pkg/apis/configs/dataresidency/testdata/config-dataresidency.yaml
@@ -39,8 +39,8 @@ data:
     # to actually change the configuration.
 
     # default-dataresidency-config is the configuration for determining the default
-    # data residency to apply to all objects that require data residency but,
-    # do not specify it. This is expected to be Channels and Sources.
+    # data residency to apply to all objects that require data residency.
+    # This is expected to be Channels and Sources and Brokers.
     #
     # We only support cluster scoped now
     default-dataresidency-config: |

--- a/pkg/apis/configs/dataresidency/testdata/config-dataresidency.yaml
+++ b/pkg/apis/configs/dataresidency/testdata/config-dataresidency.yaml
@@ -47,7 +47,10 @@ data:
       # clusterDefaults are the defaults to apply to every namespace in the
       # cluster
       clusterDefaults:
-        # messagestoragepolicy.global will set to the Org Policy
+        # messagestoragepolicy.global determines whether Global PubSub Topics are allowed.
+        # If set to false, then the PubSub Topic will be regional, based on the region the
+        # GKE cluster is running in. If set to true, then the PubSub Topic is allowed to be
+        # Global, as long as messagestoragepolicy.allowedpersistenceregions is empty and no GCP Org Policy forbids it.
         messagestoragepolicy.global: false
         # messagestoragepolicy.allowedpersistenceregions field specifies
         # all the allowed regions for data residency. The default or an empty value will

--- a/pkg/apis/configs/dataresidency/testdata/config-dataresidency.yaml
+++ b/pkg/apis/configs/dataresidency/testdata/config-dataresidency.yaml
@@ -20,6 +20,7 @@ metadata:
 data:
   default-dataresidency-config: |
     clusterDefaults:
+      messagestoragepolicy.global: false
       messagestoragepolicy.allowedpersistenceregions: []
   _example: |
     ################################
@@ -46,6 +47,8 @@ data:
       # clusterDefaults are the defaults to apply to every namespace in the
       # cluster
       clusterDefaults:
+        # messagestoragepolicy.global will set to the Org Policy
+        messagestoragepolicy.global: false
         # messagestoragepolicy.allowedpersistenceregions field specifies
         # all the allowed regions for data residency. The default or an empty value will
         # mean no data residency requirement.

--- a/pkg/gclient/metadata/client.go
+++ b/pkg/gclient/metadata/client.go
@@ -55,6 +55,10 @@ func (m *metadataClient) OnGCE() bool {
 	return metadata.OnGCE()
 }
 
+func (m *metadataClient) Zone() (string, error) {
+	return metadata.Zone()
+}
+
 func NewMetadataClient(httpClient *http.Client) Client {
 	return &metadataClient{
 		metadata: metadata.NewClient(httpClient),

--- a/pkg/gclient/metadata/interfaces.go
+++ b/pkg/gclient/metadata/interfaces.go
@@ -20,14 +20,18 @@ package metadata
 // Client matches the interface exposed by metadata.Client
 type Client interface {
 	// InstanceAttributeValue returns the value of the provided VM instance attribute.
-	// See https://godoc.org/cloud.google.com/compute/metadata#Client.ProjectID
+	// See https://godoc.org/cloud.google.com/go/compute/metadata#Client.ProjectID
 	InstanceAttributeValue(attr string) (string, error)
 
 	// ProjectID returns the current instance's project ID string.
-	// See https://godoc.org/cloud.google.com/compute/metadata#Client.InstanceAttributeValue
+	// See https://godoc.org/cloud.google.com/go/compute/metadata#Client.InstanceAttributeValue
 	ProjectID() (string, error)
 
 	// OnGCE reports whether this process is running on Google Compute Engine.
-	// See https://godoc.org/cloud.google.com/compute/metadata#OnGCE
+	// See https://godoc.org/cloud.google.com/go/compute/metadata#OnGCE
 	OnGCE() bool
+
+	// Zone returns the current VM's zone, such as "us-central1-b".
+	// See https://godoc.org/cloud.google.com/go/compute/metadata#Zone
+	Zone() (string, error)
 }

--- a/pkg/gclient/metadata/testing/client.go
+++ b/pkg/gclient/metadata/testing/client.go
@@ -24,6 +24,7 @@ var (
 	clusterNameAttr = "cluster-name"
 	FakeClusterName = "fake-cluster-name"
 	FakeProjectID   = "fake-project-id"
+	FakeZone        = "us-central1-b"
 )
 
 // TestClientData is the data used to configure the test metadata client.
@@ -72,4 +73,8 @@ func (m *testMetadataClient) ProjectID() (string, error) {
 // Assume this process is always running on Google Compute Engine
 func (m *testMetadataClient) OnGCE() bool {
 	return true
+}
+
+func (m *testMetadataClient) Zone() (string, error) {
+	return FakeZone, nil
 }

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -143,7 +143,6 @@ func (r *Reconciler) reconcileDecouplingTopicAndSubscription(ctx context.Context
 	// Check if topic exists, and if not, create it.
 	topicID := resources.GenerateDecouplingTopicName(b)
 	topicConfig := &pubsub.TopicConfig{Labels: labels}
-	fmt.Printf("Calling compute\n")
 	if r.dataresidencyStore != nil {
 		if updated, err := r.dataresidencyStore.Load().DataResidencyDefaults.ComputeAllowedPersistenceRegions(topicConfig, clusterRegionGetter); err != nil {
 			logger.Error("Failed to update topic config: ", zap.Error(err))

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -43,6 +43,8 @@ import (
 	"github.com/google/knative-gcp/pkg/apis/configs/dataresidency"
 	"github.com/google/knative-gcp/pkg/client/injection/ducks/duck/v1alpha1/resource"
 	brokerreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/broker/v1beta1/broker"
+	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
+	testingMetadataClient "github.com/google/knative-gcp/pkg/gclient/metadata/testing"
 	"github.com/google/knative-gcp/pkg/reconciler"
 	"github.com/google/knative-gcp/pkg/reconciler/broker/resources"
 	brokercellresources "github.com/google/knative-gcp/pkg/reconciler/brokercell/resources"
@@ -305,6 +307,9 @@ func TestAllCases(t *testing.T) {
 		},
 		PostConditions: []func(*testing.T, *TableRow){
 			TopicExistsWithConfig("cre-bkr_testnamespace_test-broker_abc123", &pubsub.TopicConfig{
+				MessageStoragePolicy: pubsub.MessageStoragePolicy{
+					AllowedPersistenceRegions: []string{"us-central1"},
+				},
 				Labels: map[string]string{
 					"broker_class": "googlecloud", "name": "test-broker", "namespace": "testnamespace", "resource": "brokers",
 				},
@@ -469,6 +474,9 @@ func TestAllCases(t *testing.T) {
 			// maxTime=0 is used to inject error
 			createPubsubClientFn = GetFailedTestClientCreateFunc(srv.Addr, maxTime.(int))
 			testPSClient = nil
+		}
+		defaultMetadataClientCreator = func() metadataClient.Client {
+			return testingMetadataClient.NewTestClient(testingMetadataClient.TestClientData{})
 		}
 
 		ctx = addressable.WithDuck(ctx)

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -43,8 +43,6 @@ import (
 	"github.com/google/knative-gcp/pkg/apis/configs/dataresidency"
 	"github.com/google/knative-gcp/pkg/client/injection/ducks/duck/v1alpha1/resource"
 	brokerreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/broker/v1beta1/broker"
-	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
-	testingMetadataClient "github.com/google/knative-gcp/pkg/gclient/metadata/testing"
 	"github.com/google/knative-gcp/pkg/reconciler"
 	"github.com/google/knative-gcp/pkg/reconciler/broker/resources"
 	brokercellresources "github.com/google/knative-gcp/pkg/reconciler/brokercell/resources"
@@ -307,9 +305,6 @@ func TestAllCases(t *testing.T) {
 		},
 		PostConditions: []func(*testing.T, *TableRow){
 			TopicExistsWithConfig("cre-bkr_testnamespace_test-broker_abc123", &pubsub.TopicConfig{
-				MessageStoragePolicy: pubsub.MessageStoragePolicy{
-					AllowedPersistenceRegions: []string{"us-central1"},
-				},
 				Labels: map[string]string{
 					"broker_class": "googlecloud", "name": "test-broker", "namespace": "testnamespace", "resource": "brokers",
 				},
@@ -474,9 +469,6 @@ func TestAllCases(t *testing.T) {
 			// maxTime=0 is used to inject error
 			createPubsubClientFn = GetFailedTestClientCreateFunc(srv.Addr, maxTime.(int))
 			testPSClient = nil
-		}
-		defaultMetadataClientCreator = func() metadataClient.Client {
-			return testingMetadataClient.NewTestClient(testingMetadataClient.TestClientData{})
 		}
 
 		ctx = addressable.WithDuck(ctx)

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -58,6 +58,7 @@ const (
 	systemNS    = "knative-testing"
 
 	brokerFinalizerName = "brokers.eventing.knative.dev"
+	testClusterRegion   = "us-east1"
 )
 
 var (
@@ -479,6 +480,7 @@ func TestAllCases(t *testing.T) {
 			projectID:          testProject,
 			pubsubClient:       testPSClient,
 			dataresidencyStore: drStore,
+			clusterRegion:      testClusterRegion,
 		}
 		return brokerreconciler.NewReconciler(ctx, r.Logger, r.RunClientSet, listers.GetBrokerLister(), r.Recorder, r, brokerv1beta1.BrokerClass)
 	}))

--- a/pkg/reconciler/intevents/topic/topic.go
+++ b/pkg/reconciler/intevents/topic/topic.go
@@ -47,6 +47,7 @@ import (
 	v1 "github.com/google/knative-gcp/pkg/apis/intevents/v1"
 	topicreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/intevents/v1/topic"
 	listers "github.com/google/knative-gcp/pkg/client/listers/intevents/v1"
+	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 	"github.com/google/knative-gcp/pkg/reconciler/identity"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents/topic/resources"
@@ -89,6 +90,10 @@ type Reconciler struct {
 
 // Check that our Reconciler implements Interface.
 var _ topicreconciler.Interface = (*Reconciler)(nil)
+
+// defaultMetadataClientCreator is a create function to get a default metadata client. This can be
+// swapped during testing.
+var defaultMetadataClientCreator func() metadataClient.Client = metadataClient.NewDefaultMetadataClient
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, topic *v1.Topic) reconciler.Event {
 	ctx = logging.WithLogger(ctx, r.Logger.With(zap.Any("topic", topic)))
@@ -166,13 +171,12 @@ func (r *Reconciler) reconcileTopic(ctx context.Context, topic *v1.Topic) error 
 			return fmt.Errorf("Topic %q does not exist and the topic policy doesn't allow creation", topic.Spec.Topic)
 		} else {
 			topicConfig := &pubsub.TopicConfig{}
-			if r.dataresidencyStore != nil {
-				if dataresidencyCfg := r.dataresidencyStore.Load(); dataresidencyCfg != nil {
-					if dataresidencyCfg.DataResidencyDefaults.ComputeAllowedPersistenceRegions(topicConfig) {
-						r.Logger.Debugw("Updated Topic Config AllowedPersistenceRegions for topic reconciler", zap.Any("topicConfig", *topicConfig))
-					}
-				}
+			if updated, err := r.dataresidencyStore.ComputeAllowedPersistenceRegions(topicConfig, defaultMetadataClientCreator); err != nil {
+				logging.FromContext(ctx).Desugar().Error("Failed to update topic config: ", zap.Error(err))
+			} else if updated {
+				logging.FromContext(ctx).Desugar().Debug("Updated Topic Config AllowedPersistenceRegions for topic reconciler", zap.Any("topicConfig", *topicConfig))
 			}
+
 			// Create a new topic with the given name.
 			t, err = client.CreateTopicWithConfig(ctx, topic.Spec.Topic, topicConfig)
 			if err != nil {

--- a/pkg/reconciler/intevents/topic/topic.go
+++ b/pkg/reconciler/intevents/topic/topic.go
@@ -47,6 +47,7 @@ import (
 	v1 "github.com/google/knative-gcp/pkg/apis/intevents/v1"
 	topicreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/intevents/v1/topic"
 	listers "github.com/google/knative-gcp/pkg/client/listers/intevents/v1"
+	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 	"github.com/google/knative-gcp/pkg/reconciler/identity"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents/topic/resources"
@@ -85,13 +86,12 @@ type Reconciler struct {
 	// createClientFn is the function used to create the Pub/Sub client that interacts with Pub/Sub.
 	// This is needed so that we can inject a mock client for UTs purposes.
 	createClientFn reconcilerutilspubsub.CreateFn
+	// clusterRegion is the region where GKE is running
+	clusterRegion string
 }
 
 // Check that our Reconciler implements Interface.
 var _ topicreconciler.Interface = (*Reconciler)(nil)
-
-// clusterRegionGetter is a function that can get the cluster region
-var clusterRegionGetter = utils.NewClusterRegionGetter()
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, topic *v1.Topic) reconciler.Event {
 	ctx = logging.WithLogger(ctx, r.Logger.With(zap.Any("topic", topic)))
@@ -156,6 +156,12 @@ func (r *Reconciler) reconcileTopic(ctx context.Context, topic *v1.Topic) error 
 	}
 	defer client.Close()
 
+	r.clusterRegion, err = utils.ClusterRegion(r.clusterRegion, metadataClient.NewDefaultMetadataClient)
+	if err != nil {
+		logging.FromContext(ctx).Desugar().Error("Failed to get cluster region: ", zap.Error(err))
+		return err
+	}
+
 	t := client.Topic(topic.Spec.Topic)
 	exists, err := t.Exists(ctx)
 	if err != nil {
@@ -170,9 +176,7 @@ func (r *Reconciler) reconcileTopic(ctx context.Context, topic *v1.Topic) error 
 		} else {
 			topicConfig := &pubsub.TopicConfig{}
 			if r.dataresidencyStore != nil {
-				if updated, err := r.dataresidencyStore.Load().DataResidencyDefaults.ComputeAllowedPersistenceRegions(topicConfig, clusterRegionGetter); err != nil {
-					logging.FromContext(ctx).Desugar().Error("Failed to update topic config: ", zap.Error(err))
-				} else if updated {
+				if r.dataresidencyStore.Load().DataResidencyDefaults.ComputeAllowedPersistenceRegions(topicConfig, r.clusterRegion) {
 					logging.FromContext(ctx).Desugar().Debug("Updated Topic Config AllowedPersistenceRegions for topic reconciler", zap.Any("topicConfig", *topicConfig))
 				}
 			}

--- a/pkg/reconciler/intevents/topic/topic_test.go
+++ b/pkg/reconciler/intevents/topic/topic_test.go
@@ -51,8 +51,6 @@ import (
 	"github.com/google/knative-gcp/pkg/apis/configs/dataresidency"
 	pubsubv1 "github.com/google/knative-gcp/pkg/apis/intevents/v1"
 	"github.com/google/knative-gcp/pkg/client/injection/reconciler/intevents/v1/topic"
-	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
-	testingMetadataClient "github.com/google/knative-gcp/pkg/gclient/metadata/testing"
 	"github.com/google/knative-gcp/pkg/reconciler"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents/topic/resources"
@@ -564,11 +562,7 @@ func TestAllCases(t *testing.T) {
 		}},
 		OtherTestData: map[string]interface{}{},
 		PostConditions: []func(*testing.T, *TableRow){
-			TopicExistsWithConfig(testTopicID, &pubsub.TopicConfig{
-				MessageStoragePolicy: pubsub.MessageStoragePolicy{
-					AllowedPersistenceRegions: []string{"us-central1"},
-				},
-			}),
+			TopicExistsWithConfig(testTopicID, &pubsub.TopicConfig{}),
 		},
 	}, {
 		Name: "topic successfully reconciles and reuses existing publisher",
@@ -819,9 +813,6 @@ func TestAllCases(t *testing.T) {
 			}
 		} else {
 			createClientFn = GetTestClientCreateFunc(srv.Addr)
-		}
-		defaultMetadataClientCreator = func() metadataClient.Client {
-			return testingMetadataClient.NewTestClient(testingMetadataClient.TestClientData{})
 		}
 		pubsubBase := &intevents.PubSubBase{
 			Base: reconciler.NewBase(ctx, controllerAgentName, cmw),

--- a/pkg/reconciler/intevents/topic/topic_test.go
+++ b/pkg/reconciler/intevents/topic/topic_test.go
@@ -61,12 +61,13 @@ const (
 	topicName = "hubbub"
 	sinkName  = "sink"
 
-	testNS       = "testnamespace"
-	testImage    = "test_image"
-	topicUID     = topicName + "-abc-123"
-	testProject  = "test-project-id"
-	testTopicID  = "cloud-run-topic-" + testNS + "-" + topicName + "-" + topicUID
-	testTopicURI = "http://" + topicName + "-topic." + testNS + ".svc.cluster.local"
+	testNS            = "testnamespace"
+	testImage         = "test_image"
+	topicUID          = topicName + "-abc-123"
+	testProject       = "test-project-id"
+	testTopicID       = "cloud-run-topic-" + testNS + "-" + topicName + "-" + topicUID
+	testTopicURI      = "http://" + topicName + "-topic." + testNS + ".svc.cluster.local"
+	testClusterRegion = "us-east1"
 
 	secretName = "testing-secret"
 
@@ -824,6 +825,7 @@ func TestAllCases(t *testing.T) {
 			publisherImage:     testImage,
 			createClientFn:     createClientFn,
 			dataresidencyStore: drStore,
+			clusterRegion:      testClusterRegion,
 		}
 		return topic.NewReconciler(ctx, r.Logger, r.RunClientSet, listers.GetTopicLister(), r.Recorder, r)
 	}))

--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -39,6 +39,7 @@ import (
 	"github.com/google/knative-gcp/pkg/apis/configs/dataresidency"
 	triggerreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/broker/v1beta1/trigger"
 	brokerlisters "github.com/google/knative-gcp/pkg/client/listers/broker/v1beta1"
+	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 	"github.com/google/knative-gcp/pkg/reconciler"
 	"github.com/google/knative-gcp/pkg/reconciler/broker/resources"
 	reconcilerutilspubsub "github.com/google/knative-gcp/pkg/reconciler/utils/pubsub"
@@ -62,8 +63,6 @@ var (
 	// defaulting fails.
 	defaultBackoffDelay  = "PT1S"
 	defaultBackoffPolicy = eventingduckv1beta1.BackoffPolicyExponential
-	// clusterRegionGetter is a function that can get the cluster region
-	clusterRegionGetter = utils.NewClusterRegionGetter()
 )
 
 // Reconciler implements controller.Reconciler for Trigger resources.
@@ -85,6 +84,9 @@ type Reconciler struct {
 	pubsubClient *pubsub.Client
 
 	dataresidencyStore *dataresidency.Store
+
+	// clusterRegion is the region where GKE is running
+	clusterRegion string
 }
 
 // Check that TriggerReconciler implements Interface
@@ -223,6 +225,11 @@ func (r *Reconciler) reconcileRetryTopicAndSubscription(ctx context.Context, tri
 		trig.Status.MarkSubscriptionUnknown("ProjectIdNotFound", "Failed to find project id: %v", err)
 		return err
 	}
+	r.clusterRegion, err = utils.ClusterRegion(r.clusterRegion, metadataClient.NewDefaultMetadataClient)
+	if err != nil {
+		logger.Error("Failed to get cluster region: ", zap.Error(err))
+		return err
+	}
 	// Set the projectID in the status.
 	//TODO uncomment when eventing webhook allows this
 	//trig.Status.ProjectID = projectID
@@ -246,9 +253,7 @@ func (r *Reconciler) reconcileRetryTopicAndSubscription(ctx context.Context, tri
 	topicID := resources.GenerateRetryTopicName(trig)
 	topicConfig := &pubsub.TopicConfig{Labels: labels}
 	if r.dataresidencyStore != nil {
-		if updated, err := r.dataresidencyStore.Load().DataResidencyDefaults.ComputeAllowedPersistenceRegions(topicConfig, clusterRegionGetter); err != nil {
-			logger.Error("Failed to update topic config: ", zap.Error(err))
-		} else if updated {
+		if r.dataresidencyStore.Load().DataResidencyDefaults.ComputeAllowedPersistenceRegions(topicConfig, r.clusterRegion) {
 			logging.FromContext(ctx).Debug("Updated Topic Config AllowedPersistenceRegions for Trigger", zap.Any("topicConfig", *topicConfig))
 		}
 	}

--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -39,6 +39,7 @@ import (
 	"github.com/google/knative-gcp/pkg/apis/configs/dataresidency"
 	triggerreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/broker/v1beta1/trigger"
 	brokerlisters "github.com/google/knative-gcp/pkg/client/listers/broker/v1beta1"
+	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 	"github.com/google/knative-gcp/pkg/reconciler"
 	"github.com/google/knative-gcp/pkg/reconciler/broker/resources"
 	reconcilerutilspubsub "github.com/google/knative-gcp/pkg/reconciler/utils/pubsub"
@@ -62,6 +63,9 @@ var (
 	// defaulting fails.
 	defaultBackoffDelay  = "PT1S"
 	defaultBackoffPolicy = eventingduckv1beta1.BackoffPolicyExponential
+	// defaultMetadataClientCreator is a create function to get a default metadata client. This can be
+	// swapped during testing.
+	defaultMetadataClientCreator func() metadataClient.Client = metadataClient.NewDefaultMetadataClient
 )
 
 // Reconciler implements controller.Reconciler for Trigger resources.
@@ -243,12 +247,10 @@ func (r *Reconciler) reconcileRetryTopicAndSubscription(ctx context.Context, tri
 	// Check if topic exists, and if not, create it.
 	topicID := resources.GenerateRetryTopicName(trig)
 	topicConfig := &pubsub.TopicConfig{Labels: labels}
-	if r.dataresidencyStore != nil {
-		if dataresidencyConfig := r.dataresidencyStore.Load(); dataresidencyConfig != nil {
-			if dataresidencyConfig.DataResidencyDefaults.ComputeAllowedPersistenceRegions(topicConfig) {
-				logging.FromContext(ctx).Debug("Updated Topic Config AllowedPersistenceRegions for Trigger", zap.Any("topicConfig", *topicConfig))
-			}
-		}
+	if updated, err := r.dataresidencyStore.ComputeAllowedPersistenceRegions(topicConfig, defaultMetadataClientCreator); err != nil {
+		logger.Error("Failed to update topic config: ", zap.Error(err))
+	} else if updated {
+		logging.FromContext(ctx).Debug("Updated Topic Config AllowedPersistenceRegions for Trigger", zap.Any("topicConfig", *topicConfig))
 	}
 	topic, err := pubsubReconciler.ReconcileTopic(ctx, topicID, topicConfig, trig, &trig.Status)
 	if err != nil {

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -46,8 +46,6 @@ import (
 	"github.com/google/knative-gcp/pkg/apis/configs/dataresidency"
 	"github.com/google/knative-gcp/pkg/client/injection/ducks/duck/v1alpha1/resource"
 	triggerreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/broker/v1beta1/trigger"
-	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
-	testingMetadataClient "github.com/google/knative-gcp/pkg/gclient/metadata/testing"
 	"github.com/google/knative-gcp/pkg/reconciler"
 	. "github.com/google/knative-gcp/pkg/reconciler/testing"
 )
@@ -405,9 +403,6 @@ func TestAllCasesTrigger(t *testing.T) {
 						DeadLetterTopic:     "projects/test-project-id/topics/test-dead-letter-topic-id",
 					}),
 				TopicExistsWithConfig("cre-tgr_testnamespace_test-trigger_abc123", &pubsub.TopicConfig{
-					MessageStoragePolicy: pubsub.MessageStoragePolicy{
-						AllowedPersistenceRegions: []string{"us-central1"},
-					},
 					Labels: map[string]string{
 						"name": "test-trigger", "namespace": "testnamespace", "resource": "triggers",
 					},
@@ -602,9 +597,6 @@ func TestAllCasesTrigger(t *testing.T) {
 						DeadLetterTopic:     "projects/test-project-id/topics/test-dead-letter-topic-id",
 					}),
 				TopicExistsWithConfig("cre-tgr_testnamespace_test-trigger_abc123", &pubsub.TopicConfig{
-					MessageStoragePolicy: pubsub.MessageStoragePolicy{
-						AllowedPersistenceRegions: []string{"us-central1"},
-					},
 					Labels: map[string]string{
 						"name": "test-trigger", "namespace": "testnamespace", "resource": "triggers",
 					},
@@ -694,9 +686,6 @@ func TestAllCasesTrigger(t *testing.T) {
 			// maxTime=0 is used to inject error
 			createPubsubClientFn = GetFailedTestClientCreateFunc(srv.Addr, maxTime.(int))
 			testPSClient = nil
-		}
-		defaultMetadataClientCreator = func() metadataClient.Client {
-			return testingMetadataClient.NewTestClient(testingMetadataClient.TestClientData{})
 		}
 
 		ctx = addressable.WithDuck(ctx)

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -51,11 +51,12 @@ import (
 )
 
 const (
-	testNS      = "testnamespace"
-	triggerName = "test-trigger"
-	brokerName  = "test-broker"
-	testUID     = "abc123"
-	testProject = "test-project-id"
+	testNS            = "testnamespace"
+	triggerName       = "test-trigger"
+	brokerName        = "test-broker"
+	testUID           = "abc123"
+	testProject       = "test-project-id"
+	testClusterRegion = "us-east1"
 
 	subscriberURI     = "http://example.com/subscriber/"
 	subscriberKind    = "Service"
@@ -701,6 +702,7 @@ func TestAllCasesTrigger(t *testing.T) {
 			projectID:          testProject,
 			pubsubClient:       testPSClient,
 			dataresidencyStore: drStore,
+			clusterRegion:      testClusterRegion,
 		}
 
 		return triggerreconciler.NewReconciler(ctx, r.Logger, r.RunClientSet, listers.GetTriggerLister(), r.Recorder, r, withAgentAndFinalizer(nil))

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -46,6 +46,8 @@ import (
 	"github.com/google/knative-gcp/pkg/apis/configs/dataresidency"
 	"github.com/google/knative-gcp/pkg/client/injection/ducks/duck/v1alpha1/resource"
 	triggerreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/broker/v1beta1/trigger"
+	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
+	testingMetadataClient "github.com/google/knative-gcp/pkg/gclient/metadata/testing"
 	"github.com/google/knative-gcp/pkg/reconciler"
 	. "github.com/google/knative-gcp/pkg/reconciler/testing"
 )
@@ -403,6 +405,9 @@ func TestAllCasesTrigger(t *testing.T) {
 						DeadLetterTopic:     "projects/test-project-id/topics/test-dead-letter-topic-id",
 					}),
 				TopicExistsWithConfig("cre-tgr_testnamespace_test-trigger_abc123", &pubsub.TopicConfig{
+					MessageStoragePolicy: pubsub.MessageStoragePolicy{
+						AllowedPersistenceRegions: []string{"us-central1"},
+					},
 					Labels: map[string]string{
 						"name": "test-trigger", "namespace": "testnamespace", "resource": "triggers",
 					},
@@ -597,6 +602,9 @@ func TestAllCasesTrigger(t *testing.T) {
 						DeadLetterTopic:     "projects/test-project-id/topics/test-dead-letter-topic-id",
 					}),
 				TopicExistsWithConfig("cre-tgr_testnamespace_test-trigger_abc123", &pubsub.TopicConfig{
+					MessageStoragePolicy: pubsub.MessageStoragePolicy{
+						AllowedPersistenceRegions: []string{"us-central1"},
+					},
 					Labels: map[string]string{
 						"name": "test-trigger", "namespace": "testnamespace", "resource": "triggers",
 					},
@@ -686,6 +694,9 @@ func TestAllCasesTrigger(t *testing.T) {
 			// maxTime=0 is used to inject error
 			createPubsubClientFn = GetFailedTestClientCreateFunc(srv.Addr, maxTime.(int))
 			testPSClient = nil
+		}
+		defaultMetadataClientCreator = func() metadataClient.Client {
+			return testingMetadataClient.NewTestClient(testingMetadataClient.TestClientData{})
 		}
 
 		ctx = addressable.WithDuck(ctx)

--- a/pkg/utils/metadata.go
+++ b/pkg/utils/metadata.go
@@ -106,7 +106,15 @@ type ClusterRegionGetter func() (string, error)
 
 // NewClusterRegionGetter returns CluterRegionGetter in production code
 func NewClusterRegionGetter() ClusterRegionGetter {
+	var clusterRegion string
 	return func() (string, error) {
-		return ClusterRegion("", defaultMetadataClientCreator)
+		if clusterRegion != "" {
+			return clusterRegion, nil
+		}
+		region, err := ClusterRegion("", defaultMetadataClientCreator)
+		if err == nil {
+			clusterRegion = region
+		}
+		return region, err
 	}
 }

--- a/pkg/utils/metadata.go
+++ b/pkg/utils/metadata.go
@@ -17,7 +17,9 @@ limitations under the License.
 package utils
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
 )
@@ -74,4 +76,15 @@ func ClusterName(clusterName string, client metadataClient.Client) (string, erro
 		return "", err
 	}
 	return clusterName, nil
+}
+
+// ZoneToRegion converts a GKE zone to its region
+func ZoneToRegion(zone string) (string, error) {
+	fields := strings.Split(zone, "-")
+	if len(fields) == 3 {
+		return fmt.Sprintf("%s-%s", fields[0], fields[1]), nil
+	}
+	// We can as well treat xx-xx as region and simply return,
+	// but let's be strict here
+	return "", fmt.Errorf("zone %s is not valid", zone)
 }

--- a/pkg/utils/metadata.go
+++ b/pkg/utils/metadata.go
@@ -88,3 +88,25 @@ func ZoneToRegion(zone string) (string, error) {
 	// but let's be strict here
 	return "", fmt.Errorf("zone %s is not valid", zone)
 }
+
+// ClusterRegion returns the region of the cluster
+func ClusterRegion(clusterRegion string, clientCreator func() metadataClient.Client) (string, error) {
+	if clusterRegion != "" {
+		return clusterRegion, nil
+	}
+	zone, err := clientCreator().Zone()
+	if err != nil {
+		return "", err
+	}
+	return ZoneToRegion(zone)
+}
+
+// ClusterRegionGetter is a handler that gets cluster region
+type ClusterRegionGetter func() (string, error)
+
+// NewClusterRegionGetter returns CluterRegionGetter in production code
+func NewClusterRegionGetter() ClusterRegionGetter {
+	return func() (string, error) {
+		return ClusterRegion("", defaultMetadataClientCreator)
+	}
+}

--- a/pkg/utils/metadata.go
+++ b/pkg/utils/metadata.go
@@ -100,21 +100,3 @@ func ClusterRegion(clusterRegion string, clientCreator func() metadataClient.Cli
 	}
 	return ZoneToRegion(zone)
 }
-
-// ClusterRegionGetter is a handler that gets cluster region
-type ClusterRegionGetter func() (string, error)
-
-// NewClusterRegionGetter returns CluterRegionGetter in production code
-func NewClusterRegionGetter() ClusterRegionGetter {
-	var clusterRegion string
-	return func() (string, error) {
-		if clusterRegion != "" {
-			return clusterRegion, nil
-		}
-		region, err := ClusterRegion("", defaultMetadataClientCreator)
-		if err == nil {
-			clusterRegion = region
-		}
-		return region, err
-	}
-}

--- a/pkg/utils/metadata_test.go
+++ b/pkg/utils/metadata_test.go
@@ -164,18 +164,29 @@ func TestZoneToRegion(t *testing.T) {
 	}
 }
 
-func TestNewClusterRegionGetter(t *testing.T) {
-	orig := defaultMetadataClientCreator
-	defer func() {
-		defaultMetadataClientCreator = orig
-	}()
+func TestClusterRegion(t *testing.T) {
+	testCases := map[string]struct {
+		clusterRegion string
+		expected      string
+	}{
+		"Return Region if set": {
+			clusterRegion: "us-east2",
+			expected:      "us-east2",
+		},
+		"Metadata Client": {
+			clusterRegion: "",
+			expected:      "us-central1",
+		},
+	}
 	defaultMetadataClientCreator = func() metadataClient.Client {
 		return testingMetadataClient.NewTestClient(testingMetadataClient.TestClientData{})
 	}
-	clusterRegionGetter := NewClusterRegionGetter()
-	region, _ := clusterRegionGetter()
-	expected := "us-central1"
-	if region != expected {
-		t.Errorf("Expected %s, get %s", expected, region)
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			got, _ := ClusterRegion(tc.clusterRegion, defaultMetadataClientCreator)
+			if got != tc.expected {
+				t.Errorf("expected: %s, got %s", tc.expected, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #1989 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Default to cluster region when the allowed region is nil or empty
- Use a new field `global` to default to no setting.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->
- 🎁  use cluster region as default data residency constraints
**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🎁  use cluster region as default data residency constraints
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
