### PR TITLE
feat/perf-test: Add google-broker-key secret to perf test

### DIFF
--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -31,6 +31,7 @@ readonly TEST_NAMESPACE="default"
 readonly PUBSUB_SECRET_NAME="google-cloud-key"
 readonly CONTROL_PLANE_NAMESPACE="cloud-run-events"
 readonly CONTROL_PLANE_SECRET_NAME="google-cloud-key"
+readonly BROKER_DATA_PLANE_SECRET_NAME="google-broker-key"
 
 function update_knative() {
   # Create the secret for pub-sub if it does not exist.
@@ -45,6 +46,11 @@ function update_knative() {
   # Create the secret for control-plane if it does not exist.
   kubectl -n ${CONTROL_PLANE_NAMESPACE} get secret ${CONTROL_PLANE_SECRET_NAME} || \
   kubectl -n ${CONTROL_PLANE_NAMESPACE} create secret generic ${CONTROL_PLANE_SECRET_NAME} \
+    --from-file=key.json="${GOOGLE_APPLICATION_CREDENTIALS}"
+
+  # Create the secret for data-plane if it does not exist.
+  kubectl -n ${CONTROL_PLANE_NAMESPACE} get secret ${BROKER_DATA_PLANE_SECRET_NAME} || \
+  kubectl -n ${CONTROL_PLANE_NAMESPACE} create secret generic ${BROKER_DATA_PLANE_SECRET_NAME} \
     --from-file=key.json="${GOOGLE_APPLICATION_CREDENTIALS}"
 
   # Start Knative GCP. Fail the update process if there is any error.


### PR DESCRIPTION
The performance test is currently not working due to lack of
google-broker-key secret. This commit tries to solve it by
introducing the broker key.

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add google-broker-key in performance test setup.
-
-
