### PR TITLE
feat/broker: validate deadLetterSink with retry

### DIFF
--- a/pkg/apis/broker/v1beta1/broker_validation.go
+++ b/pkg/apis/broker/v1beta1/broker_validation.go
@@ -44,7 +44,7 @@ func ValidateDeliverySpec(ctx context.Context, spec *eventingduckv1beta1.Deliver
 		errs = errs.Also(apis.ErrMissingField("backoffPolicy"))
 	}
 	if spec.Retry != nil && spec.DeadLetterSink == nil {
-		errs = errs.Also(apis.ErrMissingField("deadLetterSink"))
+		errs = errs.Also(apis.ErrGeneric("need DeadLetterSink when retry is defined", "deadLetterSink"))
 	}
 	return errs.Also(ValidateDeadLetterSink(ctx, spec.DeadLetterSink).ViaField("deadLetterSink"))
 }

--- a/pkg/apis/broker/v1beta1/broker_validation.go
+++ b/pkg/apis/broker/v1beta1/broker_validation.go
@@ -43,6 +43,9 @@ func ValidateDeliverySpec(ctx context.Context, spec *eventingduckv1beta1.Deliver
 	if spec.BackoffPolicy == nil {
 		errs = errs.Also(apis.ErrMissingField("backoffPolicy"))
 	}
+	if spec.Retry != nil && spec.DeadLetterSink == nil {
+		errs = errs.Also(apis.ErrMissingField("deadLetterSink"))
+	}
 	return errs.Also(ValidateDeadLetterSink(ctx, spec.DeadLetterSink).ViaField("deadLetterSink"))
 }
 

--- a/pkg/apis/broker/v1beta1/broker_validation_test.go
+++ b/pkg/apis/broker/v1beta1/broker_validation_test.go
@@ -72,7 +72,7 @@ func TestBroker_Validate(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrMissingField("spec.delivery.deadLetterSink"),
+		want: apis.ErrGeneric("need DeadLetterSink when retry is defined", "spec.delivery.deadLetterSink"),
 	}, {
 		name: "invalid dead letter sink missing uri",
 		broker: Broker{

--- a/pkg/apis/broker/v1beta1/broker_validation_test.go
+++ b/pkg/apis/broker/v1beta1/broker_validation_test.go
@@ -31,6 +31,7 @@ import (
 func TestBroker_Validate(t *testing.T) {
 	bop := eventingduckv1beta1.BackoffPolicyExponential
 	bod := "PT1S"
+	retry := int32(4)
 	tests := []struct {
 		name   string
 		broker Broker
@@ -60,6 +61,18 @@ func TestBroker_Validate(t *testing.T) {
 			},
 		},
 		want: apis.ErrMissingField("spec.delivery.backoffDelay"),
+	}, {
+		name: "missing dead letter sink for retry",
+		broker: Broker{
+			Spec: v1beta1.BrokerSpec{
+				Delivery: &eventingduckv1beta1.DeliverySpec{
+					BackoffDelay:  &bod,
+					BackoffPolicy: &bop,
+					Retry:         &retry,
+				},
+			},
+		},
+		want: apis.ErrMissingField("spec.delivery.deadLetterSink"),
 	}, {
 		name: "invalid dead letter sink missing uri",
 		broker: Broker{


### PR DESCRIPTION
After this commit, when retry is defined in broker delivery spec,
not having deadLetterSink will fail the validation. This is necessary
because pubsub will ignore retry number without a DLQ.

Fixes #2053 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🎁 Reject broker with retry but no DLQ
```
