### PR TITLE
Split data plane GSA to broker & sources GSAs in e2e scripts

### DIFF
--- a/hack/init_control_plane.sh
+++ b/hack/init_control_plane.sh
@@ -23,23 +23,23 @@ set -euo pipefail
 
 source $(dirname "$0")/lib.sh
 
-readonly CONTROL_PLANE_SERVICE_ACCOUNT_KEY_TEMP="$(mktemp)"
+readonly CONTROL_PLANE_GSA_KEY_TEMP="$(mktemp)"
 
 PROJECT_ID=${1:-$(gcloud config get-value project)}
 echo "PROJECT_ID used when init_control_plane is'${PROJECT_ID}'"
 
-init_control_plane_service_account "${PROJECT_ID}" "${CONTROL_PLANE_SERVICE_ACCOUNT}"
+init_control_plane_gsa "${PROJECT_ID}" "${CONTROL_PLANE_GSA}"
 
 # Download a JSON key for the service account.
-gcloud iam service-accounts keys create "${CONTROL_PLANE_SERVICE_ACCOUNT_KEY_TEMP}" \
-  --iam-account="${CONTROL_PLANE_SERVICE_ACCOUNT}"@"${PROJECT_ID}".iam.gserviceaccount.com
+gcloud iam service-accounts keys create "${CONTROL_PLANE_GSA_KEY_TEMP}" \
+  --iam-account="${CONTROL_PLANE_GSA}"@"${PROJECT_ID}".iam.gserviceaccount.com
 
 # Create/Patch the secret with the download JSON key in the control plane namespace
-kubectl --namespace "${CONTROL_PLANE_NAMESPACE}" create secret generic "${CONTROL_PLANE_SECRET_NAME}" \
-  --from-file=key.json="${CONTROL_PLANE_SERVICE_ACCOUNT_KEY_TEMP}" --dry-run -o yaml | kubectl apply --filename -
+kubectl --namespace "${CONTROL_PLANE_NAMESPACE}" create secret generic "${CONTROL_PLANE_GSA_SECRET_NAME}" \
+  --from-file=key.json="${CONTROL_PLANE_GSA_KEY_TEMP}" --dry-run -o yaml | kubectl apply --filename -
 
 # Delete the controller pod in the control plane namespace to refresh the created/patched secret
 kubectl delete pod -n "${CONTROL_PLANE_NAMESPACE}" --selector role=controller
 
 # Remove the tmp file.
-rm "${CONTROL_PLANE_SERVICE_ACCOUNT_KEY_TEMP}"
+rm "${CONTROL_PLANE_GSA_KEY_TEMP}"

--- a/hack/init_control_plane_gke.sh
+++ b/hack/init_control_plane_gke.sh
@@ -39,17 +39,17 @@ echo "CLUSTER_LOCATION used when init_control_plane_gke is'${CLUSTER_LOCATION}'"
 echo "CLUSTER_LOCATION_TYPE used when init_control_plane_gke is'${CLUSTER_LOCATION_TYPE}'"
 echo "PROJECT_ID used when init_control_plane_gke is'${PROJECT_ID}'"
 
-init_control_plane_service_account "${PROJECT_ID}" "${CONTROL_PLANE_SERVICE_ACCOUNT}"
-enable_workload_identity "${PROJECT_ID}" "${CONTROL_PLANE_SERVICE_ACCOUNT}" "${CLUSTER_NAME}" "${CLUSTER_LOCATION}" "${CLUSTER_LOCATION_TYPE}"
+init_control_plane_gsa "${PROJECT_ID}" "${CONTROL_PLANE_GSA}"
+enable_workload_identity "${PROJECT_ID}" "${CONTROL_PLANE_GSA}" "${CLUSTER_NAME}" "${CLUSTER_LOCATION}" "${CLUSTER_LOCATION_TYPE}"
 
 # Allow the Kubernetes service account to use Google service account.
 MEMBER="serviceAccount:${PROJECT_ID}.svc.id.goog[${CONTROL_PLANE_NAMESPACE}/${K8S_CONTROLLER_SERVICE_ACCOUNT}]"
 gcloud iam service-accounts add-iam-policy-binding \
   --role roles/iam.workloadIdentityUser \
