### PR TITLE
Add subscriber metrics

### DIFF
--- a/pkg/broker/config/targets.proto
+++ b/pkg/broker/config/targets.proto
@@ -31,11 +31,26 @@ enum CellTenantType {
   BROKER = 1;
 }
 
+// Types of the possible subscribers
+enum SubscriberType {
+  OTHER = 0;
+  KNATIVE_SERVICE = 1;
+  KUBERNETES_SERVICE = 2;
+  URL = 3;
+}
+
 // A pubsub "queue".
 message Queue {
   string topic = 1;
   string subscription = 2;
   State state = 3;
+}
+
+// Info associated with a subscriber
+message SubscriberInfo {
+  SubscriberType subscriberType = 1;
+  string subscriberNamespace = 2;
+  string subscriberName = 3;
 }
 
 // Represents a tenant of the Cell. E.g. Broker, Channel, etc.
@@ -95,6 +110,9 @@ message Target {
 
   // The target state.
   State state = 8;
+
+  // The metadata associated with a subscriber
+  SubscriberInfo subscriberInfo = 10;
 }
 
 // TargetsConfig is the collection of all Targets.

--- a/pkg/broker/handler/processors/deliver/processor.go
+++ b/pkg/broker/handler/processors/deliver/processor.go
@@ -170,6 +170,13 @@ func (p *Processor) deliver(ctx context.Context, target *config.Target, broker *
 	if err != nil {
 		logging.FromContext(ctx).Error("failed to add status code tags to context", zap.Error(err))
 	}
+
+	// Insert subscriber info into context.
+	cctx, err = metrics.AddSubscriberTags(ctx, target)
+	if err != nil {
+		logging.FromContext(ctx).Error("failed to add subscriber tags to context", zap.Error(err))
+	}
+
 	// Report event dispatch time with resp status code.
 	p.StatsReporter.ReportEventDispatchTime(cctx, time.Since(startTime))
 

--- a/pkg/metrics/delivery_reporter.go
+++ b/pkg/metrics/delivery_reporter.go
@@ -45,7 +45,7 @@ type DeliveryReporter struct {
 	containerName         ContainerName
 	dispatchTimeInMsecM   *stats.Float64Measure
 	processingTimeInMsecM *stats.Float64Measure
-	subscriberCount				*stats.Float64Measure
+	subscriberCount       *stats.Float64Measure
 }
 
 func (r *DeliveryReporter) register() error {

--- a/pkg/metrics/delivery_reporter_test.go
+++ b/pkg/metrics/delivery_reporter_test.go
@@ -41,16 +41,15 @@ func TestReportEventDispatchTime(t *testing.T) {
 	}
 
 	wantSubscriberTags := map[string]string{
-		metricskey.LabelFilterType:        	 "testeventtype",
-		metricskey.LabelResponseCode:      	 "202",
-		metricskey.LabelResponseCodeClass: 	 "2xx",
-		metricskey.LabelSubscriberType: 	 	 "KNATIVE_SERVICE",
+		metricskey.LabelFilterType:          "testeventtype",
+		metricskey.LabelResponseCode:        "202",
+		metricskey.LabelResponseCodeClass:   "2xx",
+		metricskey.LabelSubscriberType:      "KNATIVE_SERVICE",
 		metricskey.LabelSubscriberNamespace: "test-namespace",
-		metricskey.LabelSubscriberName: 		 "test-serving",
-		metricskey.PodName:                	 "testpod",
-		metricskey.ContainerName:          	 "testcontainer",
+		metricskey.LabelSubscriberName:      "test-serving",
+		metricskey.PodName:                  "testpod",
+		metricskey.ContainerName:            "testcontainer",
 	}
-
 
 	r, err := NewDeliveryReporter("testpod", "testcontainer")
 	if err != nil {

--- a/pkg/metrics/tags.go
+++ b/pkg/metrics/tags.go
@@ -47,6 +47,10 @@ var (
 	TriggerNameKey       = tag.MustNewKey(metricskey.LabelTriggerName)
 	TriggerFilterTypeKey = tag.MustNewKey(metricskey.LabelFilterType)
 
+	SubscriberTypeKey = tag.MustNewKey(metricskey.LabelSubscriberType)
+	SubscriberNamespaceKey = tag.MustNewKey(metricskey.LabelSubscriberNamespace)
+	SubscriberNameKey = tag.MustNewKey(metricskey.LabelSubscriberName)
+
 	ResponseCodeKey      = tag.MustNewKey(metricskey.LabelResponseCode)
 	ResponseCodeClassKey = tag.MustNewKey(metricskey.LabelResponseCodeClass)
 

--- a/pkg/metrics/tags.go
+++ b/pkg/metrics/tags.go
@@ -47,9 +47,9 @@ var (
 	TriggerNameKey       = tag.MustNewKey(metricskey.LabelTriggerName)
 	TriggerFilterTypeKey = tag.MustNewKey(metricskey.LabelFilterType)
 
-	SubscriberTypeKey = tag.MustNewKey(metricskey.LabelSubscriberType)
+	SubscriberTypeKey      = tag.MustNewKey(metricskey.LabelSubscriberType)
 	SubscriberNamespaceKey = tag.MustNewKey(metricskey.LabelSubscriberNamespace)
-	SubscriberNameKey = tag.MustNewKey(metricskey.LabelSubscriberName)
+	SubscriberNameKey      = tag.MustNewKey(metricskey.LabelSubscriberName)
 
 	ResponseCodeKey      = tag.MustNewKey(metricskey.LabelResponseCode)
 	ResponseCodeClassKey = tag.MustNewKey(metricskey.LabelResponseCodeClass)

--- a/pkg/metrics/testing/helper.go
+++ b/pkg/metrics/testing/helper.go
@@ -8,12 +8,12 @@ import (
 
 func ResetIngressMetrics() {
 	// OpenCensus metrics carry global state that need to be reset between unit tests.
-	metricstest.Unregister("event_count", "event_dispatch_latencies")
+	metricstest.Unregister("event_count", "event_dispatch_latencies", "subscriber_event_count")
 }
 
 func ResetDeliveryMetrics() {
 	// OpenCensus metrics carry global state that need to be reset between unit tests.
-	metricstest.Unregister("event_count", "event_dispatch_latencies", "event_processing_latencies")
+	metricstest.Unregister("event_count", "event_dispatch_latencies", "event_processing_latencies", "subscriber_event_count")
 }
 
 func ResetBrokerCellMetrics() {

--- a/pkg/reconciler/brokercell/broker_targets_config.go
+++ b/pkg/reconciler/brokercell/broker_targets_config.go
@@ -119,9 +119,9 @@ func (r *Reconciler) addToConfig(_ context.Context, b *brokerv1beta1.Broker, tri
 						Subscription: brokerresources.GenerateRetrySubscriptionName(t),
 					},
 					SubscriberInfo: &config.SubscriberInfo{
-						SubscriberType: getSubscriberType(t.Kind, t.APIVersion),
+						SubscriberType:      getSubscriberType(t.Kind, t.APIVersion),
 						SubscriberNamespace: t.Spec.Subscriber.Ref.Namespace,
-						SubscriberName: t.Spec.Subscriber.Ref.Name,
+						SubscriberName:      t.Spec.Subscriber.Ref.Name,
 					},
 				}
 				if t.Spec.Filter != nil && t.Spec.Filter.Attributes != nil {

--- a/test/lib/constants.go
+++ b/test/lib/constants.go
@@ -30,6 +30,7 @@ const (
 	TriggerEventCountMetricType       = "knative.dev/eventing/trigger/event_count"
 	TriggerEventDispatchLatencyType   = "knative.dev/eventing/trigger/event_dispatch_latencies"
 	TriggerEventProcessingLatencyType = "knative.dev/eventing/trigger/event_processing_latencies"
+	TriggerSubscriberEventCountType   = "knative.dev/eventing/trigger/subscriber_event_count"
 	TriggerMonitoredResourceType      = "knative_trigger"
 
 	EventType          = "type"

--- a/test/lib/trigger.go
+++ b/test/lib/trigger.go
@@ -39,6 +39,9 @@ func (a TriggerMetricAssertion) Assert(client *monitoring.MetricClient) error {
 	if err := a.assertMetric(client, TriggerEventProcessingLatencyType, a.CountPerTriggerNoRespCode, accumProcessingLatency); err != nil {
 		return err
 	}
+	if err := a.assertMetric(client, TriggerSubscriberEventCountType, a.CountPerTriggerWithRespCode, accumEventCount); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
We need a metric which gives us more information about the event subscribers. This helps us in monitoring the services which are receiving events.

As such, we need 3 additional labels for subscriber info:
- SubscriberType
- SubscriberNamespace
- SubscriberName

This metric is similar to the existing event_count metric and measure the same thing. The new labels are added as a new metric by design to ensure backwards compatibility and avoid breaking changes.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Modify targets.proto to include the additional labels
- Add subscriber_info in broker_targets_config
- Export the metric in metrics/delivery_reporter.go