### PR TITLE
Fix probe helper client listener and logging

### DIFF
--- a/test/test_images/probe_helper/probe/handlers/broker_e2e_delivery.go
+++ b/test/test_images/probe_helper/probe/handlers/broker_e2e_delivery.go
@@ -23,6 +23,8 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	cecontext "github.com/cloudevents/sdk-go/v2/context"
 	"github.com/google/knative-gcp/test/test_images/probe_helper/utils"
+	"go.uber.org/zap"
+	"knative.dev/pkg/logging"
 )
 
 const (
@@ -77,6 +79,7 @@ func (p *BrokerE2EDeliveryProbe) Forward(ctx context.Context, event cloudevents.
 	// The probe sends the event to a given broker in a given namespace.
 	target := fmt.Sprintf("%s/%s/%s", p.brokerCellIngressBaseURL, namespace, broker)
 	ctx = cecontext.WithTarget(ctx, target)
+	logging.FromContext(ctx).Infow("Sending event to broker target", zap.String("target", target))
 	if res := p.client.Send(ctx, event); !cloudevents.IsACK(res) {
 		return fmt.Errorf("Could not send event to broker target '%s', got result %s", target, res)
 	}

--- a/test/test_images/probe_helper/probe/handlers/cloudauditlogs.go
+++ b/test/test_images/probe_helper/probe/handlers/cloudauditlogs.go
@@ -25,6 +25,8 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/knative-gcp/pkg/utils/clients"
 	"github.com/google/knative-gcp/test/test_images/probe_helper/utils"
+	"go.uber.org/zap"
+	"knative.dev/pkg/logging"
 )
 
 const (
@@ -67,6 +69,7 @@ func (p *CloudAuditLogsSourceProbe) Forward(ctx context.Context, event cloudeven
 
 	// The probe creates a Pub/Sub topic.
 	topic := event.ID()
+	logging.FromContext(ctx).Infow("Creating pubsub topic", zap.String("topic", topic))
 	if _, err := p.pubsubClient.CreateTopic(ctx, topic); err != nil {
 		return fmt.Errorf("Failed to create pubsub topic '%s': %v", topic, err)
 	}

--- a/test/test_images/probe_helper/probe/handlers/cloudpubsub.go
+++ b/test/test_images/probe_helper/probe/handlers/cloudpubsub.go
@@ -25,6 +25,8 @@ import (
 	cecontext "github.com/cloudevents/sdk-go/v2/context"
 	schemasv1 "github.com/google/knative-gcp/pkg/schemas/v1"
 	"github.com/google/knative-gcp/test/test_images/probe_helper/utils"
+	"go.uber.org/zap"
+	"knative.dev/pkg/logging"
 )
 
 const (
@@ -70,6 +72,7 @@ func (p *CloudPubSubSourceProbe) Forward(ctx context.Context, event cloudevents.
 		return fmt.Errorf("CloudPubSubSource probe event has no '%s' extension", topicExtension)
 	}
 	ctx = cecontext.WithTopic(ctx, fmt.Sprint(topic))
+	logging.FromContext(ctx).Infow("Publishing message to pubsub topic", zap.String("topic", fmt.Sprint(topic)))
 	if res := p.cePubsubClient.Send(ctx, event); !cloudevents.IsACK(res) {
 		return fmt.Errorf("Failed sending event to topic %s, got result %s", topic, res)
 	}

--- a/test/test_images/probe_helper/probe/handlers/cloudscheduler.go
+++ b/test/test_images/probe_helper/probe/handlers/cloudscheduler.go
@@ -70,6 +70,7 @@ func (p *CloudSchedulerSourceProbe) Forward(ctx context.Context, event cloudeven
 	p.EventTimes.RLock()
 	defer p.EventTimes.RUnlock()
 
+	logging.FromContext(ctx).Infow("Checking last observed scheduler tick")
 	timestampID := fmt.Sprint(event.Extensions()[utils.ProbeEventTargetPathExtension])
 	schedulerTime, ok := p.EventTimes.Times[timestampID]
 	if !ok {

--- a/test/test_images/probe_helper/probe/providers.go
+++ b/test/test_images/probe_helper/probe/providers.go
@@ -82,12 +82,12 @@ func NewCeForwardClient(opts ForwardClientOptions) (handlers.CeForwardClient, er
 	return cloudevents.NewClient(sp)
 }
 
-func NewCeReceiverClientOptions(port ReceivePort) ForwardClientOptions {
+func NewCeReceiverClientOptions(port ReceivePort) ReceiveClientOptions {
 	opts := []cehttp.Option{cloudevents.WithPort(int(port))}
 	return opts
 }
 
-func NewCeForwardClientOptions(port ForwardPort) ReceiveClientOptions {
+func NewCeForwardClientOptions(port ForwardPort) ForwardClientOptions {
 	opts := []cehttp.Option{cloudevents.WithPort(int(port))}
 	return opts
 }

--- a/test/test_images/probe_helper/probe/test_providers.go
+++ b/test/test_images/probe_helper/probe/test_providers.go
@@ -33,12 +33,12 @@ var TestHelperSet wire.ProviderSet = wire.NewSet(
 	NewTestCeForwardClientOptions,
 )
 
-func NewTestCeReceiverClientOptions(listener ForwardListener) ForwardClientOptions {
+func NewTestCeReceiverClientOptions(listener ReceiveListener) ReceiveClientOptions {
 	opts := []cehttp.Option{cloudevents.WithListener(listener)}
 	return opts
 }
 
-func NewTestCeForwardClientOptions(listener ReceiveListener) ReceiveClientOptions {
+func NewTestCeForwardClientOptions(listener ForwardListener) ForwardClientOptions {
 	opts := []cehttp.Option{cloudevents.WithListener(listener)}
 	return opts
 }

--- a/test/test_images/probe_helper/probe/wire_gen.go
+++ b/test/test_images/probe_helper/probe/wire_gen.go
@@ -17,7 +17,7 @@ import (
 // Injectors from wire.go:
 
 func InitializeTestProbeHelper(ctx context.Context, brokerCellBaseUrl string, projectID clients.ProjectID, schedulerStaleDuration time.Duration, helperEnv EnvConfig, forwardListener ForwardListener, receiveListener ReceiveListener, storageClient *storage.Client, psClient *pubsub.Client) (*Helper, error) {
-	forwardClientOptions := NewTestCeReceiverClientOptions(forwardListener)
+	forwardClientOptions := NewTestCeForwardClientOptions(forwardListener)
 	ceForwardClient, err := NewCeForwardClient(forwardClientOptions)
 	if err != nil {
 		return nil, err
@@ -45,7 +45,7 @@ func InitializeTestProbeHelper(ctx context.Context, brokerCellBaseUrl string, pr
 	cloudSchedulerSourceProbe := handlers.NewCloudSchedulerSourceProbe(schedulerStaleDuration)
 	eventTypeProbe := handlers.NewEventTypeHandler(brokerE2EDeliveryProbe, cloudPubSubSourceProbe, cloudStorageSourceCreateProbe, cloudStorageSourceUpdateMetadataProbe, cloudStorageSourceArchiveProbe, cloudStorageSourceDeleteProbe, cloudAuditLogsSourceProbe, cloudSchedulerSourceProbe)
 	livenessChecker := handlers.NewLivenessChecker(cloudSchedulerSourceProbe)
-	receiveClientOptions := NewTestCeForwardClientOptions(receiveListener)
+	receiveClientOptions := NewTestCeReceiverClientOptions(receiveListener)
 	ceReceiveClient, err := NewCeReceiverClient(ctx, livenessChecker, receiveClientOptions)
 	if err != nil {
 		return nil, err

--- a/test/test_images/probe_helper/probe_helper.yaml
+++ b/test/test_images/probe_helper/probe_helper.yaml
@@ -12,23 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: serving.knative.dev/v1
-kind: Service
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: probe-helper-receiver
+  name: probe-helper
   namespace: cloud-run-events-probe
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: probe-helper
   template:
     metadata:
-      annotations:
-        autoscaling.knative.dev/minScale: "1"
-        autoscaling.knative.dev/maxScale: "1"
+      labels:
+        app: probe-helper
     spec:
-      serviceAccountName: probe-helper
       containers:
         - name: probe-helper
           image: ko://github.com/google/knative-gcp/test/test_images/probe_helper
           env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /var/secrets/google/key.json
             - name: BROKER_CELL_INGRESS_BASE_URL
               value: "http://default-brokercell-ingress.cloud-run-events.svc.cluster.local"
             - name: PROBE_PORT
@@ -47,9 +51,16 @@ spec:
             failureThreshold: 3
             httpGet:
               path: /healthz
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 125
             successThreshold: 1
             timeoutSeconds: 10
-          ports:
-            - containerPort: 8080
+          volumeMounts:
+          - name: probe-helper-key
+            mountPath: /var/secrets/google
+      volumes:
+      - name: probe-helper-key
+        secret:
+          secretName: probe-helper-key
+          optional: true

--- a/test/test_images/probe_helper/wire_gen.go
+++ b/test/test_images/probe_helper/wire_gen.go
@@ -16,7 +16,7 @@ import (
 // Injectors from wire.go:
 
 func InitializeProbeHelper(ctx context.Context, brokerCellBaseUrl string, projectID clients.ProjectID, schedulerStaleDuration time.Duration, helperEnv probe.EnvConfig, forwardPort probe.ForwardPort, receivePort probe.ReceivePort) (*probe.Helper, error) {
-	forwardClientOptions := probe.NewCeReceiverClientOptions(receivePort)
+	forwardClientOptions := probe.NewCeForwardClientOptions(forwardPort)
 	ceForwardClient, err := probe.NewCeForwardClient(forwardClientOptions)
 	if err != nil {
 		return nil, err
@@ -52,7 +52,7 @@ func InitializeProbeHelper(ctx context.Context, brokerCellBaseUrl string, projec
 	cloudSchedulerSourceProbe := handlers.NewCloudSchedulerSourceProbe(schedulerStaleDuration)
 	eventTypeProbe := handlers.NewEventTypeHandler(brokerE2EDeliveryProbe, cloudPubSubSourceProbe, cloudStorageSourceCreateProbe, cloudStorageSourceUpdateMetadataProbe, cloudStorageSourceArchiveProbe, cloudStorageSourceDeleteProbe, cloudAuditLogsSourceProbe, cloudSchedulerSourceProbe)
 	livenessChecker := handlers.NewLivenessChecker(cloudSchedulerSourceProbe)
-	receiveClientOptions := probe.NewCeForwardClientOptions(forwardPort)
+	receiveClientOptions := probe.NewCeReceiverClientOptions(receivePort)
 	ceReceiveClient, err := probe.NewCeReceiverClient(ctx, livenessChecker, receiveClientOptions)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The probe helper is facing issues where there is some mixup between the forward client and receiver client. The relevant options are mismatched currently.

## Proposed Changes
- Use the correct options for the forward client and receiver client.
- Improved logging to reduce clutter and be more informative.
- ACK received events even if they generate an error.