### PR TITLE
Remove latest_version as change is merged upstream

### DIFF
--- a/test/lib.sh
+++ b/test/lib.sh
@@ -67,19 +67,6 @@ function cloud_run_events_setup() {
   wait_until_pods_running events-system || return 1
 }
 
-function latest_version() {
-  if [ $(current_branch) = "master" ]; then
-    # For master, simply use git tag without major version, this will work even if the release tag is not in the master
-    git tag | sort -r --version-sort | head -n1
-  else
-    local semver=$(git describe --match "v[0-9]*" --abbrev=0)
-    local major_minor=$(echo "$semver" | cut -d. -f1-2)
-
-    # Get the latest patch release for the major minor
-    git tag -l "${major_minor}*" | sort -r --version-sort | head -n1
-  fi
-}
-
 # Latest release. If user does not supply this as a flag, the latest
 # tagged release on the current branch will be used.
 readonly LATEST_RELEASE_VERSION=$(latest_version)


### PR DESCRIPTION
The change is already merged in knative/hack#43, so remove it.
