### PR TITLE
Pin serving and eventing e2e test versions to 0.23

### DIFF
--- a/test/lib.sh
+++ b/test/lib.sh
@@ -41,11 +41,13 @@ function start_knative_gcp_monitoring() {
 # Install all required components for running knative-gcp.
 function start_knative_gcp() {
   # Try reapply serving yaml again in case of race condition between webhook and config map
-  start_latest_knative_serving || start_latest_knative_serving || return 1
+  SERVING_VERSION=0.23.1  # Pin serving version to 0.23
+  start_release_knative_serving $SERVING_VERSION|| start_release_knative_serving $SERVING_VERSION || return 1
   # Try reapply eventing yaml again if config-imc-event-dispatcher failed to start
   # TODO: Restore the below line after https://github.com/knative/eventing/issues/3244 is fixed
   #start_latest_knative_eventing || return 1
-  start_latest_knative_eventing || start_latest_knative_eventing || return 1
+  EVENTING_VERSION=0.23.3  # Pin eventing version to 0.23
+  start_release_knative_eventing $EVENTING_VERSION || start_release_knative_eventing $EVENTING_VERSION || return 1
   start_knative_gcp_monitoring "$KNATIVE_GCP_MONITORING_YAML" || return 1
   cloud_run_events_setup $@ || return 1
   istio_patch || return 1


### PR DESCRIPTION
Fixes the failing continuous and nightly release e2e tests, e.g., https://prow.knative.dev/view/gs/knative-prow/logs/ci-google-knative-gcp-nightly-release/1415605632215552000

The changes in https://github.com/knative/eventing/pull/5551 add a new status condition to triggers, which breaks our implementation, since we don't expect the new condition and our triggers are marked as Unknown. We should stop testing against eventing and serving nightly.