### PR TITLE
Get deployment of receive adapter by deployment's name

### DIFF
--- a/pkg/reconciler/intevents/pullsubscription/keda/pullsubscription_test.go
+++ b/pkg/reconciler/intevents/pullsubscription/keda/pullsubscription_test.go
@@ -801,10 +801,10 @@ func TestAllCases(t *testing.T) {
 		Key: testNS + "/" + sourceName,
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-			Eventf(corev1.EventTypeWarning, "DataPlaneReconcileFailed", "Failed to reconcile Data Plane resource(s): %s", "inducing failure for list deployments"),
+			Eventf(corev1.EventTypeWarning, "DataPlaneReconcileFailed", "Failed to reconcile Data Plane resource(s): %s", "inducing failure for get deployments"),
 		},
 		WithReactors: []clientgotesting.ReactionFunc{
-			InduceFailure("list", "deployments"),
+			InduceFailure("get", "deployments"),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchFinalizers(testNS, sourceName, resourceGroup),
@@ -827,7 +827,7 @@ func TestAllCases(t *testing.T) {
 				reconcilertestingv1.WithPullSubscriptionSink(sinkGVK, sinkName),
 				reconcilertestingv1.WithPullSubscriptionTransformer(transformerGVK, transformerName),
 				reconcilertestingv1.WithPullSubscriptionMarkSubscribed(testSubscriptionID),
-				reconcilertestingv1.WithPullSubscriptionMarkDeployedUnknown("ReceiveAdapterGetFailed", "Error getting the Receive Adapter: inducing failure for list deployments"),
+				reconcilertestingv1.WithPullSubscriptionMarkDeployedUnknown("ReceiveAdapterGetFailed", "Error getting the Receive Adapter: inducing failure for get deployments"),
 				reconcilertestingv1.WithPullSubscriptionMarkSink(sinkURI),
 				reconcilertestingv1.WithPullSubscriptionMarkTransformer(transformerURI),
 				reconcilertestingv1.WithPullSubscriptionStatusObservedGeneration(generation),

--- a/pkg/reconciler/intevents/pullsubscription/static/pullsubscription_test.go
+++ b/pkg/reconciler/intevents/pullsubscription/static/pullsubscription_test.go
@@ -865,10 +865,10 @@ func TestAllCases(t *testing.T) {
 		Key: testNS + "/" + sourceName,
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-			Eventf(corev1.EventTypeWarning, "DataPlaneReconcileFailed", "Failed to reconcile Data Plane resource(s): %s", "inducing failure for list deployments"),
+			Eventf(corev1.EventTypeWarning, "DataPlaneReconcileFailed", "Failed to reconcile Data Plane resource(s): %s", "inducing failure for get deployments"),
 		},
 		WithReactors: []clientgotesting.ReactionFunc{
-			InduceFailure("list", "deployments"),
+			InduceFailure("get", "deployments"),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchFinalizers(testNS, sourceName, resourceGroup),
@@ -889,7 +889,7 @@ func TestAllCases(t *testing.T) {
 				reconcilertestingv1.WithPullSubscriptionSink(sinkGVK, sinkName),
 				reconcilertestingv1.WithPullSubscriptionTransformer(transformerGVK, transformerName),
 				reconcilertestingv1.WithPullSubscriptionMarkSubscribed(testSubscriptionID),
-				reconcilertestingv1.WithPullSubscriptionMarkDeployedUnknown("ReceiveAdapterGetFailed", "Error getting the Receive Adapter: inducing failure for list deployments"),
+				reconcilertestingv1.WithPullSubscriptionMarkDeployedUnknown("ReceiveAdapterGetFailed", "Error getting the Receive Adapter: inducing failure for get deployments"),
 				reconcilertestingv1.WithPullSubscriptionMarkSink(sinkURI),
 				reconcilertestingv1.WithPullSubscriptionMarkTransformer(transformerURI),
 				reconcilertestingv1.WithPullSubscriptionStatusObservedGeneration(generation),


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Previously we get the deployment of receive adapter by labels (controllerAgentName and pullSubscription's name). We could directly get the deployment by its name, because the deployment name of a pullSubscription is generated from UID, which is unique. 
(https://github.com/google/knative-gcp/blob/350ed608feb43474488be97275723599389d76e2/pkg/reconciler/intevents/pullsubscription/resources/names.go#L44)
- 
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
