### PR TITLE
Remove GetBroker, GetTarget, and EqualsBytes

### DIFF
--- a/pkg/broker/config/cache.go
+++ b/pkg/broker/config/cache.go
@@ -109,14 +109,3 @@ func (ct *CachedTargets) DebugString() string {
 		Indent:    "\t",
 	}.Format(val)
 }
-
-// EqualsBytes checks if the current targets config equals the given
-// targets config in bytes.
-func (ct *CachedTargets) EqualsBytes(b []byte) bool {
-	self := ct.Load()
-	var other TargetsConfig
-	if err := proto.Unmarshal(b, &other); err != nil {
-		return false
-	}
-	return proto.Equal(self, &other)
-}

--- a/pkg/broker/config/cache.go
+++ b/pkg/broker/config/cache.go
@@ -57,28 +57,16 @@ func (ct *CachedTargets) RangeAllTargets(f func(*Target) bool) {
 	}
 }
 
-// GetTarget returns a target.
-// Do not modify the returned Target copy.
-func (ct *CachedTargets) GetTarget(namespace, brokerName, targetName string) (*Target, bool) {
-	Broker, ok := ct.GetBroker(namespace, brokerName)
-	if !ok {
-		return nil, false
-	}
-	t, ok := Broker.Targets[targetName]
-	return t, ok
-}
-
 // GetTargetByKey returns a target by its trigger key. The format of trigger key is namespace/brokerName/targetName.
 // Do not modify the returned Target copy.
 func (ct *CachedTargets) GetTargetByKey(key string) (*Target, bool) {
 	namespace, brokerName, targetName := SplitTriggerKey(key)
-	return ct.GetTarget(namespace, brokerName, targetName)
-}
-
-// GetBroker returns a broker and its targets if it exists.
-// Do not modify the returned Broker copy.
-func (ct *CachedTargets) GetBroker(namespace, name string) (*Broker, bool) {
-	return ct.GetBrokerByKey(BrokerKey(namespace, name))
+	broker, ok := ct.GetBrokerByKey(BrokerKey(namespace, brokerName))
+	if !ok {
+		return nil, false
+	}
+	t, ok := broker.Targets[targetName]
+	return t, ok
 }
 
 // GetBrokerByKey returns a broker and its targets if it exists.

