### PR TITLE
Update PS & Topic reconcilers to use Base instead of PubSubBase

### DIFF
--- a/pkg/reconciler/intevents/pullsubscription/keda/controller.go
+++ b/pkg/reconciler/intevents/pullsubscription/keda/controller.go
@@ -36,7 +36,6 @@ import (
 	"github.com/google/knative-gcp/pkg/reconciler"
 	"github.com/google/knative-gcp/pkg/reconciler/identity"
 	"github.com/google/knative-gcp/pkg/reconciler/identity/iam"
-	"github.com/google/knative-gcp/pkg/reconciler/intevents"
 	psreconciler "github.com/google/knative-gcp/pkg/reconciler/intevents/pullsubscription"
 	"github.com/google/knative-gcp/pkg/utils/authcheck"
 
@@ -94,15 +93,11 @@ func newController(
 		logger.Fatal("Failed to process env var", zap.Error(err))
 	}
 
-	pubsubBase := &intevents.PubSubBase{
-		Base: reconciler.NewBase(ctx, controllerAgentName, cmw),
-	}
-
 	pullSubscriptionLister := pullSubscriptionInformer.Lister()
 
 	r := &Reconciler{
 		Base: &psreconciler.Base{
-			PubSubBase:             pubsubBase,
+			Base:                   reconciler.NewBase(ctx, controllerAgentName, cmw),
 			Identity:               identity.NewIdentity(ctx, ipm, gcpas),
 			DeploymentLister:       deploymentInformer.Lister(),
 			ServiceAccountLister:   serviceAccountInformer.Lister(),
@@ -116,7 +111,7 @@ func newController(
 
 	impl := pullsubscriptionreconciler.NewImpl(ctx, r)
 
-	pubsubBase.Logger.Info("Setting up event handlers")
+	r.Logger.Info("Setting up event handlers")
 	onlyKedaScaler := pkgreconciler.AnnotationFilterFunc(duck.AutoscalingClassAnnotation, duck.KEDA, false)
 
 	pullSubscriptionHandler := cache.FilteringResourceEventHandler{

--- a/pkg/reconciler/intevents/pullsubscription/keda/pullsubscription_test.go
+++ b/pkg/reconciler/intevents/pullsubscription/keda/pullsubscription_test.go
@@ -58,7 +58,6 @@ import (
 	"github.com/google/knative-gcp/pkg/client/injection/ducks/duck/v1/resource"
 	"github.com/google/knative-gcp/pkg/client/injection/reconciler/intevents/v1/pullsubscription"
 	"github.com/google/knative-gcp/pkg/reconciler"
-	"github.com/google/knative-gcp/pkg/reconciler/intevents"
 	psreconciler "github.com/google/knative-gcp/pkg/reconciler/intevents/pullsubscription"
 	. "github.com/google/knative-gcp/pkg/reconciler/intevents/pullsubscription/keda/resources"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents/pullsubscription/resources"
@@ -1220,12 +1219,10 @@ func TestAllCases(t *testing.T) {
 		} else {
 			createClientFn = GetTestClientCreateFunc(srv.Addr)
 		}
-		pubsubBase := &intevents.PubSubBase{
-			Base: reconciler.NewBase(ctx, controllerAgentName, cmw),
-		}
+
 		r := &Reconciler{
 			Base: &psreconciler.Base{
-				PubSubBase:             pubsubBase,
+				Base:                   reconciler.NewBase(ctx, controllerAgentName, cmw),
 				DeploymentLister:       listers.GetDeploymentLister(),
 				PullSubscriptionLister: listers.GetPullSubscriptionLister(),
 				UriResolver:            resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),

--- a/pkg/reconciler/intevents/pullsubscription/reconciler.go
+++ b/pkg/reconciler/intevents/pullsubscription/reconciler.go
@@ -39,14 +39,14 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
-	"knative.dev/pkg/reconciler"
+	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
 	tracingconfig "knative.dev/pkg/tracing/config"
 
 	v1 "github.com/google/knative-gcp/pkg/apis/intevents/v1"
 	listers "github.com/google/knative-gcp/pkg/client/listers/intevents/v1"
+	"github.com/google/knative-gcp/pkg/reconciler"
 	"github.com/google/knative-gcp/pkg/reconciler/identity"
-	"github.com/google/knative-gcp/pkg/reconciler/intevents"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents/pullsubscription/resources"
 	reconcilerutilspubsub "github.com/google/knative-gcp/pkg/reconciler/utils/pubsub"
 	"github.com/google/knative-gcp/pkg/tracing"
@@ -71,7 +71,7 @@ const (
 
 // Base implements the core controller logic for pullsubscription.
 type Base struct {
-	*intevents.PubSubBase
+	*reconciler.Base
 	// identity reconciler for reconciling workload identity.
 	*identity.Identity
 	// DeploymentLister index properties about deployments.
@@ -102,7 +102,7 @@ type Base struct {
 // ReconcileDataPlaneFunc is used to reconcile the data plane component(s).
 type ReconcileDataPlaneFunc func(ctx context.Context, d *appsv1.Deployment, ps *v1.PullSubscription) error
 
-func (r *Base) ReconcileKind(ctx context.Context, ps *v1.PullSubscription) reconciler.Event {
+func (r *Base) ReconcileKind(ctx context.Context, ps *v1.PullSubscription) pkgreconciler.Event {
 	ctx = logging.WithLogger(ctx, r.Logger.With(zap.Any("pullsubscription", ps)))
 
 	ps.Status.InitializeConditions()
@@ -112,7 +112,7 @@ func (r *Base) ReconcileKind(ctx context.Context, ps *v1.PullSubscription) recon
 	// Otherwise, its owner will reconcile workload identity.
 	if (ps.OwnerReferences == nil || len(ps.OwnerReferences) == 0) && ps.Spec.ServiceAccountName != "" {
 		if _, err := r.Identity.ReconcileWorkloadIdentity(ctx, ps.Spec.Project, ps); err != nil {
-			return reconciler.NewEvent(corev1.EventTypeWarning, workloadIdentityFailed, "Failed to reconcile Pub/Sub subscription workload identity: %s", err.Error())
+			return pkgreconciler.NewEvent(corev1.EventTypeWarning, workloadIdentityFailed, "Failed to reconcile Pub/Sub subscription workload identity: %s", err.Error())
 		}
 	}
 
@@ -120,7 +120,7 @@ func (r *Base) ReconcileKind(ctx context.Context, ps *v1.PullSubscription) recon
 	sinkURI, err := r.resolveDestination(ctx, ps.Spec.Sink, ps)
 	if err != nil {
 		ps.Status.MarkNoSink("InvalidSink", err.Error())
-		return reconciler.NewEvent(corev1.EventTypeWarning, "InvalidSink", "InvalidSink: %s", err.Error())
+		return pkgreconciler.NewEvent(corev1.EventTypeWarning, "InvalidSink", "InvalidSink: %s", err.Error())
 	} else {
 		ps.Status.MarkSink(sinkURI)
 	}
@@ -142,16 +142,16 @@ func (r *Base) ReconcileKind(ctx context.Context, ps *v1.PullSubscription) recon
 	subscriptionID, err := r.reconcileSubscription(ctx, ps)
 	if err != nil {
 		ps.Status.MarkNoSubscription(reconciledPubSubFailedReason, "Failed to reconcile Pub/Sub subscription: %s", err.Error())
-		return reconciler.NewEvent(corev1.EventTypeWarning, reconciledPubSubFailedReason, "Failed to reconcile Pub/Sub subscription: %s", err.Error())
+		return pkgreconciler.NewEvent(corev1.EventTypeWarning, reconciledPubSubFailedReason, "Failed to reconcile Pub/Sub subscription: %s", err.Error())
 	}
 	ps.Status.MarkSubscribed(subscriptionID)
 
 	err = r.reconcileDataPlaneResources(ctx, ps, r.ReconcileDataPlaneFn)
 	if err != nil {
-		return reconciler.NewEvent(corev1.EventTypeWarning, reconciledDataPlaneFailedReason, "Failed to reconcile Data Plane resource(s): %s", err.Error())
+		return pkgreconciler.NewEvent(corev1.EventTypeWarning, reconciledDataPlaneFailedReason, "Failed to reconcile Data Plane resource(s): %s", err.Error())
 	}
 
-	return reconciler.NewEvent(corev1.EventTypeNormal, reconciledSuccessReason, `PullSubscription reconciled: "%s/%s"`, ps.Namespace, ps.Name)
+	return pkgreconciler.NewEvent(corev1.EventTypeNormal, reconciledSuccessReason, `PullSubscription reconciled: "%s/%s"`, ps.Namespace, ps.Name)
 }
 
 func (r *Base) reconcileSubscription(ctx context.Context, ps *v1.PullSubscription) (string, error) {
@@ -437,20 +437,20 @@ func (r *Base) resolveDestination(ctx context.Context, destination duckv1.Destin
 	return url, nil
 }
 
-func (r *Base) FinalizeKind(ctx context.Context, ps *v1.PullSubscription) reconciler.Event {
+func (r *Base) FinalizeKind(ctx context.Context, ps *v1.PullSubscription) pkgreconciler.Event {
 	// If pullsubscription doesn't have ownerReference, and
 	// k8s ServiceAccount exists, binds to the default GCP ServiceAccount, and it only has one ownerReference,
 	// remove the corresponding GCP ServiceAccount iam policy binding.
 	// No need to delete k8s ServiceAccount, it will be automatically handled by k8s Garbage Collection.
 	if (ps.OwnerReferences == nil || len(ps.OwnerReferences) == 0) && ps.Spec.ServiceAccountName != "" {
 		if err := r.Identity.DeleteWorkloadIdentity(ctx, ps.Spec.Project, ps); err != nil {
-			return reconciler.NewEvent(corev1.EventTypeWarning, deleteWorkloadIdentityFailed, "Failed to delete delete Pub/Sub subscription workload identity: %s", err.Error())
+			return pkgreconciler.NewEvent(corev1.EventTypeWarning, deleteWorkloadIdentityFailed, "Failed to delete delete Pub/Sub subscription workload identity: %s", err.Error())
 		}
 	}
 
 	logging.FromContext(ctx).Desugar().Debug("Deleting Pub/Sub subscription")
 	if err := r.deleteSubscription(ctx, ps); err != nil {
-		return reconciler.NewEvent(corev1.EventTypeWarning, deletePubSubFailedReason, "Failed to delete Pub/Sub subscription: %s", err.Error())
+		return pkgreconciler.NewEvent(corev1.EventTypeWarning, deletePubSubFailedReason, "Failed to delete Pub/Sub subscription: %s", err.Error())
 	}
 	return nil
 }

--- a/pkg/reconciler/intevents/pullsubscription/static/controller.go
+++ b/pkg/reconciler/intevents/pullsubscription/static/controller.go
@@ -42,7 +42,6 @@ import (
 	"github.com/google/knative-gcp/pkg/reconciler"
 	"github.com/google/knative-gcp/pkg/reconciler/identity"
 	"github.com/google/knative-gcp/pkg/reconciler/identity/iam"
-	"github.com/google/knative-gcp/pkg/reconciler/intevents"
 	psreconciler "github.com/google/knative-gcp/pkg/reconciler/intevents/pullsubscription"
 	"github.com/google/knative-gcp/pkg/utils/authcheck"
 )
@@ -89,15 +88,11 @@ func newController(
 		logger.Fatal("Failed to process env var", zap.Error(err))
 	}
 
-	pubsubBase := &intevents.PubSubBase{
-		Base: reconciler.NewBase(ctx, controllerAgentName, cmw),
-	}
-
 	pullSubscriptionLister := pullSubscriptionInformer.Lister()
 
 	r := &Reconciler{
 		Base: &psreconciler.Base{
-			PubSubBase:             pubsubBase,
+			Base:                   reconciler.NewBase(ctx, controllerAgentName, cmw),
 			Identity:               identity.NewIdentity(ctx, ipm, gcpas),
 			DeploymentLister:       deploymentInformer.Lister(),
 			ServiceAccountLister:   serviceAccountInformer.Lister(),
@@ -111,7 +106,7 @@ func newController(
 
 	impl := pullsubscriptionreconciler.NewImpl(ctx, r)
 
-	pubsubBase.Logger.Info("Setting up event handlers")
+	r.Logger.Info("Setting up event handlers")
 
 	// Whenever we introduce a new way of scaling, this code will have to be updated to not just exclude Keda, but the others.
 	// Might be useful to use pkgreconciler.ChainFilterFuncs and move them somewhere else.

--- a/pkg/reconciler/intevents/pullsubscription/static/pullsubscription_test.go
+++ b/pkg/reconciler/intevents/pullsubscription/static/pullsubscription_test.go
@@ -56,7 +56,6 @@ import (
 	pubsubv1 "github.com/google/knative-gcp/pkg/apis/intevents/v1"
 	"github.com/google/knative-gcp/pkg/client/injection/reconciler/intevents/v1/pullsubscription"
 	"github.com/google/knative-gcp/pkg/reconciler"
-	"github.com/google/knative-gcp/pkg/reconciler/intevents"
 	psreconciler "github.com/google/knative-gcp/pkg/reconciler/intevents/pullsubscription"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents/pullsubscription/resources"
 	. "github.com/google/knative-gcp/pkg/reconciler/testing"
@@ -1384,12 +1383,10 @@ func TestAllCases(t *testing.T) {
 		} else {
 			createClientFn = GetTestClientCreateFunc(srv.Addr)
 		}
-		pubsubBase := &intevents.PubSubBase{
-			Base: reconciler.NewBase(ctx, controllerAgentName, cmw),
-		}
+
 		r := &Reconciler{
 			Base: &psreconciler.Base{
-				PubSubBase:             pubsubBase,
+				Base:                   reconciler.NewBase(ctx, controllerAgentName, cmw),
 				DeploymentLister:       listers.GetDeploymentLister(),
 				PullSubscriptionLister: listers.GetPullSubscriptionLister(),
 				UriResolver:            resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),

--- a/pkg/reconciler/intevents/topic/controller.go
+++ b/pkg/reconciler/intevents/topic/controller.go
@@ -41,7 +41,6 @@ import (
 	"github.com/google/knative-gcp/pkg/reconciler"
 	"github.com/google/knative-gcp/pkg/reconciler/identity"
 	"github.com/google/knative-gcp/pkg/reconciler/identity/iam"
-	"github.com/google/knative-gcp/pkg/reconciler/intevents"
 	"github.com/google/knative-gcp/pkg/utils/authcheck"
 )
 
@@ -86,14 +85,10 @@ func newController(
 		logger.Fatal("Failed to process env var", zap.Error(err))
 	}
 
-	pubsubBase := &intevents.PubSubBase{
-		Base: reconciler.NewBase(ctx, controllerAgentName, cmw),
-	}
-
 	topicLister := topicInformer.Lister()
 
 	r := &Reconciler{
-		PubSubBase:           pubsubBase,
+		Base:                 reconciler.NewBase(ctx, controllerAgentName, cmw),
 		Identity:             identity.NewIdentity(ctx, ipm, gcpas),
 		dataresidencyStore:   dataresidencyStore,
 		topicLister:          topicLister,
@@ -105,7 +100,7 @@ func newController(
 
 	impl := topicreconciler.NewImpl(ctx, r)
 
-	pubsubBase.Logger.Info("Setting up event handlers")
+	r.Logger.Info("Setting up event handlers")
 	topicInformer.Informer().AddEventHandlerWithResyncPeriod(controller.HandleAll(impl.Enqueue), reconciler.DefaultResyncPeriod)
 
 	topicGK := v1.Kind("Topic")

--- a/pkg/reconciler/intevents/topic/topic.go
+++ b/pkg/reconciler/intevents/topic/topic.go
@@ -35,7 +35,7 @@ import (
 	"github.com/google/knative-gcp/pkg/utils/authcheck"
 
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/reconciler"
+	pkgreconciler "knative.dev/pkg/reconciler"
 	tracingconfig "knative.dev/pkg/tracing/config"
 
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -48,8 +48,8 @@ import (
 	topicreconciler "github.com/google/knative-gcp/pkg/client/injection/reconciler/intevents/v1/topic"
 	listers "github.com/google/knative-gcp/pkg/client/listers/intevents/v1"
 	metadataClient "github.com/google/knative-gcp/pkg/gclient/metadata"
+	"github.com/google/knative-gcp/pkg/reconciler"
 	"github.com/google/knative-gcp/pkg/reconciler/identity"
-	"github.com/google/knative-gcp/pkg/reconciler/intevents"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents/topic/resources"
 	reconcilerutilspubsub "github.com/google/knative-gcp/pkg/reconciler/utils/pubsub"
 	"github.com/google/knative-gcp/pkg/testing/testloggingutil"
@@ -68,7 +68,7 @@ const (
 
 // Reconciler implements controller.Reconciler for Topic resources.
 type Reconciler struct {
-	*intevents.PubSubBase
+	*reconciler.Base
 	// identity reconciler for reconciling workload identity.
 	*identity.Identity
 	// data residency store
@@ -93,7 +93,7 @@ type Reconciler struct {
 // Check that our Reconciler implements Interface.
 var _ topicreconciler.Interface = (*Reconciler)(nil)
 
-func (r *Reconciler) ReconcileKind(ctx context.Context, topic *v1.Topic) reconciler.Event {
+func (r *Reconciler) ReconcileKind(ctx context.Context, topic *v1.Topic) pkgreconciler.Event {
 	ctx = logging.WithLogger(ctx, r.Logger.With(zap.Any("topic", topic)))
 
 	// This is added purely for the TestCloudLogging E2E tests, which verify that the log line is
@@ -107,13 +107,13 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, topic *v1.Topic) reconci
 	// Otherwise, its owner will reconcile workload identity.
 	if (topic.OwnerReferences == nil || len(topic.OwnerReferences) == 0) && topic.Spec.ServiceAccountName != "" {
 		if _, err := r.Identity.ReconcileWorkloadIdentity(ctx, topic.Spec.Project, topic); err != nil {
-			return reconciler.NewEvent(corev1.EventTypeWarning, workloadIdentityFailed, "Failed to reconcile Pub/Sub topic workload identity: %s", err.Error())
+			return pkgreconciler.NewEvent(corev1.EventTypeWarning, workloadIdentityFailed, "Failed to reconcile Pub/Sub topic workload identity: %s", err.Error())
 		}
 	}
 
 	if err := r.reconcileTopic(ctx, topic); err != nil {
 		topic.Status.MarkNoTopic(reconciledTopicFailedReason, "Failed to reconcile Pub/Sub topic: %s", err.Error())
-		return reconciler.NewEvent(corev1.EventTypeWarning, reconciledTopicFailedReason, "Failed to reconcile Pub/Sub topic: %s", err.Error())
+		return pkgreconciler.NewEvent(corev1.EventTypeWarning, reconciledTopicFailedReason, "Failed to reconcile Pub/Sub topic: %s", err.Error())
 	}
 	topic.Status.MarkTopicReady()
 	// Set the topic being used.
@@ -121,19 +121,19 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, topic *v1.Topic) reconci
 
 	// If enablePublisher is false, then skip creating the publisher.
 	if enablePublisher := topic.Spec.EnablePublisher; enablePublisher != nil && !*enablePublisher {
-		return reconciler.NewEvent(corev1.EventTypeNormal, reconciledSuccessReason, `Topic reconciled: "%s/%s"`, topic.Namespace, topic.Name)
+		return pkgreconciler.NewEvent(corev1.EventTypeNormal, reconciledSuccessReason, `Topic reconciled: "%s/%s"`, topic.Namespace, topic.Name)
 	}
 
 	err, svc := r.reconcilePublisher(ctx, topic)
 	if err != nil {
 		topic.Status.MarkPublisherNotDeployed(reconciledPublisherFailedReason, "Failed to reconcile Publisher: %s", err.Error())
-		return reconciler.NewEvent(corev1.EventTypeWarning, reconciledPublisherFailedReason, "Failed to reconcile Publisher: %s", err.Error())
+		return pkgreconciler.NewEvent(corev1.EventTypeWarning, reconciledPublisherFailedReason, "Failed to reconcile Publisher: %s", err.Error())
 	}
 
 	// Update the topic.
 	topic.Status.PropagatePublisherStatus(&svc.Status)
 
-	return reconciler.NewEvent(corev1.EventTypeNormal, reconciledSuccessReason, `Topic reconciled: "%s/%s"`, topic.Namespace, topic.Name)
+	return pkgreconciler.NewEvent(corev1.EventTypeNormal, reconciledSuccessReason, `Topic reconciled: "%s/%s"`, topic.Namespace, topic.Name)
 }
 
 func (r *Reconciler) reconcileTopic(ctx context.Context, topic *v1.Topic) error {
@@ -306,20 +306,20 @@ func (r *Reconciler) UpdateFromTracingConfigMap(cfg *corev1.ConfigMap) {
 	// TODO: requeue all Topics. See https://github.com/google/knative-gcp/issues/457.
 }
 
-func (r *Reconciler) FinalizeKind(ctx context.Context, topic *v1.Topic) reconciler.Event {
+func (r *Reconciler) FinalizeKind(ctx context.Context, topic *v1.Topic) pkgreconciler.Event {
 	// If topic doesn't have ownerReference, and
 	// k8s ServiceAccount exists, binds to the default GCP ServiceAccount, and it only has one ownerReference,
 	// remove the corresponding GCP ServiceAccount iam policy binding.
 	// No need to delete k8s ServiceAccount, it will be automatically handled by k8s Garbage Collection.
 	if (topic.OwnerReferences == nil || len(topic.OwnerReferences) == 0) && topic.Spec.ServiceAccountName != "" {
 		if err := r.Identity.DeleteWorkloadIdentity(ctx, topic.Spec.Project, topic); err != nil {
-			return reconciler.NewEvent(corev1.EventTypeWarning, deleteWorkloadIdentityFailed, "Failed to delete delete Pub/Sub topic workload identity: %s", err.Error())
+			return pkgreconciler.NewEvent(corev1.EventTypeWarning, deleteWorkloadIdentityFailed, "Failed to delete delete Pub/Sub topic workload identity: %s", err.Error())
 		}
 	}
 	if topic.Spec.PropagationPolicy == v1.TopicPolicyCreateDelete {
 		logging.FromContext(ctx).Desugar().Debug("Deleting Pub/Sub topic")
 		if err := r.deleteTopic(ctx, topic); err != nil {
-			return reconciler.NewEvent(corev1.EventTypeWarning, deleteTopicFailed, "Failed to delete Pub/Sub topic: %s", err.Error())
+			return pkgreconciler.NewEvent(corev1.EventTypeWarning, deleteTopicFailed, "Failed to delete Pub/Sub topic: %s", err.Error())
 		}
 	}
 	return nil

--- a/pkg/reconciler/intevents/topic/topic_test.go
+++ b/pkg/reconciler/intevents/topic/topic_test.go
@@ -52,7 +52,6 @@ import (
 	pubsubv1 "github.com/google/knative-gcp/pkg/apis/intevents/v1"
 	"github.com/google/knative-gcp/pkg/client/injection/reconciler/intevents/v1/topic"
 	"github.com/google/knative-gcp/pkg/reconciler"
-	"github.com/google/knative-gcp/pkg/reconciler/intevents"
 	"github.com/google/knative-gcp/pkg/reconciler/intevents/topic/resources"
 	. "github.com/google/knative-gcp/pkg/reconciler/testing"
 )
@@ -815,11 +814,9 @@ func TestAllCases(t *testing.T) {
 		} else {
 			createClientFn = GetTestClientCreateFunc(srv.Addr)
 		}
-		pubsubBase := &intevents.PubSubBase{
-			Base: reconciler.NewBase(ctx, controllerAgentName, cmw),
-		}
+
 		r := &Reconciler{
-			PubSubBase:         pubsubBase,
+			Base:               reconciler.NewBase(ctx, controllerAgentName, cmw),
 			topicLister:        listers.GetTopicLister(),
 			serviceLister:      listers.GetV1ServiceLister(),
 			publisherImage:     testImage,


### PR DESCRIPTION
## Proposed Changes

- Both PullSubscription and Topic reconcilers are using PubSubBase which is a bit confusing as they don't need the functionalities it offers, changing this to use our [reconciler base](https://github.com/google/knative-gcp/blob/master/pkg/reconciler/reconciler.go) instead.


**Release Note**

```release-note
NONE
```