-  --member "$MEMBER" "${CONTROL_PLANE_SERVICE_ACCOUNT}"@"${PROJECT_ID}".iam.gserviceaccount.com
+  --member "$MEMBER" "${CONTROL_PLANE_GSA}"@"${PROJECT_ID}".iam.gserviceaccount.com
 
 # Add annotation to Kubernetes service account.
-kubectl annotate --overwrite serviceaccount "${K8S_CONTROLLER_SERVICE_ACCOUNT}" iam.gke.io/gcp-service-account="${CONTROL_PLANE_SERVICE_ACCOUNT}"@"${PROJECT_ID}".iam.gserviceaccount.com \
+kubectl annotate --overwrite serviceaccount "${K8S_CONTROLLER_SERVICE_ACCOUNT}" iam.gke.io/gcp-service-account="${CONTROL_PLANE_GSA}"@"${PROJECT_ID}".iam.gserviceaccount.com \
   --namespace "${CONTROL_PLANE_NAMESPACE}"
 
 # Delete the controller pod in the control plane namespace to refresh

--- a/hack/init_data_plane.sh
+++ b/hack/init_data_plane.sh
@@ -41,7 +41,7 @@ existing_namespace=$(kubectl get namespace "${NAMESPACE}" --ignore-not-found)
   fi
 echo "NAMESPACE '${NAMESPACE}' is used for this configuration"
 
-SECRET=${2:-$PUBSUB_SECRET_NAME}
+SECRET=${2:-$SOURCES_GSA_SECRET_NAME}
 echo "SECRET '${SECRET}' is used"
 PROJECT_ID=${3:-$(gcloud config get-value project)}
 echo "PROJECT_ID '${PROJECT_ID}' is used for this configuration"

