### PR TITLE
Authentication check: additional k8s Event check for Secret absence in source

### DIFF
--- a/config/core/roles/clusterrole.yaml
+++ b/config/core/roles/clusterrole.yaml
@@ -129,6 +129,8 @@ rules:
   resources:
     - events
   verbs:
+    - get
+    - list
     - create
     - patch
 

--- a/pkg/reconciler/intevents/pullsubscription/static/pullsubscription.go
+++ b/pkg/reconciler/intevents/pullsubscription/static/pullsubscription.go
@@ -68,11 +68,26 @@ func (r *Reconciler) ReconcileDeployment(ctx context.Context, ra *appsv1.Deploym
 			logging.FromContext(ctx).Error("Error propagating authentication check message", zap.Error(err))
 			return err
 		}
+		// If source is in secret mode, we need to check if the secret is absent.
+		if src.Spec.Secret != nil {
+			logging.FromContext(ctx).Error("Start to get pod list", zap.Error(err))
+			for _, pod := range podList.Items {
+				eventList, err := authcheck.GetEventList(ctx, r.KubeClientSet, pod.Name, src.Namespace)
+				logging.FromContext(ctx).Error("Start to get event list", zap.Error(err))
+				if err != nil {
+					logging.FromContext(ctx).Error("Error propagating authentication check message", zap.Error(err))
+					return err
+				}
+				if authenticationCheckMessage := authcheck.GetMountFailureMessageFromEventList(eventList, src.Spec.Secret); authenticationCheckMessage != "" {
+					src.Status.MarkDeployedUnknown(authcheck.AuthenticationCheckUnknownReason, authenticationCheckMessage)
+					return nil
+				}
+			}
+		}
 		if authenticationCheckMessage := authcheck.GetTerminationLogFromPodList(podList); authenticationCheckMessage != "" {
 			src.Status.MarkDeployedUnknown(authcheck.AuthenticationCheckUnknownReason, authenticationCheckMessage)
 		}
 	}
-
 	return nil
 }
 

