### PR TITLE
Revert "Always pass upgrade test (#2059)" (#2061)

### DIFF
--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -19,8 +19,6 @@
 
 # Script entry point.
 
-exit 0
-
 export GO111MODULE=on
 
 # shellcheck disable=SC1090

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -67,6 +67,19 @@ function cloud_run_events_setup() {
   wait_until_pods_running events-system || return 1
 }
 
+function latest_version() {
+  if [ $(current_branch) = "master" ]; then
+    # For master, simply use git tag without major version, this will work even if the release tag is not in the master
+    git tag | sort -r --version-sort | head -n1
+  else
+    local semver=$(git describe --match "v[0-9]*" --abbrev=0)
+    local major_minor=$(echo "$semver" | cut -d. -f1-2)
+
+    # Get the latest patch release for the major minor
+    git tag -l "${major_minor}*" | sort -r --version-sort | head -n1
+  fi
+}
+
 # Latest release. If user does not supply this as a flag, the latest
 # tagged release on the current branch will be used.
 readonly LATEST_RELEASE_VERSION=$(latest_version)


### PR DESCRIPTION
* Revert "Always pass upgrade test (#2059)"

This reverts commit dc07ee03c5a72795170b78b6140b0f8c3ee7da3d.

* Use git tag without major version in master to get latest tag