--- a/hack/init_data_plane_gke.sh
+++ b/hack/init_data_plane_gke.sh
@@ -47,7 +47,7 @@ if [[ $MODE == "default" ]]; then
   # Grant iam.serviceAccountAdmin permission of the Google service account events-sources-gsa
   # to the Control Plane's Google service account events-controller-gsa.
   gcloud iam service-accounts add-iam-policy-binding ${DATA_PLANE_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com  \
-  --member=serviceAccount:${CONTROL_PLANE_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com \
+  --member=serviceAccount:${CONTROL_PLANE_GSA}@${PROJECT_ID}.iam.gserviceaccount.com \
   --role roles/iam.serviceAccountAdmin
 
 # Modify ConfigMap config-gcp-auth.

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-readonly CONTROL_PLANE_SERVICE_ACCOUNT="events-controller-gsa"
+readonly CONTROL_PLANE_GSA="events-controller-gsa"
 readonly CONTROL_PLANE_NAMESPACE="events-system"
 
 readonly SERVICE_ACCOUNT_EMAIL_KEY="EMAIL"
@@ -24,10 +24,10 @@ readonly REGIONAL_CLUSTER_LOCATION_TYPE="regional"
 
 # Constants used for both init_XXX.sh and e2e-xxx.sh
 export K8S_CONTROLLER_SERVICE_ACCOUNT="controller"
-export CONTROL_PLANE_SECRET_NAME="google-cloud-key"
+export CONTROL_PLANE_GSA_SECRET_NAME="google-cloud-key"
 export SOURCES_GSA_SECRET_NAME="google-cloud-key"
 
-function init_control_plane_service_account() {
+function init_control_plane_gsa() {
   local project_id=${1}
   local control_plane_service_account=${2}
 

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -25,7 +25,7 @@ readonly REGIONAL_CLUSTER_LOCATION_TYPE="regional"
 # Constants used for both init_XXX.sh and e2e-xxx.sh
 export K8S_CONTROLLER_SERVICE_ACCOUNT="controller"
 export CONTROL_PLANE_SECRET_NAME="google-cloud-key"
-export PUBSUB_SECRET_NAME="google-cloud-key"
+export SOURCES_GSA_SECRET_NAME="google-cloud-key"
 
 function init_control_plane_service_account() {
   local project_id=${1}

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -20,7 +20,7 @@
 which gcloud &> /dev/null || gcloud() { echo "[ignore-gcloud $*]" 1>&2; }
 
 # Constants used for creating ServiceAccount for the Control Plane if it's not running on Prow.
-readonly CONTROL_PLANE_SERVICE_ACCOUNT_NON_PROW="events-controller-gsa"
+readonly CONTROL_PLANE_GSA_NON_PROW="events-controller-gsa"
 
 # Constants used for creating ServiceAccount for the Sources if it's not running on Prow.
 readonly SOURCES_GSA_NON_PROW="events-sources-gsa"
@@ -149,7 +149,7 @@ function prow_control_plane_setup() {
 
   if [ "${auth_mode}" == "secret" ]; then
     echo "Create the control plane secret"
-    kubectl -n "${CONTROL_PLANE_NAMESPACE}" create secret generic "${CONTROL_PLANE_SECRET_NAME}" --from-file=key.json="${CONTROL_PLANE_SERVICE_ACCOUNT_KEY_TEMP}"
+    kubectl -n "${CONTROL_PLANE_NAMESPACE}" create secret generic "${CONTROL_PLANE_GSA_SECRET_NAME}" --from-file=key.json="${CONTROL_PLANE_GSA_KEY_TEMP}"
     echo "Delete the controller pod in the namespace '${CONTROL_PLANE_NAMESPACE}' to refresh the created/patched secret"
     kubectl delete pod -n "${CONTROL_PLANE_NAMESPACE}" --selector role=controller
   elif [ "${auth_mode}" == "workload_identity" ]; then
@@ -158,8 +158,8 @@ function prow_control_plane_setup() {
     gcloud iam service-accounts add-iam-policy-binding \
       --role roles/iam.workloadIdentityUser \
       --member "${MEMBER}" \
-      --project "${PROW_PROJECT_NAME}" "${CONTROL_PLANE_SERVICE_ACCOUNT_EMAIL}"
-    kubectl annotate --overwrite serviceaccount "${K8S_CONTROLLER_SERVICE_ACCOUNT}" iam.gke.io/gcp-service-account="${CONTROL_PLANE_SERVICE_ACCOUNT_EMAIL}" \
+      --project "${PROW_PROJECT_NAME}" "${CONTROL_PLANE_GSA_EMAIL}"
+    kubectl annotate --overwrite serviceaccount "${K8S_CONTROLLER_SERVICE_ACCOUNT}" iam.gke.io/gcp-service-account="${CONTROL_PLANE_GSA_EMAIL}" \
       --namespace "${CONTROL_PLANE_NAMESPACE}"
     # Setup default credential information for Workload Identity.
     sed "s/K8S_SERVICE_ACCOUNT_NAME/${K8S_SERVICE_ACCOUNT_NAME}/g; s/SOURCES-GOOGLE-SERVICE-ACCOUNT/${SOURCES_GSA_EMAIL}/g" ${CONFIG_GCP_AUTH} | ko apply -f -

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -116,6 +116,7 @@ function broker_auth_setup() {
 
   if [ "${auth_mode}" == "secret" ]; then
     if (( ! IS_PROW )); then
+      # When not running on Prow we need to set up a service account for broker.
       init_pubsub_service_account "${E2E_PROJECT_ID}" "${BROKER_GSA_NON_PROW}"
       enable_monitoring "${E2E_PROJECT_ID}" "${BROKER_GSA_NON_PROW}"
       gcloud iam service-accounts keys create "${BROKER_GSA_KEY_TEMP}" \
@@ -124,6 +125,7 @@ function broker_auth_setup() {
     kubectl -n "${CONTROL_PLANE_NAMESPACE}" create secret generic "${BROKER_GSA_SECRET_NAME}" --from-file=key.json="${BROKER_GSA_KEY_TEMP}"
   elif [ "${auth_mode}" == "workload_identity" ]; then
     if (( ! IS_PROW )); then
+      # When not running on Prow we need to set up a service account for broker.
       init_pubsub_service_account "${E2E_PROJECT_ID}" "${BROKER_GSA_NON_PROW}"
       enable_monitoring "${E2E_PROJECT_ID}" "${BROKER_GSA_NON_PROW}"
       gcloud iam service-accounts add-iam-policy-binding \

--- a/test/e2e-secret-tests.sh
+++ b/test/e2e-secret-tests.sh
@@ -26,25 +26,30 @@ readonly E2E_TEST_NAMESPACE="default"
 # Constants used for creating ServiceAccount for the Control Plane if it's not running on Prow.
 readonly CONTROL_PLANE_SERVICE_ACCOUNT_NON_PROW_KEY_TEMP="$(mktemp)"
 
-# Constants used for creating ServiceAccount for Data Plane(Pub/Sub Admin) if it's not running on Prow.
-readonly PUBSUB_SERVICE_ACCOUNT_NON_PROW_KEY_TEMP="$(mktemp)"
+# Constants used for creating ServiceAccount for the Sources if it's not running on Prow.
+readonly SOURCES_GSA_NON_PROW_KEY_TEMP="$(mktemp)"
+
+# Constants used for creating ServiceAccount for the Broker if it's not running on Prow.
+readonly BROKER_GSA_NON_PROW_KEY_TEMP="$(mktemp)"
 
 # Constants used for authentication setup for GCP Broker if it's not running on Prow.
-readonly GCP_BROKER_SECRET_NAME="google-broker-key"
+readonly BROKER_GSA_SECRET_NAME="google-broker-key"
 
 function export_variable() {
   if (( ! IS_PROW )); then
     readonly CONTROL_PLANE_SERVICE_ACCOUNT_KEY_TEMP="${CONTROL_PLANE_SERVICE_ACCOUNT_NON_PROW_KEY_TEMP}"
-    readonly PUBSUB_SERVICE_ACCOUNT_KEY_TEMP="${PUBSUB_SERVICE_ACCOUNT_NON_PROW_KEY_TEMP}"
+    readonly SOURCES_GSA_KEY_TEMP="${SOURCES_GSA_NON_PROW_KEY_TEMP}"
+    readonly BROKER_GSA_KEY_TEMP="${BROKER_GSA_NON_PROW_KEY_TEMP}"
   else
     readonly CONTROL_PLANE_SERVICE_ACCOUNT_KEY_TEMP="${GOOGLE_APPLICATION_CREDENTIALS}"
-    readonly PUBSUB_SERVICE_ACCOUNT_KEY_TEMP="${GOOGLE_APPLICATION_CREDENTIALS}"
+    readonly SOURCES_GSA_KEY_TEMP="${GOOGLE_APPLICATION_CREDENTIALS}"
+    readonly BROKER_GSA_KEY_TEMP="${GOOGLE_APPLICATION_CREDENTIALS}"
   fi
 }
 
 # Setup resources common to all eventing tests.
 function test_setup() {
-  pubsub_setup "secret" || return 1
+  sources_auth_setup "secret" || return 1
 
   # Authentication check test for BrokerCell. It is used in integration test in secret mode.
   # We do not put it in the same place as other integration tests, because this test can not run in parallel with others,
@@ -53,7 +58,7 @@ function test_setup() {
     test_authentication_check_for_brokercell "secret" || return 1
   fi
 
-  gcp_broker_setup "secret" || return 1
+  broker_auth_setup "secret" || return 1
   storage_setup || return 1
   scheduler_setup || return 1
   echo "Sleep 2 mins to wait for all resources to setup"

--- a/test/e2e-secret-tests.sh
+++ b/test/e2e-secret-tests.sh
@@ -23,23 +23,14 @@ source $(dirname "${BASH_SOURCE[0]}")/e2e-common.sh
 # Eventing main config.
 readonly E2E_TEST_NAMESPACE="default"
 
-# Constants used for creating ServiceAccount for the Control Plane if it's not running on Prow.
-readonly CONTROL_PLANE_GSA_NON_PROW_KEY_TEMP="$(mktemp)"
-
-# Constants used for creating ServiceAccount for the Sources if it's not running on Prow.
-readonly SOURCES_GSA_NON_PROW_KEY_TEMP="$(mktemp)"
-
-# Constants used for creating ServiceAccount for the Broker if it's not running on Prow.
-readonly BROKER_GSA_NON_PROW_KEY_TEMP="$(mktemp)"
-
 # Constants used for authentication setup for GCP Broker if it's not running on Prow.
 readonly BROKER_GSA_SECRET_NAME="google-broker-key"
 
 function export_variable() {
   if (( ! IS_PROW )); then
-    readonly CONTROL_PLANE_GSA_KEY_TEMP="${CONTROL_PLANE_GSA_NON_PROW_KEY_TEMP}"
-    readonly SOURCES_GSA_KEY_TEMP="${SOURCES_GSA_NON_PROW_KEY_TEMP}"
-    readonly BROKER_GSA_KEY_TEMP="${BROKER_GSA_NON_PROW_KEY_TEMP}"
+    readonly CONTROL_PLANE_GSA_KEY_TEMP="$(mktemp)"
+    readonly SOURCES_GSA_KEY_TEMP="$(mktemp)"
+    readonly BROKER_GSA_KEY_TEMP="$(mktemp)"
   else
     readonly CONTROL_PLANE_GSA_KEY_TEMP="${GOOGLE_APPLICATION_CREDENTIALS}"
     readonly SOURCES_GSA_KEY_TEMP="${GOOGLE_APPLICATION_CREDENTIALS}"
@@ -81,7 +72,7 @@ function control_plane_setup() {
   if (( ! IS_PROW )); then
     echo "Set up ServiceAccount used by the Control Plane"
     init_control_plane_gsa "${E2E_PROJECT_ID}" "${CONTROL_PLANE_GSA_NON_PROW}"
-    gcloud iam service-accounts keys create "${CONTROL_PLANE_GSA_NON_PROW_KEY_TEMP}" \
+    gcloud iam service-accounts keys create "${CONTROL_PLANE_GSA_KEY_TEMP}" \
       --iam-account="${CONTROL_PLANE_GSA_NON_PROW}"@"${E2E_PROJECT_ID}".iam.gserviceaccount.com
   fi
   prow_control_plane_setup "secret"

--- a/test/e2e-wi-tests.sh
+++ b/test/e2e-wi-tests.sh
@@ -31,20 +31,20 @@ function export_variable() {
   readonly BROKER_MEMBER="serviceAccount:${E2E_PROJECT_ID}.svc.id.goog[${CONTROL_PLANE_NAMESPACE}/${BROKER_SERVICE_ACCOUNT}]"
   if (( ! IS_PROW )); then
     readonly CONTROL_PLANE_SERVICE_ACCOUNT_EMAIL="${CONTROL_PLANE_SERVICE_ACCOUNT_NON_PROW}@${E2E_PROJECT_ID}.iam.gserviceaccount.com"
-    readonly PUBSUB_SERVICE_ACCOUNT_EMAIL="${PUBSUB_SERVICE_ACCOUNT_NON_PROW}@${E2E_PROJECT_ID}.iam.gserviceaccount.com"
-    readonly DATA_PLANE_SERVICE_ACCOUNT_EMAIL=PUBSUB_SERVICE_ACCOUNT_EMAIL
+    readonly SOURCES_GSA_EMAIL="${SOURCES_GSA_NON_PROW}@${E2E_PROJECT_ID}.iam.gserviceaccount.com"
+    readonly BROKER_GSA_EMAIL="${BROKER_GSA_NON_PROW}@${E2E_PROJECT_ID}.iam.gserviceaccount.com"
   else
     readonly CONTROL_PLANE_SERVICE_ACCOUNT_EMAIL=${PROW_SERVICE_ACCOUNT_EMAIL}
     # Get the PROW service account.
     readonly PROW_PROJECT_NAME=$(cut -d'.' -f1 <<< "$(cut -d'@' -f2 <<< "${PROW_SERVICE_ACCOUNT_EMAIL}")")
-    readonly DATA_PLANE_SERVICE_ACCOUNT_EMAIL="cloud-run-events-source@${PROW_PROJECT_NAME}.iam.gserviceaccount.com"
-    readonly PUBSUB_SERVICE_ACCOUNT_EMAIL=${PROW_SERVICE_ACCOUNT_EMAIL}
+    readonly SOURCES_GSA_EMAIL="cloud-run-events-source@${PROW_PROJECT_NAME}.iam.gserviceaccount.com"
+    readonly BROKER_GSA_EMAIL=${PROW_SERVICE_ACCOUNT_EMAIL}
   fi
 }
 
 # Setup resources common to all eventing tests.
 function test_setup() {
-  pubsub_setup "workload_identity" || return 1
+  sources_auth_setup "workload_identity" || return 1
 
   # Authentication check test for BrokerCell. It is used in integration test in workload identity mode.
   # We do not put it in the same place as other integration tests, because this test can not run in parallel with others,
@@ -53,7 +53,7 @@ function test_setup() {
     test_authentication_check_for_brokercell "workload_identity" || return 1
   fi
 
-  gcp_broker_setup "workload_identity" || return 1
+  broker_auth_setup "workload_identity" || return 1
   storage_setup || return 1
   scheduler_setup || return 1
   echo "Sleep 2 mins to wait for all resources to setup"
@@ -77,7 +77,7 @@ function control_plane_setup() {
     kubectl annotate --overwrite serviceaccount "${K8S_CONTROLLER_SERVICE_ACCOUNT}" iam.gke.io/gcp-service-account="${CONTROL_PLANE_SERVICE_ACCOUNT_EMAIL}" \
       --namespace "${CONTROL_PLANE_NAMESPACE}"
     # Setup default credential information for Workload Identity.
-    sed "s/K8S_SERVICE_ACCOUNT_NAME/${K8S_SERVICE_ACCOUNT_NAME}/g; s/PUBSUB-SERVICE-ACCOUNT/${DATA_PLANE_SERVICE_ACCOUNT_EMAIL}/g" ${CONFIG_GCP_AUTH} | ko apply -f -
+    sed "s/K8S_SERVICE_ACCOUNT_NAME/${K8S_SERVICE_ACCOUNT_NAME}/g; s/SOURCES-GOOGLE-SERVICE-ACCOUNT/${SOURCES_GSA_EMAIL}/g" ${CONFIG_GCP_AUTH} | ko apply -f -
   else
     prow_control_plane_setup "workload_identity"
   fi

--- a/test/e2e-wi-tests.sh
+++ b/test/e2e-wi-tests.sh
@@ -30,11 +30,11 @@ function export_variable() {
   readonly MEMBER="serviceAccount:${E2E_PROJECT_ID}.svc.id.goog[${CONTROL_PLANE_NAMESPACE}/${K8S_CONTROLLER_SERVICE_ACCOUNT}]"
   readonly BROKER_MEMBER="serviceAccount:${E2E_PROJECT_ID}.svc.id.goog[${CONTROL_PLANE_NAMESPACE}/${BROKER_SERVICE_ACCOUNT}]"
   if (( ! IS_PROW )); then
-    readonly CONTROL_PLANE_SERVICE_ACCOUNT_EMAIL="${CONTROL_PLANE_SERVICE_ACCOUNT_NON_PROW}@${E2E_PROJECT_ID}.iam.gserviceaccount.com"
+    readonly CONTROL_PLANE_GSA_EMAIL="${CONTROL_PLANE_GSA_NON_PROW}@${E2E_PROJECT_ID}.iam.gserviceaccount.com"
     readonly SOURCES_GSA_EMAIL="${SOURCES_GSA_NON_PROW}@${E2E_PROJECT_ID}.iam.gserviceaccount.com"
     readonly BROKER_GSA_EMAIL="${BROKER_GSA_NON_PROW}@${E2E_PROJECT_ID}.iam.gserviceaccount.com"
   else
-    readonly CONTROL_PLANE_SERVICE_ACCOUNT_EMAIL=${PROW_SERVICE_ACCOUNT_EMAIL}
+    readonly CONTROL_PLANE_GSA_EMAIL=${PROW_SERVICE_ACCOUNT_EMAIL}
     # Get the PROW service account.
     readonly PROW_PROJECT_NAME=$(cut -d'.' -f1 <<< "$(cut -d'@' -f2 <<< "${PROW_SERVICE_ACCOUNT_EMAIL}")")
     readonly SOURCES_GSA_EMAIL="cloud-run-events-source@${PROW_PROJECT_NAME}.iam.gserviceaccount.com"
@@ -67,14 +67,14 @@ function control_plane_setup() {
   # When not running on Prow we need to set up a service account for managing resources.
   if (( ! IS_PROW )); then
     echo "Set up ServiceAccount used by the Control Plane"
-    init_control_plane_service_account "${E2E_PROJECT_ID}" "${CONTROL_PLANE_SERVICE_ACCOUNT_NON_PROW}"
+    init_control_plane_gsa "${E2E_PROJECT_ID}" "${CONTROL_PLANE_GSA_NON_PROW}"
     local cluster_name="$(cut -d'_' -f4 <<<"$(kubectl config current-context)")"
     local cluster_location="$(cut -d'_' -f3 <<<"$(kubectl config current-context)")"
-    enable_workload_identity "${E2E_PROJECT_ID}" "${CONTROL_PLANE_SERVICE_ACCOUNT_NON_PROW}" "${cluster_name}" "${cluster_location}" "${REGIONAL_CLUSTER_LOCATION_TYPE}"
+    enable_workload_identity "${E2E_PROJECT_ID}" "${CONTROL_PLANE_GSA_NON_PROW}" "${cluster_name}" "${cluster_location}" "${REGIONAL_CLUSTER_LOCATION_TYPE}"
     gcloud iam service-accounts add-iam-policy-binding \
       --role roles/iam.workloadIdentityUser \
-      --member "${MEMBER}" "${CONTROL_PLANE_SERVICE_ACCOUNT_EMAIL}"
-    kubectl annotate --overwrite serviceaccount "${K8S_CONTROLLER_SERVICE_ACCOUNT}" iam.gke.io/gcp-service-account="${CONTROL_PLANE_SERVICE_ACCOUNT_EMAIL}" \
+      --member "${MEMBER}" "${CONTROL_PLANE_GSA_EMAIL}"
+    kubectl annotate --overwrite serviceaccount "${K8S_CONTROLLER_SERVICE_ACCOUNT}" iam.gke.io/gcp-service-account="${CONTROL_PLANE_GSA_EMAIL}" \
       --namespace "${CONTROL_PLANE_NAMESPACE}"
     # Setup default credential information for Workload Identity.
     sed "s/K8S_SERVICE_ACCOUNT_NAME/${K8S_SERVICE_ACCOUNT_NAME}/g; s/SOURCES-GOOGLE-SERVICE-ACCOUNT/${SOURCES_GSA_EMAIL}/g" ${CONFIG_GCP_AUTH} | ko apply -f -

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -31,12 +31,13 @@ readonly TEST_NAMESPACE="default"
 readonly PUBSUB_SECRET_NAME="google-cloud-key"
 readonly CONTROL_PLANE_NAMESPACE="events-system"
 readonly CONTROL_PLANE_SECRET_NAME="google-cloud-key"
-readonly BROKER_DATA_PLANE_SECRET_NAME="google-broker-key"
+readonly SOURCES_GSA_SECRET_NAME="google-cloud-key"
+readonly BROKER_GSA_SECRET_NAME="google-broker-key"
 
 function update_knative() {
-  # Create the secret for pub-sub if it does not exist.
-  kubectl -n ${TEST_NAMESPACE} get secret ${PUBSUB_SECRET_NAME} || \
-  kubectl -n ${TEST_NAMESPACE} create secret generic ${PUBSUB_SECRET_NAME} \
+  # Create the secret for sources if it does not exist.
+  kubectl -n ${TEST_NAMESPACE} get secret ${SOURCES_GSA_SECRET_NAME} || \
+  kubectl -n ${TEST_NAMESPACE} create secret generic ${SOURCES_GSA_SECRET_NAME} \
     --from-file=key.json="${GOOGLE_APPLICATION_CREDENTIALS}"
 
   # Create the control-plane namespace if it does not exist.
@@ -49,8 +50,8 @@ function update_knative() {
     --from-file=key.json="${GOOGLE_APPLICATION_CREDENTIALS}"
 
   # Create the secret for data-plane if it does not exist.
-  kubectl -n ${CONTROL_PLANE_NAMESPACE} get secret ${BROKER_DATA_PLANE_SECRET_NAME} || \
-  kubectl -n ${CONTROL_PLANE_NAMESPACE} create secret generic ${BROKER_DATA_PLANE_SECRET_NAME} \
+  kubectl -n ${CONTROL_PLANE_NAMESPACE} get secret ${BROKER_GSA_SECRET_NAME} || \
+  kubectl -n ${CONTROL_PLANE_NAMESPACE} create secret generic ${BROKER_GSA_SECRET_NAME} \
     --from-file=key.json="${GOOGLE_APPLICATION_CREDENTIALS}"
 
   # Start Knative GCP. Fail the update process if there is any error.

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -30,7 +30,7 @@ readonly TEST_CONFIG_VARIANT="continuous"
 readonly TEST_NAMESPACE="default"
 readonly PUBSUB_SECRET_NAME="google-cloud-key"
 readonly CONTROL_PLANE_NAMESPACE="events-system"
-readonly CONTROL_PLANE_SECRET_NAME="google-cloud-key"
+readonly CONTROL_PLANE_GSA_SECRET_NAME="google-cloud-key"
 readonly SOURCES_GSA_SECRET_NAME="google-cloud-key"
 readonly BROKER_GSA_SECRET_NAME="google-broker-key"
 
@@ -45,8 +45,8 @@ function update_knative() {
     kubectl create namespace ${CONTROL_PLANE_NAMESPACE}
 
   # Create the secret for control-plane if it does not exist.
-  kubectl -n ${CONTROL_PLANE_NAMESPACE} get secret ${CONTROL_PLANE_SECRET_NAME} || \
-  kubectl -n ${CONTROL_PLANE_NAMESPACE} create secret generic ${CONTROL_PLANE_SECRET_NAME} \
+  kubectl -n ${CONTROL_PLANE_NAMESPACE} get secret ${CONTROL_PLANE_GSA_SECRET_NAME} || \
+  kubectl -n ${CONTROL_PLANE_NAMESPACE} create secret generic ${CONTROL_PLANE_GSA_SECRET_NAME} \
     --from-file=key.json="${GOOGLE_APPLICATION_CREDENTIALS}"
 
   # Create the secret for data-plane if it does not exist.

--- a/test/test_configs/config-gcp-auth-wi.yaml
+++ b/test/test_configs/config-gcp-auth-wi.yaml
@@ -25,4 +25,4 @@ data:
     clusterDefaults:
       serviceAccountName: K8S_SERVICE_ACCOUNT_NAME
       workloadIdentityMapping:
-        K8S_SERVICE_ACCOUNT_NAME: PUBSUB-SERVICE-ACCOUNT
+        K8S_SERVICE_ACCOUNT_NAME: SOURCES-GOOGLE-SERVICE-ACCOUNT


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add the logic to split the data plane GSA to two separate broker & sources GSAs in the e2e scripts to match our documentation.
- Rename variables related to the control plane GSA to be consistent with the other GSAs variables.
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
