### PR TITLE
feat/trigger: enable trigger to send to different namespace

### DIFF
--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -180,7 +180,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, t *brokerv1beta1.Trigger)
 }
 
 func (r *Reconciler) resolveSubscriber(ctx context.Context, t *brokerv1beta1.Trigger, b *brokerv1beta1.Broker) error {
-	if t.Spec.Subscriber.Ref != nil {
+	if t.Spec.Subscriber.Ref != nil && t.Spec.Subscriber.Ref.Namespace == "" {
 		// To call URIFromDestination(dest apisv1alpha1.Destination, parent interface{}), dest.Ref must have a Namespace
 		// We will use the Namespace of Trigger as the Namespace of dest.Ref
 		t.Spec.Subscriber.Ref.Namespace = t.GetNamespace()


### PR DESCRIPTION
After this change, when the namepsace is specified in the subscriber
the URI can be resolved correctly to the specified namespace instead
of forcing it to the be same as the trigger namespace.

Fixes #2015 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Don't over the namespace of a trigger

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->
- 🎁 Allow triggers to send to a sink in different namespace

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🎁 Allow triggers to send to a sink in different namespace
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