--- a/pkg/reconciler/intevents/pullsubscription/static/pullsubscription.go
+++ b/pkg/reconciler/intevents/pullsubscription/static/pullsubscription.go
@@ -70,10 +70,8 @@ func (r *Reconciler) ReconcileDeployment(ctx context.Context, ra *appsv1.Deploym
 		}
 		// If source is in secret mode, we need to check if the secret is absent.
 		if src.Spec.Secret != nil {
-			logging.FromContext(ctx).Error("Start to get pod list", zap.Error(err))
 			for _, pod := range podList.Items {
 				eventList, err := authcheck.GetEventList(ctx, r.KubeClientSet, pod.Name, src.Namespace)
-				logging.FromContext(ctx).Error("Start to get event list", zap.Error(err))
 				if err != nil {
 					logging.FromContext(ctx).Error("Error propagating authentication check message", zap.Error(err))
 					return err

--- a/pkg/reconciler/intevents/pullsubscription/static/pullsubscription_test.go
+++ b/pkg/reconciler/intevents/pullsubscription/static/pullsubscription_test.go
@@ -24,14 +24,13 @@ import (
 
 	"cloud.google.com/go/pubsub"
 	"cloud.google.com/go/pubsub/pstest"
+	"google.golang.org/grpc/codes"
 
 	reconcilertestingv1 "github.com/google/knative-gcp/pkg/reconciler/testing/v1"
 	"github.com/google/knative-gcp/pkg/utils/authcheck"
 
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-
 	v1 "k8s.io/api/apps/v1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -1112,6 +1111,173 @@ func TestAllCases(t *testing.T) {
 			OnlySubscriptions(testSubscriptionID),
 		},
 	}, {
+		Name: "propagate availability adapter with termination log message",
+		Objects: []runtime.Object{
+			reconcilertestingv1.NewPullSubscription(sourceName, testNS,
+				reconcilertestingv1.WithPullSubscriptionUID(sourceUID),
+				reconcilertestingv1.WithPullSubscriptionObjectMetaGeneration(generation),
+				reconcilertestingv1.WithPullSubscriptionSpec(pubsubv1.PullSubscriptionSpec{
+					PubSubSpec: gcpduckv1.PubSubSpec{
+						Secret:  &secret,
+						Project: testProject,
+					},
+					Topic: testTopicID,
+				}),
+				reconcilertestingv1.WithPullSubscriptionSink(sinkGVK, sinkName),
+				reconcilertestingv1.WithPullSubscriptionTransformer(transformerGVK, transformerName),
+				reconcilertestingv1.WithPullSubscriptionSetDefaults,
+			),
+			newSink(),
+			newTransformer(),
+			newSecret(),
+			newMinimumReplicasUnavailableAdapter(context.Background(), "old"+testImage, nil),
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-1",
+					Namespace: testNS,
+					Labels:    resources.GetLabels(controllerAgentName, sourceName),
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{{
+						LastTerminationState: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								Message: "checking authentication",
+							},
+						}}},
+				},
+			},
+		},
+		OtherTestData: map[string]interface{}{
+			"pre": []PubsubAction{
+				Topic(testTopicID),
+			},
+		},
+		Key: testNS + "/" + sourceName,
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+			Eventf(corev1.EventTypeNormal, "PullSubscriptionReconciled", `PullSubscription reconciled: "%s/%s"`, testNS, sourceName),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: testNS,
+				Verb:      "update",
+				Resource:  receiveAdapterGVR(),
+			},
+			Object: newMinimumReplicasUnavailableAdapter(context.Background(), testImage, transformerURI),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(testNS, sourceName, resourceGroup),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: reconcilertestingv1.NewPullSubscription(sourceName, testNS,
+				reconcilertestingv1.WithPullSubscriptionUID(sourceUID),
+				reconcilertestingv1.WithPullSubscriptionObjectMetaGeneration(generation),
+				reconcilertestingv1.WithPullSubscriptionSpec(pubsubv1.PullSubscriptionSpec{
+					PubSubSpec: gcpduckv1.PubSubSpec{
+						Secret:  &secret,
+						Project: testProject,
+					},
+					Topic: testTopicID,
+				}),
+				reconcilertestingv1.WithInitPullSubscriptionConditions,
+				reconcilertestingv1.WithPullSubscriptionProjectID(testProject),
+				reconcilertestingv1.WithPullSubscriptionSink(sinkGVK, sinkName),
+				reconcilertestingv1.WithPullSubscriptionTransformer(transformerGVK, transformerName),
+				reconcilertestingv1.WithPullSubscriptionMarkSubscribed(testSubscriptionID),
+				reconcilertestingv1.WithPullSubscriptionMarkDeployedUnknown("AuthenticationCheckPending", "checking authentication"),
+				reconcilertestingv1.WithPullSubscriptionMarkSink(sinkURI),
+				reconcilertestingv1.WithPullSubscriptionMarkTransformer(transformerURI),
+				reconcilertestingv1.WithPullSubscriptionStatusObservedGeneration(generation),
+				reconcilertestingv1.WithPullSubscriptionSetDefaults,
+			),
+		}},
+		PostConditions: []func(*testing.T, *TableRow){
+			OnlySubscriptions(testSubscriptionID),
+		},
+	}, {
+		Name: "propagate availability adapter with mount failure message",
+		Objects: []runtime.Object{
+			reconcilertestingv1.NewPullSubscription(sourceName, testNS,
+				reconcilertestingv1.WithPullSubscriptionUID(sourceUID),
+				reconcilertestingv1.WithPullSubscriptionObjectMetaGeneration(generation),
+				reconcilertestingv1.WithPullSubscriptionSpec(pubsubv1.PullSubscriptionSpec{
+					PubSubSpec: gcpduckv1.PubSubSpec{
+						Secret:  &secret,
+						Project: testProject,
+					},
+					Topic: testTopicID,
+				}),
+				reconcilertestingv1.WithPullSubscriptionSink(sinkGVK, sinkName),
+				reconcilertestingv1.WithPullSubscriptionTransformer(transformerGVK, transformerName),
+				reconcilertestingv1.WithPullSubscriptionSetDefaults,
+			),
+			newSink(),
+			newTransformer(),
+			newSecret(),
+			newMinimumReplicasUnavailableAdapter(context.Background(), "old"+testImage, nil),
+			&corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "event-1",
+					Namespace: testNS,
+				},
+				Message: "couldn't find key testing-key in Secret testnamespace/testing-secret",
+			},
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-1",
+					Namespace: testNS,
+					Labels:    resources.GetLabels(controllerAgentName, sourceName),
+				},
+			},
+		},
+		OtherTestData: map[string]interface{}{
+			"pre": []PubsubAction{
+				Topic(testTopicID),
+			},
+		},
+		Key: testNS + "/" + sourceName,
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+			Eventf(corev1.EventTypeNormal, "PullSubscriptionReconciled", `PullSubscription reconciled: "%s/%s"`, testNS, sourceName),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: testNS,
+				Verb:      "update",
+				Resource:  receiveAdapterGVR(),
+			},
+			Object: newMinimumReplicasUnavailableAdapter(context.Background(), testImage, transformerURI),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(testNS, sourceName, resourceGroup),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: reconcilertestingv1.NewPullSubscription(sourceName, testNS,
+				reconcilertestingv1.WithPullSubscriptionUID(sourceUID),
+				reconcilertestingv1.WithPullSubscriptionObjectMetaGeneration(generation),
+				reconcilertestingv1.WithPullSubscriptionSpec(pubsubv1.PullSubscriptionSpec{
+					PubSubSpec: gcpduckv1.PubSubSpec{
+						Secret:  &secret,
+						Project: testProject,
+					},
+					Topic: testTopicID,
+				}),
+				reconcilertestingv1.WithInitPullSubscriptionConditions,
+				reconcilertestingv1.WithPullSubscriptionProjectID(testProject),
+				reconcilertestingv1.WithPullSubscriptionSink(sinkGVK, sinkName),
+				reconcilertestingv1.WithPullSubscriptionTransformer(transformerGVK, transformerName),
+				reconcilertestingv1.WithPullSubscriptionMarkSubscribed(testSubscriptionID),
+				reconcilertestingv1.WithPullSubscriptionMarkDeployedUnknown("AuthenticationCheckPending", "couldn't find key testing-key in Secret testnamespace/testing-secret"),
+				reconcilertestingv1.WithPullSubscriptionMarkSink(sinkURI),
+				reconcilertestingv1.WithPullSubscriptionMarkTransformer(transformerURI),
+				reconcilertestingv1.WithPullSubscriptionStatusObservedGeneration(generation),
+				reconcilertestingv1.WithPullSubscriptionSetDefaults,
+			),
+		}},
+		PostConditions: []func(*testing.T, *TableRow){
+			OnlySubscriptions(testSubscriptionID),
+		},
+	}, {
 		Name: "deleting - failed to delete subscription",
 		Objects: []runtime.Object{
 			reconcilertestingv1.NewPullSubscription(sourceName, testNS,
@@ -1256,6 +1422,14 @@ func newReceiveAdapter(ctx context.Context, image string, transformer *apis.URL)
 	}
 	ra := resources.MakeReceiveAdapter(ctx, args)
 	return ra
+}
+
+// newMinimumReplicasUnavailableAdapter is the adapter based on static configuration.
+func newMinimumReplicasUnavailableAdapter(ctx context.Context, image string, transformer *apis.URL) runtime.Object {
+	obj := newReceiveAdapter(ctx, image, transformer)
+	ra := obj.(*v1.Deployment)
+	WithDeploymentMinimumReplicasUnavailable()(ra)
+	return obj
 }
 
 func newAvailableReceiveAdapter(ctx context.Context, image string, transformer *apis.URL) runtime.Object {

--- a/pkg/reconciler/intevents/pullsubscription/static/pullsubscription_test.go
+++ b/pkg/reconciler/intevents/pullsubscription/static/pullsubscription_test.go
@@ -24,15 +24,15 @@ import (
 
 	"cloud.google.com/go/pubsub"
 	"cloud.google.com/go/pubsub/pstest"
-	"google.golang.org/grpc/codes"
 
 	reconcilertestingv1 "github.com/google/knative-gcp/pkg/reconciler/testing/v1"
 	"github.com/google/knative-gcp/pkg/utils/authcheck"
 
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
-	v1 "k8s.io/api/apps/v1"
+	"google.golang.org/grpc/codes"
 
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/pkg/reconciler/testing/deployment.go
+++ b/pkg/reconciler/testing/deployment.go
@@ -94,3 +94,16 @@ func WithDeploymentAvailable() DeploymentOption {
 		}
 	}
 }
+
+// WithDeploymentMinimumReplicasUnavailable marks the Deployment as unavailable for minimal replica unavailable.
+func WithDeploymentMinimumReplicasUnavailable() DeploymentOption {
+	return func(d *appsv1.Deployment) {
+		d.Status.Conditions = []appsv1.DeploymentCondition{
+			{
+				Type:   appsv1.DeploymentAvailable,
+				Status: corev1.ConditionFalse,
+				Reason: "MinimumReplicasUnavailable",
+			},
+		}
+	}
+}

--- a/pkg/utils/authcheck/list.go
+++ b/pkg/utils/authcheck/list.go
@@ -49,7 +49,7 @@ func GetPodList(ctx context.Context, ls labels.Selector, kubeClientSet kubernete
 	return pl, nil
 }
 
-// GetEventList get a list of k8s event in a certain namespace with certain label selector.
+// GetEventList get a list of k8s event in a certain namespace with certain field selector related to Pod.
 func GetEventList(ctx context.Context, kubeClientSet kubernetes.Interface, pod, namespace string) (*corev1.EventList, error) {
 	pl, err := kubeClientSet.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
 		TypeMeta: metav1.TypeMeta{
@@ -65,6 +65,8 @@ func GetEventList(ctx context.Context, kubeClientSet kubernetes.Interface, pod, 
 	return pl, nil
 }
 
+// GetMountFailureMessageFromEventList gets the k8s events message that related to secret errors.
+// It returns the first relevant k8s event message from any Event in the list.
 func GetMountFailureMessageFromEventList(el *corev1.EventList, secret *corev1.SecretKeySelector) string {
 	for _, event := range el.Items {
 		if isWarningMessage(event.Message, event.Namespace, secret) {

--- a/pkg/utils/authcheck/list_test.go
+++ b/pkg/utils/authcheck/list_test.go
@@ -225,7 +225,7 @@ func TestGetEventList(t *testing.T) {
 					Type: "Warning",
 				},
 			},
-			fieldSelector: getFieldSelector("pod-1"),
+			fieldSelector: podWarningFieldSelector("pod-1"),
 			wantNames: []string{
 				"event-1",
 			},
@@ -245,7 +245,7 @@ func TestGetEventList(t *testing.T) {
 					Type: "Warning",
 				},
 			},
-			fieldSelector: getFieldSelector("Pod"),
+			fieldSelector: podWarningFieldSelector("Pod"),
 			wantNames:     []string{},
 		},
 		{
@@ -263,7 +263,7 @@ func TestGetEventList(t *testing.T) {
 					Type: "Warning",
 				},
 			},
-			fieldSelector: getFieldSelector("Pod"),
+			fieldSelector: podWarningFieldSelector("Pod"),
 			wantNames:     []string{},
 		},
 	}

--- a/pkg/utils/authcheck/list_test.go
+++ b/pkg/utils/authcheck/list_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakeKubeClient "k8s.io/client-go/kubernetes/fake"
@@ -103,7 +104,7 @@ func TestGetPodList(t *testing.T) {
 				}
 			}
 			if len(pl.Items) != len(tc.wantNames) {
-				t.Errorf("Diffenrent Podlist length, want %v, got %v ", len(pl.Items), len(tc.wantNames))
+				t.Errorf("Diffenrent Podlist length, want %v, got %v ", len(tc.wantNames), len(pl.Items))
 			}
 		})
 	}
