### PR TITLE
Add a doc for multi project configuration

### DIFF
--- a/docs/examples/cloudauditlogssource/README.md
+++ b/docs/examples/cloudauditlogssource/README.md
@@ -45,8 +45,9 @@ directly publish to the underlying transport (Pub/Sub), in CloudEvents format.
    1. If you are using standard Kubernetes secrets, but want to use a
       non-default one, update `secret` with your own secret.
 
-    1. If you are [managing multiple project](../../install/managing-multiple-projects.md), be careful to specify the `project`
-    where you want your Google Cloud resources resides.
+   1. By default, the AuditLog Sink will be created in the same project as your GKE cluster.
+   However, if you are [managing multiple projects](../../install/managing-multiple-projects.md), then you can specify `spec.project`,
+   which is the Google Cloud Project that the AuditLog Sink is created in.
 
    ```shell
    kubectl apply --filename cloudauditlogssource.yaml
@@ -64,7 +65,7 @@ directly publish to the underlying transport (Pub/Sub), in CloudEvents format.
 Create a GCP PubSub Topic:
 
 ```shell
-gcloud pubsub topics create test-auditlogs-source
+gcloud pubsub topics create test-auditlogs-source --topic-project=$PROJECT_ID
 ```
 
 ## Verify

--- a/docs/examples/cloudauditlogssource/README.md
+++ b/docs/examples/cloudauditlogssource/README.md
@@ -45,6 +45,9 @@ directly publish to the underlying transport (Pub/Sub), in CloudEvents format.
    1. If you are using standard Kubernetes secrets, but want to use a
       non-default one, update `secret` with your own secret.
 
+    1. If you are [managing multiple project](../../install/managing-multiple-projects.md), be careful to specify the `project`
+    where you want your Google Cloud resources resides.
+
    ```shell
    kubectl apply --filename cloudauditlogssource.yaml
    ```

--- a/docs/examples/cloudbuildsource/README.md
+++ b/docs/examples/cloudbuildsource/README.md
@@ -39,6 +39,9 @@ build completes.
       non-default one, update `secret` with your own secret which has the
       permission of `roles/pubsub.subscriber`.
 
+   1. If you are [managing multiple project](../../install/managing-multiple-projects.md), be careful to specify the `project`
+   where you want your Google Cloud resources resides.
+
    ```shell
    kubectl apply --filename cloudbuildsource.yaml
    ```

--- a/docs/examples/cloudbuildsource/README.md
+++ b/docs/examples/cloudbuildsource/README.md
@@ -39,8 +39,9 @@ build completes.
       non-default one, update `secret` with your own secret which has the
       permission of `roles/pubsub.subscriber`.
 
-   1. If you are [managing multiple project](../../install/managing-multiple-projects.md), be careful to specify the `project`
-   where you want your Google Cloud resources resides.
+   1. By default, the events will be from Builds running in the same project as your GKE cluster.
+   However, if you are [managing multiple projects](../../install/managing-multiple-projects.md), then you can specify `spec.project`,
+   which is the Google Cloud Project whose Builds you want to get events for.
 
    ```shell
    kubectl apply --filename cloudbuildsource.yaml

--- a/docs/examples/cloudpubsubsource/README.md
+++ b/docs/examples/cloudpubsubsource/README.md
@@ -29,8 +29,9 @@ events using a Push-compatible format.
    1. If you are using standard Kubernetes secrets, but want to use a
       non-default one, update `secret` with your own secret.
 
-   1. If you are [managing multiple project](../../install/managing-multiple-projects.md), be careful to specify the `project`
-   where you want your Google Cloud resources resides.
+   1. By default, the Pub/Sub Topic will exist in the same project as your GKE cluster.
+   However, if you are [managing multiple projects](../../install/managing-multiple-projects.md), then you can specify `spec.project`,
+   which is the Google Cloud Project that the Topic exists in.
 
    ```shell
    gcloud pubsub topics create testing --project=your-project-id
@@ -54,7 +55,7 @@ events using a Push-compatible format.
 Publish messages to your GCP PubSub topic:
 
 ```shell
