### PR TITLE
Failures to send Replies are considered delivery failures

### DIFF
--- a/pkg/broker/handler/processors/deliver/processor.go
+++ b/pkg/broker/handler/processors/deliver/processor.go
@@ -239,6 +239,9 @@ func (p *Processor) deliver(ctx context.Context, target *config.Target, broker *
 	if err != nil {
 		return err
 	}
+	if replyResp.StatusCode/100 != 2 {
+		return fmt.Errorf("event delivery failed sending the reply: HTTP status code %d", replyResp.StatusCode)
+	}
 	if err := replyResp.Body.Close(); err != nil {
 		logging.FromContext(ctx).Warn("failed to close reply response body", zap.Error(err))
 	}

--- a/pkg/broker/handler/processors/deliver/processor_test.go
+++ b/pkg/broker/handler/processors/deliver/processor_test.go
@@ -341,8 +341,7 @@ func TestDeliverFailure(t *testing.T) {
 		replyHandler: testingReplyHandler{
 			responseCode: http.StatusBadRequest,
 		},
-		// TODO(https://github.com/google/knative-gcp/issues/2106): This should actually be true.
-		wantErr: false,
+		wantErr: true,
 	}, {
 		name: "reply server success",
 		targetHandler: &targetWithFailureHandler{


### PR DESCRIPTION
Fixes #2106.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- If the reply event is not successfully delivered, then the overall event delivery via the Trigger is considered a failure.
- Add unit tests for successful replies.
- Fix `malformed CloudEvent reply failure` unit test, which passed for the wrong reason.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🐛 Failures to send a Trigger's reply back into the Broker are now retried.
```
