### PR TITLE
Check custom metrics only if running E2E tests

### DIFF
--- a/.github/workflows/knative-go-build.yaml
+++ b/.github/workflows/knative-go-build.yaml
@@ -27,7 +27,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.16.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}
@@ -43,7 +43,13 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+      - id: go_mod
+        uses: andstor/file-existence-action@v1
+        with:
+          files: go.mod
+
       - name: Build
+        if: ${{ steps.go_mod.outputs.files_exists == 'true' }}
         run: |
           tags="$(grep -I  -r '// +build' . | \
                 grep -v '^./vendor/' | \
@@ -53,7 +59,5 @@ jobs:
                 sort | uniq | \
                 grep -v '^!' | \
                 tr '\n' ' ')"
-
           echo "Building with tags: ${tags}"
-          go test -vet=off -tags "${tags}" -run=^$ ./... | grep -v "no test" || true
-
+          go test -vet=off -tags "${tags}" -run=^$ ./...

--- a/test/conformance/main_test.go
+++ b/test/conformance/main_test.go
@@ -51,7 +51,8 @@ func TestMain(m *testing.M) {
 	os.Exit(func() int {
 		test.InitializeFlags()
 		eventingtest.InitializeEventingFlags()
-		projectID, e2e_test := os.LookupEnv(lib.ProwProjectKey)
+		// If there's no project ID environment variable, it's probably a build test
+		projectID, projectProvided := os.LookupEnv(lib.ProwProjectKey)
 		channelTestRunner = eventingtestlib.ComponentsTestRunner{
 			// ChannelFeatureMap saves the channel-features mapping.
 			// Each pair means the channel support the given list of features.
@@ -81,7 +82,7 @@ func TestMain(m *testing.M) {
 			return code
 		}
 
-		if e2e_test {
+		if projectProvided {
 			// The knative/pkg base controller emits custom metrics, plus some other components can
 			// potentially emit custom metrics. By default custom metrics should not be published to
 			// Stackdriver.

--- a/test/conformance/main_test.go
+++ b/test/conformance/main_test.go
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 	os.Exit(func() int {
 		test.InitializeFlags()
 		eventingtest.InitializeEventingFlags()
-		projectID = os.Getenv(lib.ProwProjectKey)
+		projectID, e2e_test := os.LookupEnv(lib.ProwProjectKey)
 		channelTestRunner = eventingtestlib.ComponentsTestRunner{
 			// ChannelFeatureMap saves the channel-features mapping.
 			// Each pair means the channel support the given list of features.
@@ -81,13 +81,15 @@ func TestMain(m *testing.M) {
 			return code
 		}
 
-		// The knative/pkg base controller emits custom metrics, plus some other components can
-		// potentially emit custom metrics. By default custom metrics should not be published to
-		// Stackdriver.
-		// After running all tests, we verify that no custom metrics have been emitted in the past
-		// 30 min to cover roughly how long the e2e tests run.
-		if err := verifyNoCustomMetrics(projectID, time.Duration(-30)*time.Minute); err != nil {
-			log.Fatalf("Failed to verify that no custom metrics are emitted: %v", err)
+		if e2e_test {
+			// The knative/pkg base controller emits custom metrics, plus some other components can
+			// potentially emit custom metrics. By default custom metrics should not be published to
+			// Stackdriver.
+			// After running all tests, we verify that no custom metrics have been emitted in the past
+			// 30 min to cover roughly how long the e2e tests run.
+			if err := verifyNoCustomMetrics(projectID, time.Duration(-30)*time.Minute); err != nil {
+				log.Fatalf("Failed to verify that no custom metrics are emitted: %v", err)
+			}
 		}
 
 		return 0

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -51,7 +51,8 @@ func TestMain(m *testing.M) {
 	os.Exit(func() int {
 		test.InitializeFlags()
 		eventingtest.InitializeEventingFlags()
-		projectID, e2e_test := os.LookupEnv(lib.ProwProjectKey)
+		// If there's no project ID environment variable, it's probably a build test
+		projectID, projectProvided := os.LookupEnv(lib.ProwProjectKey)
 		channelTestRunner = eventingtestlib.ComponentsTestRunner{
 			// ChannelFeatureMap saves the channel-features mapping.
 			// Each pair means the channel support the given list of features.
@@ -81,7 +82,7 @@ func TestMain(m *testing.M) {
 			return code
 		}
 
-		if e2e_test {
+		if projectProvided {
 			// The knative/pkg base controller emits custom metrics, plus some other components can
 			// potentially emit custom metrics. By default custom metrics should not be published to
 			// Stackdriver.

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 	os.Exit(func() int {
 		test.InitializeFlags()
 		eventingtest.InitializeEventingFlags()
-		projectID = os.Getenv(lib.ProwProjectKey)
+		projectID, e2e_test := os.LookupEnv(lib.ProwProjectKey)
 		channelTestRunner = eventingtestlib.ComponentsTestRunner{
 			// ChannelFeatureMap saves the channel-features mapping.
 			// Each pair means the channel support the given list of features.
@@ -81,13 +81,15 @@ func TestMain(m *testing.M) {
 			return code
 		}
 
-		// The knative/pkg base controller emits custom metrics, plus some other components can
-		// potentially emit custom metrics. By default custom metrics should not be published to
-		// Stackdriver.
-		// After running all tests, we verify that no custom metrics have been emitted in the past
-		// 30 min to cover roughly how long the e2e tests run.
-		if err := verifyNoCustomMetrics(projectID, time.Duration(-30)*time.Minute); err != nil {
-			log.Fatalf("Failed to verify that no custom metrics are emitted: %v", err)
+		if e2e_test {
+			// The knative/pkg base controller emits custom metrics, plus some other components can
+			// potentially emit custom metrics. By default custom metrics should not be published to
+			// Stackdriver.
+			// After running all tests, we verify that no custom metrics have been emitted in the past
+			// 30 min to cover roughly how long the e2e tests run.
+			if err := verifyNoCustomMetrics(projectID, time.Duration(-30)*time.Minute); err != nil {
+				log.Fatalf("Failed to verify that no custom metrics are emitted: %v", err)
+			}
 		}
 
 		return 0


### PR DESCRIPTION
This unblocks #2212.

The "build" GitHub action has been changed to actually perform the build test. It ends up running our e2e tests a little bit and failing because the metrics client can't authenticate. This change makes it so the metrics check only runs when the e2e tests are running, not when the build test is running.

Tested with:

```shell
tags="$(grep -I  -r '// +build' . | \
      grep -v '^./vendor/' | \
      grep -v '^./hack/' | \
      grep -v '^./third_party' | \
      cut -f3 -d' ' | \
      sort | uniq | \
      grep -v '^!' | \
      tr '\n' ' ')"
go test -vet=off -tags "${tags}" -run=^$ ./...
```