### PR TITLE
release-0.18: Add safeguards for Broker delivery spec nil pointer dereference

### DIFF
--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -52,6 +52,7 @@ const (
 	triggerReconciled = "TriggerReconciled"
 	triggerFinalized  = "TriggerFinalized"
 
+	defaultMinimumBackoff = 1 * time.Second
 	// Default maximum backoff duration used in the backoff retry policy for
 	// pubsub subscriptions. 600 seconds is the longest supported time.
 	defaultMaximumBackoff = 600 * time.Second
@@ -268,6 +269,12 @@ func (r *Reconciler) reconcileRetryTopicAndSubscription(ctx context.Context, tri
 // getPubsubRetryPolicy gets the eventing retry policy from the Broker delivery
 // spec and translates it to a pubsub retry policy.
 func getPubsubRetryPolicy(spec *eventingduckv1beta1.DeliverySpec) *pubsub.RetryPolicy {
+	if spec == nil {
+		return &pubsub.RetryPolicy{
+			MinimumBackoff: defaultMinimumBackoff,
+			MaximumBackoff: defaultMaximumBackoff,
+		}
+	}
 	// The Broker delivery spec is translated to a pubsub retry policy in the
 	// manner defined in the following post:
 	// https://github.com/google/knative-gcp/issues/1392#issuecomment-655617873
@@ -289,7 +296,7 @@ func getPubsubRetryPolicy(spec *eventingduckv1beta1.DeliverySpec) *pubsub.RetryP
 // getPubsubDeadLetterPolicy gets the eventing dead letter policy from the
 // Broker delivery spec and translates it to a pubsub dead letter policy.
 func getPubsubDeadLetterPolicy(projectID string, spec *eventingduckv1beta1.DeliverySpec) *pubsub.DeadLetterPolicy {
-	if spec.DeadLetterSink == nil {
+	if spec == nil || spec.DeadLetterSink == nil {
 		return nil
 	}
 	// Translate to the pubsub dead letter policy format.


### PR DESCRIPTION
Fixes delivery spec nil pointer dereference.

## Proposed Changes
- Check spec before dereferencing in getPubsubRetryPolicy.
- Check spec before dereferencing in getPubsubDeadLetterPolicy.
- Add unit test for broker without delivery spec.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fixed a potential nil pointer dereference when using a GCP Broker.
```