### PR TITLE
Add filter broker class when building the routing config

### DIFF
--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -30,11 +30,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/google/knative-gcp/pkg/logging"
-	eventingv1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
-	pkgreconciler "knative.dev/pkg/reconciler"
 
 	brokerv1beta1 "github.com/google/knative-gcp/pkg/apis/broker/v1beta1"
 	inteventsv1alpha1 "github.com/google/knative-gcp/pkg/apis/intevents/v1alpha1"
@@ -42,6 +40,7 @@ import (
 	brokercellinformer "github.com/google/knative-gcp/pkg/client/injection/informers/intevents/v1alpha1/brokercell"
 	brokerreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/broker/v1beta1/broker"
 	"github.com/google/knative-gcp/pkg/reconciler"
+	reconcilerutils "github.com/google/knative-gcp/pkg/reconciler/utils"
 	"github.com/google/knative-gcp/pkg/utils"
 )
 
@@ -108,7 +107,7 @@ func newController(ctx context.Context, cmw configmap.Watcher, brds *brokerdeliv
 	brokerInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.FilteringResourceEventHandler{
 			// Only reconcile brokers with the proper class annotation
-			FilterFunc: pkgreconciler.AnnotationFilterFunc(eventingv1beta1.BrokerClassAnnotationKey, brokerv1beta1.BrokerClass, false /*allowUnset*/),
+			FilterFunc: reconcilerutils.BrokerClassFilter,
 			Handler:    controller.HandleAll(impl.Enqueue),
 		},
 		reconciler.DefaultResyncPeriod,

--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -106,7 +106,7 @@ func newController(ctx context.Context, cmw configmap.Watcher, brds *brokerdeliv
 
 	brokerInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.FilteringResourceEventHandler{
-			// Only reconcile brokers with the proper class annotation
+			// Only reconcile brokers with proper brokerclass
 			FilterFunc: reconcilerutils.BrokerClassFilter,
 			Handler:    controller.HandleAll(impl.Enqueue),
 		},

--- a/pkg/reconciler/brokercell/broker_targets_config.go
+++ b/pkg/reconciler/brokercell/broker_targets_config.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/knative-gcp/pkg/broker/config/memory"
 	brokerresources "github.com/google/knative-gcp/pkg/reconciler/broker/resources"
 	"github.com/google/knative-gcp/pkg/reconciler/brokercell/resources"
+	"github.com/google/knative-gcp/pkg/reconciler/utils"
 	"github.com/google/knative-gcp/pkg/reconciler/utils/volume"
 )
 
@@ -73,6 +74,9 @@ func (r *Reconciler) addBrokersAndTriggersToTargets(ctx context.Context, bc *int
 		return err
 	}
 	for _, broker := range brokers {
+		if !utils.BrokerClassFilter(broker) {
+			continue
+		}
 		// Filter by `eventing.knative.dev/broker: <name>` here
 		// to get only the triggers for this broker. The trigger webhook will
 		// ensure that triggers are always labeled with their broker name.

--- a/pkg/reconciler/trigger/controller.go
+++ b/pkg/reconciler/trigger/controller.go
@@ -111,7 +111,7 @@ func newController(ctx context.Context, cmw configmap.Watcher, drs *dataresidenc
 	// Watch brokers.
 	brokerinformer.Get(ctx).Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{
-			// Only care about brokers with the proper class annotation
+			// Only care about brokers with proper brokerclass
 			FilterFunc: reconcilerutils.BrokerClassFilter,
 			Handler: controller.HandleAll(func(obj interface{}) {
 				if b, ok := obj.(*brokerv1beta1.Broker); ok {

--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -36,6 +36,7 @@ import (
 	triggerreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/broker/v1beta1/trigger"
 	brokerlisters "github.com/google/knative-gcp/pkg/client/listers/broker/v1beta1"
 	"github.com/google/knative-gcp/pkg/reconciler"
+	reconcilerutils "github.com/google/knative-gcp/pkg/reconciler/utils"
 	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
 )
 
@@ -84,7 +85,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *brokerv1beta1.Trigger
 		return r.FinalizeKind(ctx, t)
 	}
 
-	if !filterBroker(b) {
+	if !reconcilerutils.BrokerClassFilter(b) {
 		// Call Finalizer anyway in case the Trigger still holds GCP Broker related resources.
 		// If a Trigger used to point to a GCP Broker but now has a Broker with a different brokerclass,
 		// we should clean up resources related to GCP Broker.

--- a/pkg/reconciler/utils/filter.go
+++ b/pkg/reconciler/utils/filter.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	brokerv1beta1 "github.com/google/knative-gcp/pkg/apis/broker/v1beta1"
+	eventingv1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
+	reconciler "knative.dev/pkg/reconciler"
+)
+
+// BrokerClassFilter is the function to filter brokers with proper brokerclass.
+var BrokerClassFilter = reconciler.AnnotationFilterFunc(eventingv1beta1.BrokerClassAnnotationKey, brokerv1beta1.BrokerClass, false /*allowUnset*/)

--- a/pkg/reconciler/utils/filter.go
+++ b/pkg/reconciler/utils/filter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Google LLC
+Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes  #2094 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add the filter as an util function to be shared by different places
- Filter the broker class when building routing configmap so that only gcp broker and trigger are included
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
