### PR TITLE
Remove stale liveliness and readiness check in broker ingress

### DIFF
--- a/pkg/broker/ingress/handler.go
+++ b/pkg/broker/ingress/handler.go
@@ -60,9 +60,6 @@ const (
 	// The format is an RFC3339 time in string format. For example: 2019-08-26T23:38:17.834384404Z.
 	EventArrivalTime = "knativearrivaltime"
 
-	// For probes.
-	heathCheckPath = "/healthz"
-
 	// for permission denied error msg
 	// TODO(cathyzhyi) point to official doc rather than github doc
 	deniedErrMsg string = `Failed to publish to PubSub because permission denied.
@@ -124,10 +121,6 @@ func (h *Handler) Start(ctx context.Context) error {
 // 3. Convert request to event.
 // 4. Send event to decouple sink.
 func (h *Handler) ServeHTTP(response nethttp.ResponseWriter, request *nethttp.Request) {
-	if request.URL.Path == heathCheckPath {
-		response.WriteHeader(nethttp.StatusOK)
-		return
-	}
 	ctx := request.Context()
 	ctx = logging.WithLogger(ctx, h.logger)
 	ctx = tracing.WithLogging(ctx, trace.FromContext(ctx))

--- a/pkg/broker/ingress/handler_test.go
+++ b/pkg/broker/ingress/handler_test.go
@@ -137,12 +137,6 @@ func (m *fakeOverloadedDecoupleSink) Send(_ context.Context, _ *config.BrokerKey
 func TestHandler(t *testing.T) {
 	tests := []testCase{
 		{
-			name:     "probe check",
-			path:     "/healthz",
-			method:   nethttp.MethodGet,
-			wantCode: nethttp.StatusOK,
-		},
-		{
 			name:           "happy case",
 			path:           "/ns1/broker1",
 			event:          createTestEvent("test-event"),


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Since broker ingress HTTP Receiver is using Drainer for liveliness and readiness check from knative/pkg, this part of the code is stale. remove that with related UT.
- New liveliness and readiness related UTs are in https://github.com/google/knative-gcp/blob/master/pkg/utils/clients/factories_test.go#L31
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
