### PR TITLE
Fix failure during serving installation in e2e test

### DIFF
--- a/test/lib.sh
+++ b/test/lib.sh
@@ -40,7 +40,8 @@ function start_knative_gcp_monitoring() {
 
 # Install all required components for running knative-gcp.
 function start_knative_gcp() {
-  start_latest_knative_serving || return 1
+  # Try reapply serving yaml again in case of race condition between webhook and config map
+  start_latest_knative_serving || start_latest_knative_serving || return 1
   # Try reapply eventing yaml again if config-imc-event-dispatcher failed to start
   # TODO: Restore the below line after https://github.com/knative/eventing/issues/3244 is fixed
   #start_latest_knative_eventing || return 1


### PR DESCRIPTION
Install serving in case of failure to avoid race condition of webhook and config map.