### PR TITLE
Change the unavailable time contraint for upgrade test to 1 second

### DIFF
--- a/test/upgrade/config.toml
+++ b/test/upgrade/config.toml
@@ -6,4 +6,4 @@ interval = {{ .Config.Interval.Nanoseconds }}
 target = 'http://wathola-receiver.{{- .Config.Namespace -}}.svc.cluster.local'
 [receiver]
 teardown.Duration = 15000000000
-errors.UnavailablePeriodToReport = 0
+errors.UnavailablePeriodToReport = 1000000000


### PR DESCRIPTION
This relaxes the failure constraint of unavailability for the upgrade test. Event error or drop test will not be affected.