-gcloud pubsub topics publish testing --message='{"Hello": "world"}'
+gcloud pubsub topics publish testing --message='{"Hello": "world"}' --topic-project=$PROJECT_ID
 ```
 
 ## Verify

--- a/docs/examples/cloudpubsubsource/README.md
+++ b/docs/examples/cloudpubsubsource/README.md
@@ -29,8 +29,11 @@ events using a Push-compatible format.
    1. If you are using standard Kubernetes secrets, but want to use a
       non-default one, update `secret` with your own secret.
 
+   1. If you are [managing multiple project](../../install/managing-multiple-projects.md), be careful to specify the `project`
+   where you want your Google Cloud resources resides.
+
    ```shell
-   gcloud pubsub topics create testing
+   gcloud pubsub topics create testing --project=your-project-id
    ```
 
 1. Create a [`CloudPubSubSource`](cloudpubsubsource.yaml)

--- a/docs/examples/cloudschedulersource/README.md
+++ b/docs/examples/cloudschedulersource/README.md
@@ -43,8 +43,9 @@ scheduled events from
    1. If you are using standard Kubernetes secrets, but want to use a
       non-default one, update `secret` with your own secret.
 
-   1. If you are [managing multiple project](../../install/managing-multiple-projects.md), be careful to specify the `project`
-   where you want your Google Cloud resources resides.
+   1. By default, the Scheduler will be created in the same project as your GKE cluster.
+   However, if you are [managing multiple projects](../../install/managing-multiple-projects.md), then you can specify `spec.project`,
+   which is the Google Cloud Project that the Scheduler is created in.
 
    ```shell
    kubectl apply --filename cloudschedulersource.yaml

--- a/docs/examples/cloudschedulersource/README.md
+++ b/docs/examples/cloudschedulersource/README.md
@@ -43,6 +43,9 @@ scheduled events from
    1. If you are using standard Kubernetes secrets, but want to use a
       non-default one, update `secret` with your own secret.
 
+   1. If you are [managing multiple project](../../install/managing-multiple-projects.md), be careful to specify the `project`
+   where you want your Google Cloud resources resides.
+
    ```shell
    kubectl apply --filename cloudschedulersource.yaml
    ```

--- a/docs/examples/cloudstoragesource/README.md
+++ b/docs/examples/cloudstoragesource/README.md
@@ -77,7 +77,7 @@ Object Notifications for when a new object is added to Google Cloud Storage
 
 ## Deployment
 
-1. Update `serviceAccountName` / `secret` in the
+1. Update `serviceAccountName` / `secret` / `project` in the
    [`cloudstoragesource.yaml`](cloudstoragesource.yaml)
 
    1. If you are in GKE and using
@@ -89,6 +89,9 @@ Object Notifications for when a new object is added to Google Cloud Storage
 
    1. If you are using standard Kubernetes secrets, but want to use a
       non-default one, update `secret` with your own secret.
+
+   1. If you are [managing multiple project](../../install/managing-multiple-projects.md), be careful to specify the `project`
+   where you want your Google Cloud resources resides.
 
 1. Update `BUCKET` in the [`cloudstoragesource.yaml`](cloudstoragesource.yaml)
    and apply it.

--- a/docs/examples/cloudstoragesource/README.md
+++ b/docs/examples/cloudstoragesource/README.md
@@ -77,7 +77,7 @@ Object Notifications for when a new object is added to Google Cloud Storage
 
 ## Deployment
 
-1. Update `serviceAccountName` / `secret` / `project` in the
+1. Update `serviceAccountName` / `secret` in the
    [`cloudstoragesource.yaml`](cloudstoragesource.yaml)
 
    1. If you are in GKE and using
@@ -90,8 +90,11 @@ Object Notifications for when a new object is added to Google Cloud Storage
    1. If you are using standard Kubernetes secrets, but want to use a
       non-default one, update `secret` with your own secret.
 
-   1. If you are [managing multiple project](../../install/managing-multiple-projects.md), be careful to specify the `project`
-   where you want your Google Cloud resources resides.
+1. Update  `project` in the [`cloudstoragesource.yaml`](cloudstoragesource.yaml)
+
+   By default, the Storage Notification will be created in the same project as your GKE cluster.
+   However, if you are [managing multiple projects](../../install/managing-multiple-projects.md), then you can specify `spec.project`,
+   which is the Google Cloud Project that the Storage Notification is created in.
 
 1. Update `BUCKET` in the [`cloudstoragesource.yaml`](cloudstoragesource.yaml)
    and apply it.

