### PR TITLE
Remove empty spec

### DIFF
--- a/test/performance/benchmarks/broker-gcp/continuous/100-broker-gcp-setup.yaml
+++ b/test/performance/benchmarks/broker-gcp/continuous/100-broker-gcp-setup.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: default
   annotations:
     eventing.knative.dev/broker.class: googlecloud
-spec: {}
 
 ---
 


### PR DESCRIPTION
Empty spec will now cause error. The error is about webhook, but I believe this is just because it is not parsed properly.