### PR TITLE
Extend Probe Helper to cover PingSource

### DIFF
--- a/test/test_images/probe_helper/main.go
+++ b/test/test_images/probe_helper/main.go
@@ -95,6 +95,14 @@ The Probe Helper can handle multiple different types of probes.
 	The Probe Helper receives an event, creates a Pub/Sub topic named after it,
 	and waits to observe its creation having been logged by a CloudAuditLogsSource.
 
+6. PingSource Probe
+
+	This is similar to the CloudSchedulerSource Probe.
+
+	The Probe Helper receives an event of type `pingsource-probe`, and
+	compares the delay between the current time and the last observed PingSource
+	tick. The probe fails if the delay exceeds a threshold.
+
 */
 
 type envConfig struct {
@@ -105,8 +113,8 @@ type envConfig struct {
 	ReceiverPort probe.ReceivePort `envconfig:"RECEIVER_PORT" default:"8080"`
 	// Environment variable containing the base URL for the brokercell ingress, used in the broker e2e delivery probe
 	BrokerCellIngressBaseURL string `envconfig:"BROKER_CELL_INGRESS_BASE_URL" default:"http://default-brokercell-ingress.events-system.svc.cluster.local"`
-	// Environment variable containing the maximum tolerated staleness duration for Cloud Scheduler job ticks before they are discarded
-	SchedulerStaleDuration time.Duration `envconfig:"SCHEDULER_STALE_DURATION" default:"3m"`
+	// Environment variable containing the maximum tolerated staleness duration for Cloud Scheduler job / PingSource ticks before they are discarded
+	CronStaleDuration time.Duration `envconfig:"CRON_STALE_DURATION" default:"3m"`
 }
 
 func main() {
@@ -130,7 +138,7 @@ func main() {
 		logging.FromContext(ctx).Fatal("Failed to get the default project ID", zap.Error(err))
 	}
 
-	ph, err := InitializeProbeHelper(ctx, env.BrokerCellIngressBaseURL, clients.ProjectID(projectID), env.SchedulerStaleDuration, env.EnvConfig, env.ProbePort, env.ReceiverPort)
+	ph, err := InitializeProbeHelper(ctx, env.BrokerCellIngressBaseURL, clients.ProjectID(projectID), env.CronStaleDuration, env.EnvConfig, env.ProbePort, env.ReceiverPort)
 	if err != nil {
 		logging.FromContext(ctx).Fatal("Failed to initialize probe helper", zap.Error(err))
 	}

--- a/test/test_images/probe_helper/probe/handlers/cloudscheduler.go
+++ b/test/test_images/probe_helper/probe/handlers/cloudscheduler.go
@@ -32,7 +32,7 @@ const (
 	// CloudSchedulerSource probes.
 	CloudSchedulerSourceProbeEventType = "cloudschedulersource-probe"
 
-	periodExtension = "period"
+	cloudSchedulerPeriodExtension = "period"
 )
 
 func NewCloudSchedulerSourceProbe(staleDuration time.Duration) *CloudSchedulerSourceProbe {
@@ -58,9 +58,9 @@ type CloudSchedulerSourceProbe struct {
 // Forward tests the delay between the current time and the latest recorded Cloud
 // Scheduler tick in a given scope.
 func (p *CloudSchedulerSourceProbe) Forward(ctx context.Context, event cloudevents.Event) error {
-	period, ok := event.Extensions()[periodExtension]
+	period, ok := event.Extensions()[cloudSchedulerPeriodExtension]
 	if !ok {
-		return fmt.Errorf("CloudSchedulerProbe event has no '%s' extension", namespaceExtension)
+		return fmt.Errorf("CloudSchedulerProbe event has no '%s' extension", cloudSchedulerPeriodExtension)
 	}
 	periodDuration, err := time.ParseDuration(fmt.Sprint(period))
 	if err != nil {

--- a/test/test_images/probe_helper/probe/handlers/event_type.go
+++ b/test/test_images/probe_helper/probe/handlers/event_type.go
@@ -23,6 +23,7 @@ import (
 	"knative.dev/pkg/logging"
 
 	schemasv1 "github.com/google/knative-gcp/pkg/schemas/v1"
+	sourcesv1beta1 "knative.dev/eventing/pkg/apis/sources/v1beta1"
 )
 
 // EventTypeProbe is a handler that maps an event types to its corresponding underlying handler.
@@ -34,7 +35,7 @@ type EventTypeProbe struct {
 func NewEventTypeHandler(brokerE2EDeliveryProbe *BrokerE2EDeliveryProbe, cloudPubSubSourceProbe *CloudPubSubSourceProbe,
 	cloudStorageSourceCreateProbe *CloudStorageSourceCreateProbe, cloudStorageSourceUpdateMetadataProbe *CloudStorageSourceUpdateMetadataProbe,
 	cloudStorageSourceArchiveProbe *CloudStorageSourceArchiveProbe, cloudStorageSourceDeleteProbe *CloudStorageSourceDeleteProbe,
-	cloudAuditLogsSourceProbe *CloudAuditLogsSourceProbe, cloudSchedulerSourceProbe *CloudSchedulerSourceProbe) *EventTypeProbe {
+	cloudAuditLogsSourceProbe *CloudAuditLogsSourceProbe, cloudSchedulerSourceProbe *CloudSchedulerSourceProbe, pingSourceProbe *PingSourceProbe) *EventTypeProbe {
 	// Set the forward and receiver probe handlers now that they are initialized.
 	forwardHandlers := map[string]Interface{
 		BrokerE2EDeliveryProbeEventType:                brokerE2EDeliveryProbe,
@@ -45,6 +46,7 @@ func NewEventTypeHandler(brokerE2EDeliveryProbe *BrokerE2EDeliveryProbe, cloudPu
 		CloudStorageSourceDeleteProbeEventType:         cloudStorageSourceDeleteProbe,
 		CloudAuditLogsSourceProbeEventType:             cloudAuditLogsSourceProbe,
 		CloudSchedulerSourceProbeEventType:             cloudSchedulerSourceProbe,
+		PingSourceProbeEventType:                       pingSourceProbe,
 	}
 	receiveHandlers := map[string]Interface{
 		BrokerE2EDeliveryProbeEventType:                      brokerE2EDeliveryProbe,
@@ -55,6 +57,7 @@ func NewEventTypeHandler(brokerE2EDeliveryProbe *BrokerE2EDeliveryProbe, cloudPu
 		schemasv1.CloudStorageObjectDeletedEventType:         cloudStorageSourceDeleteProbe,
 		schemasv1.CloudAuditLogsLogWrittenEventType:          cloudAuditLogsSourceProbe,
 		schemasv1.CloudSchedulerJobExecutedEventType:         cloudSchedulerSourceProbe,
+		sourcesv1beta1.PingSourceEventType:                   pingSourceProbe,
 	}
 	return &EventTypeProbe{
 		forward: forwardHandlers,

--- a/test/test_images/probe_helper/probe/handlers/ping.go
+++ b/test/test_images/probe_helper/probe/handlers/ping.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/google/knative-gcp/test/test_images/probe_helper/utils"
+	"go.uber.org/zap"
+	"knative.dev/pkg/logging"
+)
+
+const (
+	// PingSourceProbeEventType is the CloudEvent type of forward
+	// PingSource probes.
+	PingSourceProbeEventType = "pingsource-probe"
+
+	pingSourcePeriodExtension = "period"
+)
+
+func NewPingSourceProbe(staleDuration time.Duration) *PingSourceProbe {
+	return &PingSourceProbe{
+		EventTimes: utils.SyncTimesMap{
+			Times: map[string]time.Time{},
+		},
+		StaleDuration: staleDuration,
+	}
+}
+
+// PingSourceProbe is the probe handler for probe requests in the
+// PingSource probe.
+type PingSourceProbe struct {
+	// The map of times of observed ticks in the PingSource probe
+	EventTimes utils.SyncTimesMap
+
+	// StaleDuration is the duration after which entries in the EventTimes map are
+	// considered stale and should be cleaned up in the liveness probe.
+	StaleDuration time.Duration
+}
+
+// Forward tests the delay between the current time and the latest recorded
+// PingSource tick in a given scope.
+func (p *PingSourceProbe) Forward(ctx context.Context, event cloudevents.Event) error {
+	period, ok := event.Extensions()[pingSourcePeriodExtension]
+	if !ok {
+		return fmt.Errorf("PingSourceProbe event has no '%s' extension", pingSourcePeriodExtension)
+	}
+	periodDuration, err := time.ParseDuration(fmt.Sprint(period))
+	if err != nil {
+		return fmt.Errorf("failed to parse PingSource probe period and time.Duration: " + fmt.Sprint(period))
+	}
+
+	p.EventTimes.RLock()
+	defer p.EventTimes.RUnlock()
+
+	timestampID := fmt.Sprint(event.Extensions()[utils.ProbeEventTargetPathExtension])
+	pingSourceTime, ok := p.EventTimes.Times[timestampID]
+	if !ok {
+		return fmt.Errorf("no PingSource tick observed")
+	}
+	if delay := time.Now().Sub(pingSourceTime); delay.Nanoseconds() > periodDuration.Nanoseconds() {
+		return fmt.Errorf("PingSource probe delay %s exceeds period %s", delay, periodDuration)
+	}
+	return nil
+}
+
+// Receive refreshes the latest timestamp for a PingSource tick in a given scope.
+func (p *PingSourceProbe) Receive(ctx context.Context, event cloudevents.Event) error {
+	// Recover the waiting receiver channel ID for the forward PingSource probe.
+	//
+	// Example:
+	//   Context Attributes,
+	//     specversion: 1.0
+	//     type: dev.knative.sources.ping
+	//     source: /apis/v1/namespaces/default/pingsources/test-ping-source-9af24c86-8ba9-4688-80d0-e527678a6a63
+	//     id: 1533039115503825
+	//     time: 2020-09-15T20:12:00.14Z
+	//     datacontenttype: application/json
+	//   Data,
+	//     { ... }
+	p.EventTimes.Lock()
+	defer p.EventTimes.Unlock()
+
+	timestampID := fmt.Sprint(event.Extensions()[utils.ProbeEventReceiverPathExtension])
+	p.EventTimes.Times[timestampID] = time.Now()
+	return nil
+}
+
+// CleanupStalePingSourceTimes returns a handler which loops through each PingSource
+// event time and clears the stale entries from the EventTimes map.
+func (p *PingSourceProbe) CleanupStalePingSourceTimes() utils.ActionFunc {
+	return func(ctx context.Context) error {
+		p.EventTimes.Lock()
+		defer p.EventTimes.Unlock()
+
+		for timestampID, pingSourceTime := range p.EventTimes.Times {
+			if delay := time.Now().Sub(pingSourceTime); delay.Nanoseconds() > p.StaleDuration.Nanoseconds() {
+				logging.FromContext(ctx).Infow("Deleting stale PingSource time", zap.String("timestampID", timestampID), zap.Duration("delay", delay))
+				delete(p.EventTimes.Times, timestampID)
+			}
+		}
+		return nil
+	}
+}

--- a/test/test_images/probe_helper/probe/handlers/providers.go
+++ b/test/test_images/probe_helper/probe/handlers/providers.go
@@ -30,6 +30,7 @@ var HandlerSet wire.ProviderSet = wire.NewSet(
 	NewCloudAuditLogsSourceProbe,
 	NewCloudPubSubSourceProbe,
 	NewCloudSchedulerSourceProbe,
+	NewPingSourceProbe,
 	NewCloudStorageSourceProbe,
 	wire.Struct(new(CloudStorageSourceCreateProbe), "*"),
 	wire.Struct(new(CloudStorageSourceDeleteProbe), "*"),
@@ -38,6 +39,9 @@ var HandlerSet wire.ProviderSet = wire.NewSet(
 	NewLivenessChecker,
 )
 
-func NewLivenessChecker(probe *CloudSchedulerSourceProbe) *utils.LivenessChecker {
-	return &utils.LivenessChecker{ActionFuncs: []utils.ActionFunc{probe.CleanupStaleSchedulerTimes()}}
+func NewLivenessChecker(cloudSchedulerProbe *CloudSchedulerSourceProbe, pingSourceProbe *PingSourceProbe) *utils.LivenessChecker {
+	return &utils.LivenessChecker{ActionFuncs: []utils.ActionFunc{
+		cloudSchedulerProbe.CleanupStaleSchedulerTimes(),
+		pingSourceProbe.CleanupStalePingSourceTimes(),
+	}}
 }

--- a/test/test_images/probe_helper/probe/wire.go
+++ b/test/test_images/probe_helper/probe/wire.go
@@ -30,6 +30,6 @@ import (
 	"github.com/google/knative-gcp/test/test_images/probe_helper/probe/handlers"
 )
 
-func InitializeTestProbeHelper(ctx context.Context, brokerCellBaseUrl string, projectID clients.ProjectID, schedulerStaleDuration time.Duration, helperEnv EnvConfig, forwardListener ForwardListener, receiveListener ReceiveListener, storageClient *storage.Client, psClient *pubsub.Client) (*Helper, error) {
+func InitializeTestProbeHelper(ctx context.Context, brokerCellBaseUrl string, projectID clients.ProjectID, cronStaleDuration time.Duration, helperEnv EnvConfig, forwardListener ForwardListener, receiveListener ReceiveListener, storageClient *storage.Client, psClient *pubsub.Client) (*Helper, error) {
 	panic(wire.Build(TestHelperSet, handlers.HandlerSet))
 }

--- a/test/test_images/probe_helper/probe/wire_gen.go
+++ b/test/test_images/probe_helper/probe/wire_gen.go
@@ -16,7 +16,7 @@ import (
 
 // Injectors from wire.go:
 
-func InitializeTestProbeHelper(ctx context.Context, brokerCellBaseUrl string, projectID clients.ProjectID, schedulerStaleDuration time.Duration, helperEnv EnvConfig, forwardListener ForwardListener, receiveListener ReceiveListener, storageClient *storage.Client, psClient *pubsub.Client) (*Helper, error) {
+func InitializeTestProbeHelper(ctx context.Context, brokerCellBaseUrl string, projectID clients.ProjectID, cronStaleDuration time.Duration, helperEnv EnvConfig, forwardListener ForwardListener, receiveListener ReceiveListener, storageClient *storage.Client, psClient *pubsub.Client) (*Helper, error) {
 	forwardClientOptions := NewTestCeForwardClientOptions(forwardListener)
 	ceForwardClient, err := NewCeForwardClient(forwardClientOptions)
 	if err != nil {
@@ -42,9 +42,10 @@ func InitializeTestProbeHelper(ctx context.Context, brokerCellBaseUrl string, pr
 		CloudStorageSourceProbe: cloudStorageSourceProbe,
 	}
 	cloudAuditLogsSourceProbe := handlers.NewCloudAuditLogsSourceProbe(projectID, psClient)
-	cloudSchedulerSourceProbe := handlers.NewCloudSchedulerSourceProbe(schedulerStaleDuration)
-	eventTypeProbe := handlers.NewEventTypeHandler(brokerE2EDeliveryProbe, cloudPubSubSourceProbe, cloudStorageSourceCreateProbe, cloudStorageSourceUpdateMetadataProbe, cloudStorageSourceArchiveProbe, cloudStorageSourceDeleteProbe, cloudAuditLogsSourceProbe, cloudSchedulerSourceProbe)
-	livenessChecker := handlers.NewLivenessChecker(cloudSchedulerSourceProbe)
+	cloudSchedulerSourceProbe := handlers.NewCloudSchedulerSourceProbe(cronStaleDuration)
+	pingSourceProbe := handlers.NewPingSourceProbe(cronStaleDuration)
+	eventTypeProbe := handlers.NewEventTypeHandler(brokerE2EDeliveryProbe, cloudPubSubSourceProbe, cloudStorageSourceCreateProbe, cloudStorageSourceUpdateMetadataProbe, cloudStorageSourceArchiveProbe, cloudStorageSourceDeleteProbe, cloudAuditLogsSourceProbe, cloudSchedulerSourceProbe, pingSourceProbe)
+	livenessChecker := handlers.NewLivenessChecker(cloudSchedulerSourceProbe, pingSourceProbe)
 	receiveClientOptions := NewTestCeReceiverClientOptions(receiveListener)
 	ceReceiveClient, err := NewCeReceiverClient(ctx, livenessChecker, receiveClientOptions)
 	if err != nil {

--- a/test/test_images/probe_helper/probe_helper.yaml
+++ b/test/test_images/probe_helper/probe_helper.yaml
@@ -45,7 +45,7 @@ spec:
               value: "30m"
             - name: LIVENESS_STALE_DURATION
               value: "5m"
-            - name: SCHEDULER_STALE_DURATION
+            - name: CRON_STALE_DURATION
               value: "3m"
           livenessProbe:
             failureThreshold: 3

--- a/test/test_images/probe_helper/wire.go
+++ b/test/test_images/probe_helper/wire.go
@@ -29,6 +29,6 @@ import (
 	"github.com/google/knative-gcp/test/test_images/probe_helper/probe/handlers"
 )
 
-func InitializeProbeHelper(ctx context.Context, brokerCellBaseUrl string, projectID clients.ProjectID, schedulerStaleDuration time.Duration, helperEnv probe.EnvConfig, forwardPort probe.ForwardPort, receivePort probe.ReceivePort) (*probe.Helper, error) {
+func InitializeProbeHelper(ctx context.Context, brokerCellBaseUrl string, projectID clients.ProjectID, cronStaleDuration time.Duration, helperEnv probe.EnvConfig, forwardPort probe.ForwardPort, receivePort probe.ReceivePort) (*probe.Helper, error) {
 	panic(wire.Build(probe.HelperSet, handlers.HandlerSet))
 }

--- a/test/test_images/probe_helper/wire_gen.go
+++ b/test/test_images/probe_helper/wire_gen.go
@@ -15,7 +15,7 @@ import (
 
 // Injectors from wire.go:
 
-func InitializeProbeHelper(ctx context.Context, brokerCellBaseUrl string, projectID clients.ProjectID, schedulerStaleDuration time.Duration, helperEnv probe.EnvConfig, forwardPort probe.ForwardPort, receivePort probe.ReceivePort) (*probe.Helper, error) {
+func InitializeProbeHelper(ctx context.Context, brokerCellBaseUrl string, projectID clients.ProjectID, cronStaleDuration time.Duration, helperEnv probe.EnvConfig, forwardPort probe.ForwardPort, receivePort probe.ReceivePort) (*probe.Helper, error) {
 	forwardClientOptions := probe.NewCeForwardClientOptions(forwardPort)
 	ceForwardClient, err := probe.NewCeForwardClient(forwardClientOptions)
 	if err != nil {
@@ -49,9 +49,10 @@ func InitializeProbeHelper(ctx context.Context, brokerCellBaseUrl string, projec
 		CloudStorageSourceProbe: cloudStorageSourceProbe,
 	}
 	cloudAuditLogsSourceProbe := handlers.NewCloudAuditLogsSourceProbe(projectID, client)
-	cloudSchedulerSourceProbe := handlers.NewCloudSchedulerSourceProbe(schedulerStaleDuration)
-	eventTypeProbe := handlers.NewEventTypeHandler(brokerE2EDeliveryProbe, cloudPubSubSourceProbe, cloudStorageSourceCreateProbe, cloudStorageSourceUpdateMetadataProbe, cloudStorageSourceArchiveProbe, cloudStorageSourceDeleteProbe, cloudAuditLogsSourceProbe, cloudSchedulerSourceProbe)
-	livenessChecker := handlers.NewLivenessChecker(cloudSchedulerSourceProbe)
+	cloudSchedulerSourceProbe := handlers.NewCloudSchedulerSourceProbe(cronStaleDuration)
+	pingSourceProbe := handlers.NewPingSourceProbe(cronStaleDuration)
+	eventTypeProbe := handlers.NewEventTypeHandler(brokerE2EDeliveryProbe, cloudPubSubSourceProbe, cloudStorageSourceCreateProbe, cloudStorageSourceUpdateMetadataProbe, cloudStorageSourceArchiveProbe, cloudStorageSourceDeleteProbe, cloudAuditLogsSourceProbe, cloudSchedulerSourceProbe, pingSourceProbe)
+	livenessChecker := handlers.NewLivenessChecker(cloudSchedulerSourceProbe, pingSourceProbe)
 	receiveClientOptions := probe.NewCeReceiverClientOptions(receivePort)
 	ceReceiveClient, err := probe.NewCeReceiverClient(ctx, livenessChecker, receiveClientOptions)
 	if err != nil {

--- a/test/test_images/scheduler_receiver/pod.yaml
+++ b/test/test_images/scheduler_receiver/pod.yaml
@@ -18,6 +18,6 @@ metadata:
   name: scheduler_receiver
 spec:
   containers:
-    - name: auditlogs_receiver
+    - name: scheduler_receiver
       image: ko://github.com/google/knative-gcp/test/test_images/scheduler_receiver
 


### PR DESCRIPTION
Extends Probe Helper functionality to cover PingSource, a built-in Knative source.

## Proposed Changes
- Add PingSource HTTP endpoint to Probe Helper, for use by testing infrastructure.
- Add Probe Helper PingSource test.

**Release Note**

```release-note

```

**Docs**