--- a/docs/examples/pullsubscription/README.md
+++ b/docs/examples/pullsubscription/README.md
@@ -24,7 +24,7 @@ does so using a Pull format.
    gcloud pubsub topics create $TOPIC_NAME
    ```
 
-1. Update `googleServiceAccount` / `secret` in the
+1. Update `googleServiceAccount` / `secret` / `project`  in the
    [`pullsubscription.yaml`](pullsubscription.yaml)
 
    1. If you are in GKE and using
@@ -36,6 +36,9 @@ does so using a Pull format.
 
    1. If you are using standard Kubernetes secrets, but want to use a
       non-default one, update `secret` with your own secret.
+
+   1. If you are [managing multiple project](../../install/managing-multiple-projects.md), be careful to specify the `project`
+   where you want your Google Cloud resources resides.
 
 1. Update `TOPIC_NAME` in the [`pullsubscription.yaml`](pullsubscription.yaml)
    and apply it.

--- a/docs/examples/pullsubscription/README.md
+++ b/docs/examples/pullsubscription/README.md
@@ -21,10 +21,10 @@ does so using a Pull format.
 
    ```shell
    export TOPIC_NAME=testing
-   gcloud pubsub topics create $TOPIC_NAME
+   gcloud pubsub topics create $TOPIC_NAME --project=$PROJECT_ID
    ```
 
-1. Update `googleServiceAccount` / `secret` / `project`  in the
+1. Update `googleServiceAccount` / `secret` in the
    [`pullsubscription.yaml`](pullsubscription.yaml)
 
    1. If you are in GKE and using
@@ -37,8 +37,12 @@ does so using a Pull format.
    1. If you are using standard Kubernetes secrets, but want to use a
       non-default one, update `secret` with your own secret.
 
-   1. If you are [managing multiple project](../../install/managing-multiple-projects.md), be careful to specify the `project`
-   where you want your Google Cloud resources resides.
+1. Update `project`  in the
+   [`pullsubscription.yaml`](pullsubscription.yaml)
+
+   By default, the PullSubscription will be created in the same project as your GKE cluster.
+   However, if you are [managing multiple projects](../../install/managing-multiple-projects.md), then you can specify `spec.project`,
+   which is the Google Cloud Project that the PullSubscription is created in.
 
 1. Update `TOPIC_NAME` in the [`pullsubscription.yaml`](pullsubscription.yaml)
    and apply it.
@@ -93,7 +97,7 @@ does so using a Pull format.
 Publish messages to your Cloud Pub/Sub Topic:
 
 ```shell
-gcloud pubsub topics publish testing --message='{"Hello": "world"}'
+gcloud pubsub topics publish testing --message='{"Hello": "world"}' --project=$PROJECT_ID
 ```
 
 ## Verify

--- a/docs/examples/topic/README.md
+++ b/docs/examples/topic/README.md
@@ -18,10 +18,10 @@ construct used by higher-level objects, such as `Channel`.
 
    ```shell
    export TOPIC_NAME=testing
-   gcloud pubsub topics create $TOPIC_NAME
+   gcloud pubsub topics create $TOPIC_NAME --project=$PROJECT_ID
    ```
 
-1. Update `googleServiceAccount` / `secret` / `project` in the [`topic.yaml`](topic.yaml)
+1. Update `googleServiceAccount` / `secret` in the [`topic.yaml`](topic.yaml)
 
    1. If you are in GKE and using
       [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity),
@@ -33,8 +33,11 @@ construct used by higher-level objects, such as `Channel`.
    1. If you are using standard Kubernetes secrets, but want to use a
       non-default one, update `secret` with your own secret.
 
-   1. If you are [managing multiple project](../../install/managing-multiple-projects.md), be careful to specify the `project`
-   where you want your Google Cloud resources resides.
+1. Update `project` in the [`topic.yaml`](topic.yaml)
+
+   By default, the Topic will be created in the same project as your GKE cluster.
+   However, if you are [managing multiple projects](../../install/managing-multiple-projects.md), then you can specify `spec.project`,
+   which is the Google Cloud Project that the Topic is created in.
 
 1. Update `TOPIC_NAME` in the [`topic.yaml`](topic.yaml) and apply it.
 
@@ -66,6 +69,7 @@ construct used by higher-level objects, such as `Channel`.
    gcloud pubsub subscriptions create test-topic-subscription \
     --topic=$TOPIC_NAME \
     --topic-project=$PROJECT_ID
+    --project=$PROJECT_ID
    ```
 
 ## Publish
