### PR TITLE
Mark pullSubscription as empty when it is deleted

### DIFF
--- a/pkg/reconciler/intevents/reconciler.go
+++ b/pkg/reconciler/intevents/reconciler.go
@@ -288,5 +288,6 @@ func (psb *PubSubBase) DeletePubSub(ctx context.Context, pubsubable duck.PubSuba
 		return fmt.Errorf("failed to delete PullSubscription: %w", err)
 	}
 	status.SinkURI = nil
+	status.SubscriptionID = ""
 	return nil
 }


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- The topic ID and projectID for topic is set to empty when topic is deleted, so does the sinkURI. Mark pullSubscription to be empty to keep them consistent.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
