### PR TITLE
Fail when there is any unavailability during upgrade

### DIFF
--- a/test/upgrade/config.toml
+++ b/test/upgrade/config.toml
@@ -6,3 +6,4 @@ interval = {{ .Config.Interval.Nanoseconds }}
 target = 'http://wathola-receiver.{{- .Config.Namespace -}}.svc.cluster.local'
 [receiver]
 teardown.Duration = 15000000000
+errors.UnavailablePeriodToReport = 0


### PR DESCRIPTION
After this commit, any unavailable time during upgrade will be considered as a failure.