@@ -98,7 +102,8 @@ We will verify that the event was actually sent to Cloud Pub/Sub by pulling the
 message from the subscription:
 
 ```shell
-gcloud pubsub subscriptions pull test-topic-subscription --format=json
+gcloud pubsub subscriptions pull test-topic-subscription --format=json --project=$PROJECT_ID
+
 ```
 
 You should see log lines similar to:

--- a/docs/examples/topic/README.md
+++ b/docs/examples/topic/README.md
@@ -21,7 +21,7 @@ construct used by higher-level objects, such as `Channel`.
    gcloud pubsub topics create $TOPIC_NAME
    ```
 
-1. Update `googleServiceAccount` / `secret` in the [`topic.yaml`](topic.yaml)
+1. Update `googleServiceAccount` / `secret` / `project` in the [`topic.yaml`](topic.yaml)
 
    1. If you are in GKE and using
       [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity),
@@ -32,6 +32,9 @@ construct used by higher-level objects, such as `Channel`.
 
    1. If you are using standard Kubernetes secrets, but want to use a
       non-default one, update `secret` with your own secret.
+
+   1. If you are [managing multiple project](../../install/managing-multiple-projects.md), be careful to specify the `project`
+   where you want your Google Cloud resources resides.
 
 1. Update `TOPIC_NAME` in the [`topic.yaml`](topic.yaml) and apply it.
 

--- a/docs/install/managing-multiple-projects.md
+++ b/docs/install/managing-multiple-projects.md
@@ -89,7 +89,7 @@ In order to make your CloudPubSubSource in `CLUSTER_PROJECT`'s cluster consume G
             iam.gke.io/gcp-service-account=$SOURCE_DATA_PLANE_GSA
             ```
     1. or Exporting Service Account Keys And Store Them as Kubernetes Secret
