### PR TITLE
Remove unused parameter from storage_admin_set_up

### DIFF
--- a/hack/init_cloud_storage_source.sh
+++ b/hack/init_cloud_storage_source.sh
@@ -16,7 +16,6 @@
 
 # Usage: ./init_cloud_storage_source.sh [PROJECT_ID]
 #  [PROJECT_ID] is an optional parameter to specify the project to use, default to `gcloud config get-value project`.
-# The script always uses the same service account called cre-pubsub.
 set -o errexit
 set -o nounset
 set -euo pipefail
@@ -26,4 +25,4 @@ source $(dirname "$0")/lib.sh
 PROJECT_ID=${1:-$(gcloud config get-value project)}
 echo "PROJECT_ID used when init_cloud_storage_source is'${PROJECT_ID}'"
 
-storage_admin_set_up "${PROJECT_ID}" "${PUBSUB_SERVICE_ACCOUNT}"
+storage_admin_set_up "${PROJECT_ID}"

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -17,8 +17,6 @@
 readonly CONTROL_PLANE_SERVICE_ACCOUNT="events-controller-gsa"
 readonly CONTROL_PLANE_NAMESPACE="events-system"
 
-readonly PUBSUB_SERVICE_ACCOUNT="cre-pubsub"
-
 readonly SERVICE_ACCOUNT_EMAIL_KEY="EMAIL"
 
 readonly ZONAL_CLUSTER_LOCATION_TYPE="zonal"
@@ -151,16 +149,11 @@ function enable_workload_identity(){
 function storage_admin_set_up() {
   echo "Update ServiceAccount for Storage Admin"
   local project_id=${1}
-  local pubsub_service_account=${2}
 
   echo "parameter project_id used when setting up storage admin is'${project_id}'"
-  echo "parameter pubsub_service_account used when setting up storage admin is'${pubsub_service_account}'"
   echo "Update ServiceAccount for Storage Admin"
   gcloud services enable storage-component.googleapis.com
   gcloud services enable storage-api.googleapis.com
-  gcloud projects add-iam-policy-binding "${project_id}" \
-    --member=serviceAccount:"${pubsub_service_account}"@"${project_id}".iam.gserviceaccount.com \
-    --role roles/storage.admin
 
   # We assume the service account's name is in the form '<project-number>@gs-project-accounts.iam.gserviceaccount.com',
   # because it has been for all projects we've encountered. However, nothing requires this

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -71,7 +71,7 @@ function scheduler_setup() {
 # Create resources required for Storage Admin setup.
 function storage_setup() {
   if (( ! IS_PROW )); then
-    storage_admin_set_up "${E2E_PROJECT_ID}" ${PUBSUB_SERVICE_ACCOUNT_NON_PROW} "${PUBSUB_SERVICE_ACCOUNT_KEY_TEMP}"
+    storage_admin_set_up "${E2E_PROJECT_ID}"
   fi
 }
 


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- This PR could be considered as a followup to https://github.com/google/knative-gcp/pull/1418, it includes further cleanup for the unused parameters in `storage_admin_set_up` which were mainly used for the outdated curl command.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