--- a/pkg/broker/config/cache_test.go
+++ b/pkg/broker/config/cache_test.go
@@ -140,18 +140,18 @@ func TestCachedTargetsRange(t *testing.T) {
 	})
 
 	t.Run("get individual broker", func(t *testing.T) {
-		gotBroker, ok := targets.GetBroker("ns", "non-existing")
+		gotBroker, ok := targets.GetBrokerByKey(BrokerKey("ns", "non-existing"))
 		if ok {
 			t.Error("get non-existing broker got ok=true, want ok=false")
 		}
-		gotBroker, ok = targets.GetBroker(b1.Namespace, b1.Name)
+		gotBroker, ok = targets.GetBrokerByKey(b1.Key())
 		if !ok {
 			t.Error("get existing broker got ok=false, want ok=true")
 		}
 		if !proto.Equal(b1, gotBroker) {
 			t.Errorf("get existing broker got=%+v, want=%+v", gotBroker, b1)
 		}
-		gotBroker, ok = targets.GetBroker(b2.Namespace, b2.Name)
+		gotBroker, ok = targets.GetBrokerByKey(b2.Key())
 		if !ok {
 			t.Error("get existing broker got ok=false, want ok=true")
 		}
@@ -460,7 +460,7 @@ func TestGetBrokerOrTarget(t *testing.T) {
 
 	t.Run("get broker", func(t *testing.T) {
 		wantBroker := b1
-		gotBroker, _ := targets.GetBroker(b1.Namespace, b1.Name)
+		gotBroker, _ := targets.GetBrokerByKey(b1.Key())
 		if diff := cmp.Diff(wantBroker, gotBroker, protocmp.Transform()); diff != "" {
 			t.Errorf("GetBroker (-want,+got): %v", diff)
 		}

--- a/pkg/broker/config/cache_test.go
+++ b/pkg/broker/config/cache_test.go
@@ -265,13 +265,24 @@ func TestCachedTargetsBytes(t *testing.T) {
 	}
 
 	// Test EqualsBytes
-	if !targets.EqualsBytes(wantBytes) {
+	if !equalsBytes(targets, wantBytes) {
 		t.Error("CachedTargets.EqualsBytes() got=false, want=true")
 	}
 
-	if targets.EqualsBytes([]byte("random")) {
+	if equalsBytes(targets, []byte("random")) {
 		t.Error("CachedTargets.EqualBytes() with random bytes got=true, want=false")
 	}
+}
+
+// equalsBytes checks if the current targets config equals the given
+// targets config in bytes.
+func equalsBytes(ct *CachedTargets, b []byte) bool {
+	self := ct.Load()
+	var other TargetsConfig
+	if err := proto.Unmarshal(b, &other); err != nil {
+		return false
+	}
+	return proto.Equal(self, &other)
 }
 
 func TestCachedTargetsString(t *testing.T) {

--- a/pkg/broker/config/config.go
+++ b/pkg/broker/config/config.go
@@ -26,16 +26,11 @@ type ReadonlyTargets interface {
 	// RangeAllTargets ranges over all targets.
 	// Do not modify the given Target copy.
 	RangeAllTargets(func(*Target) bool)
-	// GetTarget returns a target.
-	// Do not modify the returned Target copy.
-	GetTarget(namespace, brokerName, targetName string) (*Target, bool)
 	// GetTargetByKey returns a target by its trigger key. The format of trigger key is namespace/brokerName/targetName.
 	// Do not modify the returned Target copy.
 	GetTargetByKey(key string) (*Target, bool)
-	// GetBroker returns a broker and its targets if it exists.
+	// GetBrokerByKey returns a Broker and its targets, if it exists.
 	// Do not modify the returned Broker copy.
-	GetBroker(namespace, name string) (*Broker, bool)
-	// GetBroker by its key (namespace/name).
 	GetBrokerByKey(key string) (*Broker, bool)
 	// RangeBrokers ranges over all brokers.
 	// Do not modify the given Broker copy.

--- a/pkg/broker/config/config.go
+++ b/pkg/broker/config/config.go
@@ -40,9 +40,6 @@ type ReadonlyTargets interface {
 	// DebugString returns the text format of all the targets. It is for _debug_ purposes only. The
 	// output format is not guaranteed to be stable and may change at any time.
 	DebugString() string
-	// EqualsBytes checks if the current targets config equals the given
-	// targets config in bytes.
-	EqualsBytes([]byte) bool
 }
 
 // BrokerMutation provides functions to mutate a Broker.

--- a/pkg/broker/config/memory/memory_test.go
+++ b/pkg/broker/config/memory/memory_test.go
@@ -82,7 +82,7 @@ func TestMutateBroker(t *testing.T) {
 				Subscription: "sub",
 			})
 		})
-		assertBroker(t, wantBroker, "ns", "broker", targets)
+		assertBroker(t, wantBroker, targets)
 	})
 
 	t.Run("update broker attribute", func(t *testing.T) {
@@ -90,7 +90,7 @@ func TestMutateBroker(t *testing.T) {
 		targets.MutateBroker("ns", "broker", func(m config.BrokerMutation) {
 			m.SetAddress("external.broker.example.com")
 		})
-		assertBroker(t, wantBroker, "ns", "broker", targets)
+		assertBroker(t, wantBroker, targets)
 	})
 
 	t1 := &config.Target{
@@ -145,7 +145,7 @@ func TestMutateBroker(t *testing.T) {
 			// Intentionally call insert twice to verify they can be chained.
 			m.UpsertTargets(t1).UpsertTargets(t2)
 		})
-		assertBroker(t, wantBroker, "ns", "broker", targets)
+		assertBroker(t, wantBroker, targets)
 	})
 
 	t.Run("insert and delete targets", func(t *testing.T) {
@@ -157,7 +157,7 @@ func TestMutateBroker(t *testing.T) {
 			// Chain insert and delete.
 			m.UpsertTargets(t3).DeleteTargets(t2)
 		})
-		assertBroker(t, wantBroker, "ns", "broker", targets)
+		assertBroker(t, wantBroker, targets)
 	})
 
 	t.Run("delete and then change broker", func(t *testing.T) {
@@ -176,7 +176,7 @@ func TestMutateBroker(t *testing.T) {
 			})
 			m.UpsertTargets(t1, t2)
 		})
-		assertBroker(t, wantBroker, "ns", "broker", targets)
+		assertBroker(t, wantBroker, targets)
 	})
 
 	t.Run("make change then delete broker", func(t *testing.T) {
@@ -186,7 +186,7 @@ func TestMutateBroker(t *testing.T) {
 			// no matter what changes have been made.
 			m.Delete()
 		})
-		if _, ok := targets.GetBroker("ns", "broker"); ok {
+		if _, ok := targets.GetBrokerByKey(wantBroker.Key()); ok {
 			t.Error("GetBroker got ok=true, want ok=false")
 		}
 	})
@@ -199,9 +199,9 @@ func TestMutateBroker(t *testing.T) {
 	})
 }
 
-func assertBroker(t *testing.T, want *config.Broker, namespace, name string, targets config.Targets) {
+func assertBroker(t *testing.T, want *config.Broker, targets config.Targets) {
 	t.Helper()
-	got, ok := targets.GetBroker(namespace, name)
+	got, ok := targets.GetBrokerByKey(want.Key())
 	if !ok {
 		t.Error("GetBroker got ok=false, want ok=true")
 	}

--- a/pkg/broker/ingress/multi_topic_decouple_sink.go
+++ b/pkg/broker/ingress/multi_topic_decouple_sink.go
@@ -175,7 +175,7 @@ func (m *multiTopicDecoupleSink) updateTopicForBroker(ctx context.Context, broke
 }
 
 func (m *multiTopicDecoupleSink) getTopicIDForBroker(ctx context.Context, broker types.NamespacedName) (string, error) {
-	brokerConfig, ok := m.brokerConfig.GetBroker(broker.Namespace, broker.Name)
+	brokerConfig, ok := m.brokerConfig.GetBrokerByKey(config.BrokerKey(broker.Namespace, broker.Name))
 	if !ok {
 		// There is an propagation delay between the controller reconciles the broker config and
 		// the config being pushed to the configmap volume in the ingress pod. So sometimes we return


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Remove `GetBroker` and `GetTarget`, in favor of their `Get{Broker,Target}ByKey` equivalents.
    - The non-keyed versions were used primarily in tests, not real code.
- Remove 'EqualsBytes`, it was only used in tests.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```