-       1. Download a new JSON private key for Source Data Plane GSA `your-gsa@project-b.iam.gserviceaccount.com`
+       1. Download a new JSON private key for Source Data Plane GSA `SOURCE_DATA_PLANE_GSA`
 
           ```shell
           gcloud iam service-accounts keys create events-sources-key.json \

--- a/docs/install/managing-multiple-projects.md
+++ b/docs/install/managing-multiple-projects.md
@@ -1,3 +1,103 @@
 # Managing Multiple Projects
 
-Documentation coming soon! See https://github.com/google/knative-gcp/issues/460
+A general Knative-GCP installation configures three identities (represents as Google service accounts) on your project.
+
+1. Identity for the Control Plane.
+2. Identity for the GCP Broker.
+3. Identity for the Source. (This is the default identity for the Source.
+Users can use this identity for multiple Source custom objects,
+or create additional identities in the form of Google service accounts for different Source custom objects,
+to achieve more fine-grained configurations)
+
+In general Knative-GCP installation guide, each Knative-GCP component consumes/creates Google Cloud resources within the scope of the project
+(the project where the kubernetes cluster contained your Knative-GCP components resides). For example, if your kubernetes cluster is in Project A, and
+you apply StorageSource in this kubernetes cluster, it will create a Google Cloud Storage Bucket, a Google Cloud PubSub Topic, and a Google Cloud PubSub Subscription,
+all belong to Project A.
+
+This topic explains how to set-up Knative GCP configuration to create Sources which consume/create Google Cloud resources from other projects.
+
+Here we use PubSubSource as an example.
+
+The following names are representing:
+* `project-a`: Project (project where all Knative-GCP system resides)
+
+* `events-controller-gsa@project-a.iam.gserviceaccount.com`: Control-plane GSA (which is used for the control plane)
+
+* `project-b`: Project (project where your topic and subscription resides)
+
+* `your-gsa@project-b.iam.gserviceaccount.com`: Source Data-Plane GSA (which is used in your namespace where your PubSubSource resides)
+
+In order to make your PubSubSource in Project A' cluster to consume Google PubSub resource in Project B:
+1. Control Plane GSA `events-controller-gsa@project-a.iam.gserviceaccount.com` needs `pubsub.editor` role for `project-b`
+    ```
+    gcloud projects add-iam-policy-binding project-b
+    --member=serviceAccount:events-controller-gsa@project-a.iam.gserviceaccount.com
+    --role roles/pubsub.editor
+    ```
+    ***Note:*** To create different Google Cloud Resource, the Control Plane needs different permissions.
+    Refer to [Manually Configure Authentication Mechanism for the Control Plane](./authentication-mechanisms-gcp.md/#authentication-mechanism-for-the-control-plane)
+    for specific roles(a set of permissions) needed to create each Source.
+
+1. Source Data-plane GSA `your-gsa@project-b.iam.gserviceaccount.com` needs `pubsub.editor` role for `project-b`
+
+    ```
+    gcloud projects add-iam-policy-binding project-b
+    --member=serviceAccount:your-gsa@project-b.iam.gserviceaccount.com
+    --role roles/pubsub.editor
+    ```
+   ***Note:*** Source Data Plane only pulls subscription from Cloud PubSub Subscription, thus,
+   no matter which Cloud Source you are creating, this GSA only needs `roles/pubsub.editor` role.
+   Refer to [Installing a Service Account for the Data Plane](../install/dataplane-service-account.md)
+   for specific roles(a set of permissions) needed if you also want metrics and tracing for your Source.
+
+1. Configure credentials in the kubernetes cluster. You can either use:
+    1. Workload Identity
+        1. Create a Kubernetes Service Account `ksa-name` in the same namespace where the PubSubSource will reside.
+            ```
+            kubectl create service account ksa-name -n namespace
+            ```
+        2. Source Data-plane GSA `your-gsa@project-b.iam.gserviceaccount.com` needs workload identity binding.
+            ```
+            gcloud iam service-accounts add-iam-policy-binding your-gsa@project-b.iam.gserviceaccount.com
+            --role "roles/iam.workloadIdentityUser"
+            --member "serviceAccount:project-a.svc.id.goog[namespace/ksa-name]”
+            ```
+        3. Kubernetes Service Account `ksa-name` needs annotation
+            ```
+            kubectl annotate serviceaccount ksa-name \
+            iam.gke.io/gcp-service-account=your-gsa@project-b.iam.gserviceaccount.com
+            ```
+    1. or Exporting Service Account Keys And Store Them as Kubernetes Secret
+       1. Download a new JSON private key for Source Data-plane GSA `your-gsa@project-b.iam.gserviceaccount.com`
+
+          ```shell
+          gcloud iam service-accounts keys create events-sources-key.json \
+            --iam-account=your-gsa@project-b.iam.gserviceaccount.com
+          ```
+
+       1. Create a secret on the Kubernetes cluster with the downloaded key. Remember
+          to create the secret in the namespace your resources will reside.
+
+          ```shell
+          kubectl --namespace default create secret generic google-cloud-key --from-file=key.json=events-sources-key.json
+          ```
+
+          `google-cloud-key` and `key.json` are default values expected by our
+          resources.
+1. Following [CloudPubSubSource](../examples/cloudpubsubsource/README.md) example to create your PubSubSource.
+***[Important]*** Don't forget to specifying `project-b` and `secret`/ `serviceAccountName` under `spec` when you apply your PubSubSource:
+
+    ```
+    apiVersion: events.cloud.google.com/v1
+    kind: CloudPubSubSource
+    metadata:
+      name: cloudpubsubsource-test
+    spec:
+      ...
+      secret:
+        name: google-cloud-key
+        key: key.json
+      serviceAccountName: ksa-name
+      project: project-b
+      ...
+   ```


### PR DESCRIPTION
## Proposed Changes

- Add documentation around running sources in distinct GCP projects than the cluster and control plane.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```
