### PR TITLE
Remove redundant tag keys from delivery metrics

### DIFF
--- a/pkg/metrics/delivery_reporter.go
+++ b/pkg/metrics/delivery_reporter.go
@@ -55,9 +55,6 @@ func (r *DeliveryReporter) register() error {
 			Measure:     r.dispatchTimeInMsecM,
 			Aggregation: view.Count(),
 			TagKeys: []tag.Key{
-				NamespaceNameKey,
-				BrokerNameKey,
-				TriggerNameKey,
 				TriggerFilterTypeKey,
 				ResponseCodeKey,
 				ResponseCodeClassKey,
@@ -71,9 +68,6 @@ func (r *DeliveryReporter) register() error {
 			Measure:     r.dispatchTimeInMsecM,
 			Aggregation: view.Distribution(metrics.Buckets125(1, 10000)...), // 1, 2, 5, 10, 20, 50, 100, 1000, 5000, 10000
 			TagKeys: []tag.Key{
-				NamespaceNameKey,
-				BrokerNameKey,
-				TriggerNameKey,
 				TriggerFilterTypeKey,
 				ResponseCodeKey,
 				ResponseCodeClassKey,
@@ -87,9 +81,6 @@ func (r *DeliveryReporter) register() error {
 			Measure:     r.processingTimeInMsecM,
 			Aggregation: view.Distribution(metrics.Buckets125(1, 10000)...), // 1, 2, 5, 10, 20, 50, 100, 1000, 5000, 10000
 			TagKeys: []tag.Key{
-				NamespaceNameKey,
-				BrokerNameKey,
-				TriggerNameKey,
 				TriggerFilterTypeKey,
 				PodNameKey,
 				ContainerNameKey,


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Remove metric labels that should not be present. They are not in the metric's descriptors, therefore are unexpected.
  - Current StackDriver exporter ignores them, but the otel Collector doesn't. 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```