### PR TITLE
feat/perftest: make throughput more stable

### DIFF
--- a/test/performance/benchmarks/broker-gcp/continuous/100-broker-gcp-setup.yaml
+++ b/test/performance/benchmarks/broker-gcp/continuous/100-broker-gcp-setup.yaml
@@ -55,7 +55,7 @@ spec:
     ref:
       apiVersion: v1
       kind: Service
-      name: broker-gcp-receiver
+      name: broker-gcp-sender-receiver
 
 ---
 
@@ -85,10 +85,10 @@ roleRef:
 apiVersion: v1
 kind: Service
 metadata:
-  name: broker-gcp-receiver
+  name: broker-gcp-sender-receiver
 spec:
   selector:
-    role: broker-gcp-receiver
+    role: broker-gcp-sender-receiver
   ports:
     - name: http
       port: 80

--- a/test/performance/benchmarks/broker-gcp/continuous/200-broker-gcp.yaml
+++ b/test/performance/benchmarks/broker-gcp/continuous/200-broker-gcp.yaml
@@ -123,6 +123,7 @@ spec:
                 # set to the number of sender + receiver (same image that does both counts 2)
                 - "--expect-records=2"
                 - "--mako-tags=channel=pubsub"
+                - "-logtostderr"
               env:
                 - name: GOGC
                   value: "on"

--- a/test/performance/benchmarks/broker-gcp/continuous/200-broker-gcp.yaml
+++ b/test/performance/benchmarks/broker-gcp/continuous/200-broker-gcp.yaml
@@ -15,10 +15,10 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: broker-gcp-receiver
+  name: broker-gcp-sender-receiver
   namespace: default
   labels:
-    role: broker-gcp-receiver
+    role: broker-gcp-sender-receiver
 spec:
   schedule: "0/15 * * * *"
   # History must be zero to ensure no failed pods stick around and block the next job
@@ -34,34 +34,58 @@ spec:
       template:
         metadata:
           labels:
-            role: broker-gcp-receiver
+            role: broker-gcp-sender-receiver
         spec:
           serviceAccountName: perf-gcpbroker
           restartPolicy: Never
           containers:
-          - name: sender-receiver
-            image: ko://knative.dev/eventing/test/test_images/performance
-            args:
-              - "--roles=sender,receiver"
-              - "--sink=http://default-brokercell-ingress.events-system.svc.cluster.local/default/gcp"
-              - "--aggregator=broker-gcp-aggregator:10000"
-              - "--pace=100:10,600:40,800:120,1000:120,1400:120,2200:120,2800:120"
-            env:
-              - name: POD_NAME
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.name
-              - name: POD_NAMESPACE
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.namespace
-            resources:
-              requests:
-                cpu: 1000m
-                memory: 2Gi
-            ports:
-              - name: cloudevents
-                containerPort: 8080
+            - name: sender
+              image: ko://knative.dev/eventing/test/test_images/performance
+              args:
+                - "--roles=sender"
+                - "--sink=http://default-brokercell-ingress.events-system.svc.cluster.local/default/gcp"
+                - "--aggregator=broker-gcp-aggregator:10000"
+                - "--pace=6000:60,6000:60,6000:60"
+              env:
+                - name: GOGC
+                  value: "off"
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              resources:
+                requests:
+                  cpu: 1500m
+                  memory: 4Gi
+            - name: receiver
+              image: ko://knative.dev/eventing/test/test_images/performance
+              args:
+                - "--roles=receiver"
+                - "--sink=http://default-brokercell-ingress.events-system.svc.cluster.local/default/gcp"
+                - "--aggregator=broker-gcp-aggregator:10000"
+                - "--pace=6000:60,6000:60,6000:60"
+              env:
+                - name: GOGC
+                  value: "off"
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              resources:
+                requests:
+                  cpu: 1500m
+                  memory: 4Gi
+              ports:
+                - name: cloudevents
+                  containerPort: 8080
 
 ---
 
@@ -92,36 +116,49 @@ spec:
           serviceAccountName: perf-gcpbroker
           restartPolicy: Never
           containers:
-          - name: aggregator
-            image: ko://knative.dev/eventing/test/test_images/performance
-            args:
-              - "--roles=aggregator"
-              # set to the number of sender + receiver (same image that does both counts 2)
-              - "--expect-records=2"
-              - "--mako-tags=channel=pubsub"
-            ports:
-              - name: grpc
-                containerPort: 10000
-            resources:
-              requests:
-                cpu: 1000m
-                memory: 2Gi
-            volumeMounts:
-              - name: config-mako
-                mountPath: /etc/config-mako
-            terminationMessagePolicy: FallbackToLogsOnError
-          - name: mako
-            image: gcr.io/knative-tests/test-infra/mako-microservice:latest
-            env:
-              - name: GOOGLE_APPLICATION_CREDENTIALS
-                value: /var/secret/robot.json
-            volumeMounts:
-              - name: mako-secrets
-                mountPath: /var/secret
-            ports:
-              - name: quickstore
-                containerPort: 9813
-            terminationMessagePolicy: FallbackToLogsOnError
+            - name: aggregator
+              image: ko://knative.dev/eventing/test/test_images/performance
+              args:
+                - "--roles=aggregator"
+                # set to the number of sender + receiver (same image that does both counts 2)
+                - "--expect-records=2"
+                - "--mako-tags=channel=pubsub"
+              env:
+                - name: GOGC
+                  value: "on"
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              ports:
+                - name: grpc
+                  containerPort: 10000
+              resources:
+                requests:
+                  cpu: 1000m
+                  memory: 2Gi
+              volumeMounts:
+                - name: config-mako
+                  mountPath: /etc/config-mako
+                - name: mako-secrets
+                  mountPath: /var/secret
+              terminationMessagePolicy: FallbackToLogsOnError
+            - name: mako
+              image: gcr.io/knative-tests/test-infra/mako-microservice:latest
+              env:
+                - name: GOOGLE_APPLICATION_CREDENTIALS
+                  value: /var/secret/robot.json
+              volumeMounts:
+                - name: mako-secrets
+                  mountPath: /var/secret
+              ports:
+                - name: quickstore
+                  containerPort: 9813
+              terminationMessagePolicy: FallbackToLogsOnError
           volumes:
             - name: config-mako
               configMap:


### PR DESCRIPTION
This commit mostly makes use of the recent optimization in
knative/eventing#2299. Main changes include:
* Break down the sender and receiver to two containers
* Disable automatical GC
* Tune the pace to be higher without running out of memory

