### PR TITLE
Filter brokerCell resource updates by label

### DIFF
--- a/pkg/reconciler/brokercell/controller.go
+++ b/pkg/reconciler/brokercell/controller.go
@@ -55,6 +55,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
 	systemnamespacesecretinformer "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret"
+	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
 )
 
@@ -181,7 +182,10 @@ func handleResourceUpdate(impl *controller.Impl) cache.ResourceEventHandler {
 	// Resources created by the brokercell, including the indirectly created ingress service endpoints,
 	// have such a label resources.BrokerCellLabelKey=<brokercellName>. Resources without this label
 	// will be skipped by the function.
-	return controller.HandleAll(impl.EnqueueLabelOfNamespaceScopedResource(namespaceLabel, resources.BrokerCellLabelKey))
+	return cache.FilteringResourceEventHandler{
+		FilterFunc: pkgreconciler.LabelExistsFilterFunc(resources.BrokerCellLabelKey),
+		Handler:    controller.HandleAll(impl.EnqueueLabelOfNamespaceScopedResource(namespaceLabel, resources.BrokerCellLabelKey)),
+	}
 }
 
 // reportLatency estimates the time spent since the last update of the resource object and records it to the latency metric


### PR DESCRIPTION
Without filtering these updates, the controller debug logs get polluted with many irrelevant messages, for example:

```
controller-5c5d65bccd-vpr8p controller {"level":"debug","ts":"2021-03-23T18:43:17.186Z","logger":"controller.github.com-google-knative-gcp-pkg-reconciler-brokercell.Reconciler","caller":"controller/controller.go:335","msg":"Object kube-system/cluster-autoscaler-status does not have a referring name label brokerCell"}
```

## Proposed Changes

- 🧽 Filter brokerCell resource updates by label.