@@ -198,5 +199,195 @@ func TestGetTerminationLogFromPodList(t *testing.T) {
 				t.Error("unexpected termination message (-want, +got) = ", diff)
 			}
 		})
+	}
+}
+
+func TestGetEventList(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name          string
+		objects       []runtime.Object
+		fieldSelector fields.Selector
+		wantNames     []string
+	}{
+		{
+			name: "using correct field selector to get eventlist",
+			objects: []runtime.Object{
+				&corev1.Event{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "event-1",
+						Namespace: testNS,
+					},
+					InvolvedObject: corev1.ObjectReference{
+						Kind: "Pod",
+						Name: "pod-1",
+					},
+					Type: "Warning",
+				},
+			},
+			fieldSelector: getFieldSelector("pod-1"),
+			wantNames: []string{
+				"event-1",
+			},
+		},
+		{
+			name: "using incorrect field selector to get eventlist",
+			objects: []runtime.Object{
+				&corev1.Event{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "event-1",
+						Namespace: testNS,
+					},
+					InvolvedObject: corev1.ObjectReference{
+						Kind: "Non-Pod",
+						Name: "pod-1",
+					},
+					Type: "Warning",
+				},
+			},
+			fieldSelector: getFieldSelector("Pod"),
+			wantNames:     []string{},
+		},
+		{
+			name: "using incorrect namespace to get eventlist",
+			objects: []runtime.Object{
+				&corev1.Event{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "event-1",
+						Namespace: "fake-namespace",
+					},
+					InvolvedObject: corev1.ObjectReference{
+						Kind: "Non-Pod",
+						Name: "pod-1",
+					},
+					Type: "Warning",
+				},
+			},
+			fieldSelector: getFieldSelector("Pod"),
+			wantNames:     []string{},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			//  Sets up the the Context and the fake informers for the tests.
+			ctx, cancel, _ := pkgtesting.SetupFakeContextWithCancel(t)
+			defer cancel()
+
+			// Form a fake Kube Client from tc.objects.
+			cs := fakeKubeClient.NewSimpleClientset(tc.objects...)
+
+			el, _ := GetEventList(ctx, cs, "pod-1", testNS)
+
+			// Field Selector doesn't apply in fake clients List. We need to filter it manually.
+			// More information: https://github.com/kubernetes/kubernetes/issues/78824.
+			el = filterField(tc.fieldSelector, el)
+
+			for _, event := range el.Items {
+				found := false
+				for _, wantName := range tc.wantNames {
+					if event.Name == wantName {
+						found = true
+					}
+					if !found {
+						t.Error("Unexpected event", event.Name)
+					}
+				}
+			}
+			if len(el.Items) != len(tc.wantNames) {
+				t.Errorf("Diffenrent Eventlist length, want %v, got %v ", len(tc.wantNames), len(el.Items))
+			}
+		})
+	}
+}
+
+func TestGetMountFailureMessageFromEventList(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name        string
+		eventlist   *corev1.EventList
+		secret      *corev1.SecretKeySelector
+		wantMessage string
+	}{
+		{
+			name: "qualified secret related message from event",
+			eventlist: &corev1.EventList{
+				Items: []corev1.Event{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "event-1",
+						Namespace: testNS,
+					},
+					Message: `MountVolume.SetUp failed for volume "google-cloud-key"`,
+				}},
+			},
+			secret: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "google-cloud-key"},
+				Key:                  "key.json",
+			},
+			wantMessage: `MountVolume.SetUp failed for volume "google-cloud-key"`,
+		},
+		{
+			name: "qualified key related message from event",
+			eventlist: &corev1.EventList{
+				Items: []corev1.Event{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "event-1",
+						Namespace: testNS,
+					},
+					Message: "couldn't find key key.json in Secret test/google-cloud-key",
+				}},
+			},
+			secret: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "google-cloud-key"},
+				Key:                  "key.json",
+			},
+			wantMessage: "couldn't find key key.json in Secret test/google-cloud-key",
+		},
+		{
+			name: "un-qualified message",
+			eventlist: &corev1.EventList{
+				Items: []corev1.Event{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "event-1",
+						Namespace: testNS,
+					},
+					Message: "non",
+				}},
+			},
+			secret: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "google-cloud-key"},
+				Key:                  "key.json",
+			},
+			wantMessage: "",
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			getMessage := GetMountFailureMessageFromEventList(tc.eventlist, tc.secret)
+			if diff := cmp.Diff(getMessage, tc.wantMessage); diff != "" {
+				t.Error("unexpected termination message (-want, +got) = ", diff)
+			}
+		})
+	}
+}
+
+func filterField(selector fields.Selector, eventList *corev1.EventList) *corev1.EventList {
+	list := &corev1.EventList{}
+	for _, event := range eventList.Items {
+		if selector.Matches(eventSet(event)) {
+			list.Items = append(list.Items, event)
+		}
+	}
+	return list
+}
+
+func eventSet(event corev1.Event) fields.Set {
+	return map[string]string{
+		"involvedObject.kind": event.InvolvedObject.Kind,
+		"type":                event.Type,
+		"involvedObject.name": event.InvolvedObject.Name,
 	}
 }


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

PRs to add the authentication check:
1. Environment variable to differentiate authentication mode
2. Authentication check running inside the Pod (left part:  Pods using kncloudevent library like Ingress)
3. **Additional k8s Event check for Secret absence in source**(<-this PR)

## Proposed Changes
- If deployment has minimal replica unavailable error and it is secret mode, check k8s event to see if it is caused by secret absence.
- Remark upper-level source with authentication related Reason and Message.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🎁 Authentication check: additional k8s Event check for Secret absence
```